### PR TITLE
PET and SPECT scanners, EEG and MEG machines

### DIFF
--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -29,6 +29,7 @@
     <!ENTITY NIF-GrossAnatomy "http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-GrossAnatomy.owl#" >
     <!ENTITY NEMO_annotation_properties "http://purl.bioontology.org/NEMO/ontology/NEMO_annotation_properties.owl#" >
     <!ENTITY birn_annot "http://ontology.neuinfo.org/NIF/Backend/BIRNLex_annotation_properties.owl#" >
+    <!ENTITY ILX "http://uri.interlex.org/base/" >
 ]>
 
 
@@ -60,7 +61,8 @@
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:obo_annot="http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#"
-     xmlns:span="http://www.ifomis.org/bfo/1.1/span#">
+     xmlns:span="http://www.ifomis.org/bfo/1.1/span#"
+     xmlns:ILX="http://uri.interlex.org/base/">
     <owl:Ontology rdf:about="http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl">
         <owl:versionInfo rdf:datatype="&xsd;string">2.3; December 1, 2012</owl:versionInfo>
         <dc:title rdf:datatype="&xsd;string">NIF-Investigation</dc:title>
@@ -2017,7 +2019,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <birn_annot:hasCurationStatus rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/BIRNLex_annotation_properties.owl#uncurated</birn_annot:hasCurationStatus>
     </owl:Class>
     
-    <owl:Class rdf:about="&p17;ixl_0050000">
+    <owl:Class rdf:about="&ILX;ixl_0050000">
         <rdfs:label rdf:datatype="&xsd;string">Positron emission tomography scanner</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
@@ -2027,7 +2029,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Positron_emission_tomography</j.1:definingCitationURI>
     </owl:Class>
 
-    <owl:Class rdf:about="&p17;ixl_0050001">
+    <owl:Class rdf:about="&ILX;ixl_0050001">
         <rdfs:label rdf:datatype="&xsd;string">Single-photon emission computed tomography scanner</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
@@ -2037,7 +2039,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Single-photon_emission_computed_tomography</j.1:definingCitationURI>
     </owl:Class>    
 
-    <owl:Class rdf:about="&p17;ixl_0050002">
+    <owl:Class rdf:about="&ILX;ixl_0050002">
         <rdfs:label rdf:datatype="&xsd;string">Magnetoencephalography machine</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
@@ -2047,7 +2049,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Magnetoencephalography</j.1:definingCitationURI>
     </owl:Class>
 
-    <owl:Class rdf:about="&p17;ixl_0050003">
+    <owl:Class rdf:about="&ILX;ixl_0050003">
         <rdfs:label rdf:datatype="&xsd;string">Electroencephalography machine</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -2017,6 +2017,55 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <birn_annot:hasCurationStatus rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/BIRNLex_annotation_properties.owl#uncurated</birn_annot:hasCurationStatus>
     </owl:Class>
     
+    <owl:Class rdf:about="&p17;birnlex_XXX_PET_scanner">
+        <rdfs:label rdf:datatype="&xsd;string">Positron emission tomography scanner</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
+        <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
+        <j.1:synonym rdf:datatype="&xsd;string">PET scanner</j.1:synonym>
+        <core:prefLabel rdf:datatype="&xsd;string">Positron emission tomography scanner</core:prefLabel>
+        <core:definition rdf:datatype="&xsd;string">A Positron emission tomography scanner is a device used in a nuclear medicine to observe metabolic processes in the body.</core:definition>
+        <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Positron_emission_tomography</j.1:definingCitationURI>
+    </owl:Class>
+
+    <owl:Class rdf:about="&p17;birnlex_XXX_SPECT_scanner">
+        <rdfs:label rdf:datatype="&xsd;string">Single-photon emission computed tomography scanner</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
+        <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
+        <j.1:synonym rdf:datatype="&xsd;string">SPECT scanner</j.1:synonym>
+        <core:prefLabel rdf:datatype="&xsd;string">Single-photon emission computed tomography scanner</core:prefLabel>
+        <core:definition rdf:datatype="&xsd;string">A Single-photon emission computed tomography scanner is a device used in nuclear medicine tomographic imaging to measure perfusion in the body using gamma rays.</core:definition>
+        <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Single-photon_emission_computed_tomography</j.1:definingCitationURI>
+    </owl:Class>    
+
+    <owl:Class rdf:about="&p17;birnlex_XXX_MEG_machine">
+        <rdfs:label rdf:datatype="&xsd;string">Magnetoencephalography machine</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
+        <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
+        <j.1:synonym rdf:datatype="&xsd;string">MEG machine</j.1:synonym>
+        <core:prefLabel rdf:datatype="&xsd;string">Magnetoencephalography machine</core:prefLabel>
+        <core:definition rdf:datatype="&xsd;string">A Magnetoencephalography machine is a device used in functional neuroimaging for mapping brain activity by recording magnetic fields produced by electrical currents occurring naturally in the brain, using very sensitive magnetometers..</core:definition>
+        <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Magnetoencephalography</j.1:definingCitationURI>
+    </owl:Class>
+
+    <owl:Class rdf:about="&p17;birnlex_XXX_EEG_machine">
+        <rdfs:label rdf:datatype="&xsd;string">Electroencephalography machine</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
+        <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
+        <j.1:synonym rdf:datatype="&xsd;string">EEG machine</j.1:synonym>
+        <core:prefLabel rdf:datatype="&xsd;string">Electroencephalography machine</core:prefLabel>
+        <core:definition rdf:datatype="&xsd;string">A Electroencephalography machine is a device used in electrophysiology to record electrical activity of the brain..</core:definition>
+        <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Electroencephalography</j.1:definingCitationURI>
+    </owl:Class>        
+
+    <owl:Class rdf:about="&p17;birnlex_XXX_PET_scanner">
+        <rdfs:label rdf:datatype="&xsd;string">Positron emission tomography scanner</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
+        <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
+        <j.1:synonym rdf:datatype="&xsd;string">PET scanner</j.1:synonym>
+        <core:prefLabel rdf:datatype="&xsd;string">Positron emission tomography scanner</core:prefLabel>
+        <core:definition rdf:datatype="&xsd;string">A Positron emission tomography scanner is a device used in a nuclear medicine to observe metabolic processes in the body.</core:definition>
+        <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Positron_emission_tomography</j.1:definingCitationURI>
+    </owl:Class>        
 
 
     <!-- http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl#birnlex_2101 -->

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -2017,7 +2017,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <birn_annot:hasCurationStatus rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/BIRNLex_annotation_properties.owl#uncurated</birn_annot:hasCurationStatus>
     </owl:Class>
     
-    <owl:Class rdf:about="&p17;birnlex_XXX_PET_scanner">
+    <owl:Class rdf:about="&p17;ixl_0050000">
         <rdfs:label rdf:datatype="&xsd;string">Positron emission tomography scanner</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
@@ -2027,7 +2027,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Positron_emission_tomography</j.1:definingCitationURI>
     </owl:Class>
 
-    <owl:Class rdf:about="&p17;birnlex_XXX_SPECT_scanner">
+    <owl:Class rdf:about="&p17;ixl_0050001">
         <rdfs:label rdf:datatype="&xsd;string">Single-photon emission computed tomography scanner</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
@@ -2037,7 +2037,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Single-photon_emission_computed_tomography</j.1:definingCitationURI>
     </owl:Class>    
 
-    <owl:Class rdf:about="&p17;birnlex_XXX_MEG_machine">
+    <owl:Class rdf:about="&p17;ixl_0050002">
         <rdfs:label rdf:datatype="&xsd;string">Magnetoencephalography machine</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
@@ -2047,7 +2047,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Magnetoencephalography</j.1:definingCitationURI>
     </owl:Class>
 
-    <owl:Class rdf:about="&p17;birnlex_XXX_EEG_machine">
+    <owl:Class rdf:about="&p17;ixl_0050003">
         <rdfs:label rdf:datatype="&xsd;string">Electroencephalography machine</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
@@ -2056,17 +2056,6 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <core:definition rdf:datatype="&xsd;string">A Electroencephalography machine is a device used in electrophysiology to record electrical activity of the brain..</core:definition>
         <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Electroencephalography</j.1:definingCitationURI>
     </owl:Class>        
-
-    <owl:Class rdf:about="&p17;birnlex_XXX_PET_scanner">
-        <rdfs:label rdf:datatype="&xsd;string">Positron emission tomography scanner</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&p17;birnlex_2094"/>
-        <j.1:createdDate rdf:datatype="&xsd;string">2016-02-12</j.1:createdDate>
-        <j.1:synonym rdf:datatype="&xsd;string">PET scanner</j.1:synonym>
-        <core:prefLabel rdf:datatype="&xsd;string">Positron emission tomography scanner</core:prefLabel>
-        <core:definition rdf:datatype="&xsd;string">A Positron emission tomography scanner is a device used in a nuclear medicine to observe metabolic processes in the body.</core:definition>
-        <j.1:definingCitationURI rdf:datatype="&xsd;string">https://en.wikipedia.org/wiki/Positron_emission_tomography</j.1:definingCitationURI>
-    </owl:Class>        
-
 
     <!-- http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl#birnlex_2101 -->
 

--- a/interlex_reserved.txt
+++ b/interlex_reserved.txt
@@ -1,8 +1,8 @@
 ilx_0049999:Example label here
-ilx_0050000:
-ilx_0050001:
-ilx_0050002:
-ilx_0050003:
+ilx_0050000:Positron emission tomography scanner
+ilx_0050001:Single-photon emission computed tomography scanner
+ilx_0050002:Magnetoencephalography machine
+ilx_0050003:Electroencephalography machine
 ilx_0050004:
 ilx_0050005:
 ilx_0050006:


### PR DESCRIPTION
Create PET, SPECT, EEG and MEG imaging instruments. 

These imaging methods are mentioned in Neurolex, with associated protocols:
 - [PET imaging protocol](http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl#birnlex_2171), 
 - [SPECT imaging protocol](http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl#birnlex_2236), 
 - [Electroencephalography recording protocol](http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl#birnlex_2293), 
 - [Magnetoencephalography](http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl#nlx_inv_090918)

but the corresponding imaging instruments seem to be missing. 

Those terms could be directly re-used in the NeuroImaging Data Model to describe the Agent associated with the Data entity (cf. [NIDM-Results chart](https://raw.githubusercontent.com/cmaumet/nidm/9e3ebbec9624b840f8aabaae34944cc095024380/doc/content/specs/img/nidm-results_dev/nidm-results-core-uml.png)). The proposed update is under discussion at: https://github.com/incf-nidash/nidm/pull/374.

I have used placeholder for the identifiers (e.g. `birnlex_XXX_PET_scanner`), as I was unsure how to attribute a numeric id to those proposed new terms.

Please let me know if this update can be of interest. Thank you!