### PR TITLE
Identifier request for new term: 'Anatomical MRI protocol'

### DIFF
--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -2616,7 +2616,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
 
     <owl:Class rdf:about="&p17;birnlex_2134">
         <rdfs:label rdf:datatype="&xsd;string">T1 weighted protocol</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&p17;ixl_0050004"/>
+        <rdfs:subClassOf rdf:resource="&ILX;ixl_0050004"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2007-03-07</j.1:createdDate>
         <core:definition rdf:datatype="&xsd;string">An MRI scanning pulse sequence that is used to acquire structural data whose tissue contrast parameter is T1-weighted.</core:definition>
         <j.1:tempDefinition rdf:datatype="&xsd;string">An imaging protocol typically using short TE and TR times whose contrast and brightness are predominately determined by T1 signals. This leads to high contrast between white and gray matter and is the basis for high-resolution anatomical brain imaging.</j.1:tempDefinition>
@@ -3359,7 +3359,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:hasDefinitionSource rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#UMLS_defSource</j.1:hasDefinitionSource>
     </owl:Class>
     
-    <owl:Class rdf:about="&p17;ixl_0050004">
+    <owl:Class rdf:about="&ILX;ixl_0050004">
         <rdfs:label rdf:datatype="&xsd;string">Anatomical MRI protocol</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2251"/>
         <core:definition rdf:datatype="&xsd;string"></core:definition>
@@ -3628,7 +3628,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
 
     <owl:Class rdf:about="&p17;birnlex_2193">
         <rdfs:label rdf:datatype="&xsd;string">T2 weighted protocol</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&p17;ixl_0050004"/>
+        <rdfs:subClassOf rdf:resource="&ILX;ixl_0050004"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2007-03-07</j.1:createdDate>
         <core:definition rdf:datatype="&xsd;string">An MRI scanning pulse sequence that is used to acquire structural data whose tissue contrast parameter is T2-weighted.</core:definition>
         <j.1:tempDefinition rdf:datatype="&xsd;string">An imaging protocol typically using longer TE and TR times whose contrast and brightness are predominately determined by T2 signals (2007-03-07)</j.1:tempDefinition>

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -2616,7 +2616,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
 
     <owl:Class rdf:about="&p17;birnlex_2134">
         <rdfs:label rdf:datatype="&xsd;string">T1 weighted protocol</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&p17;birnlex_xxx_anat_mri_protocol_xxx"/>
+        <rdfs:subClassOf rdf:resource="&p17;ixl_0050004"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2007-03-07</j.1:createdDate>
         <core:definition rdf:datatype="&xsd;string">An MRI scanning pulse sequence that is used to acquire structural data whose tissue contrast parameter is T1-weighted.</core:definition>
         <j.1:tempDefinition rdf:datatype="&xsd;string">An imaging protocol typically using short TE and TR times whose contrast and brightness are predominately determined by T1 signals. This leads to high contrast between white and gray matter and is the basis for high-resolution anatomical brain imaging.</j.1:tempDefinition>
@@ -3359,7 +3359,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:hasDefinitionSource rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#UMLS_defSource</j.1:hasDefinitionSource>
     </owl:Class>
     
-    <owl:Class rdf:about="&p17;birnlex_xxx_anat_mri_protocol_xxx">
+    <owl:Class rdf:about="&p17;ixl_0050004">
         <rdfs:label rdf:datatype="&xsd;string">Anatomical MRI protocol</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2251"/>
         <core:definition rdf:datatype="&xsd;string"></core:definition>
@@ -3628,7 +3628,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
 
     <owl:Class rdf:about="&p17;birnlex_2193">
         <rdfs:label rdf:datatype="&xsd;string">T2 weighted protocol</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&p17;birnlex_xxx_anat_mri_protocol_xxx"/>
+        <rdfs:subClassOf rdf:resource="&p17;ixl_0050004"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2007-03-07</j.1:createdDate>
         <core:definition rdf:datatype="&xsd;string">An MRI scanning pulse sequence that is used to acquire structural data whose tissue contrast parameter is T2-weighted.</core:definition>
         <j.1:tempDefinition rdf:datatype="&xsd;string">An imaging protocol typically using longer TE and TR times whose contrast and brightness are predominately determined by T2 signals (2007-03-07)</j.1:tempDefinition>

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -3363,7 +3363,9 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <rdfs:label rdf:datatype="&xsd;string">Anatomical MRI protocol</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2251"/>
         <core:definition rdf:datatype="&xsd;string"></core:definition>
-        <core:definition rdf:datatype="&xsd;string">An anatomical MRI protocol is a structural MRI protocol that is not a diffusion-weighted MRI protocol.</core:definition>        
+        <core:definition rdf:datatype="&xsd;string">
+        An anatomical MRI protocol is a structural MRI protocol that can be used to delineate the anatomy, for example by the way of a segmentation or parcellation.
+        </core:definition>        
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-15</j.1:createdDate>
         <j.1:hasDefinitionSource rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#UMLS_defSource</j.1:hasDefinitionSource>
 

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -2616,7 +2616,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
 
     <owl:Class rdf:about="&p17;birnlex_2134">
         <rdfs:label rdf:datatype="&xsd;string">T1 weighted protocol</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&p17;birnlex_2251"/>
+        <rdfs:subClassOf rdf:resource="&p17;birnlex_xxx_anat_mri_protocol_xxx"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2007-03-07</j.1:createdDate>
         <core:definition rdf:datatype="&xsd;string">An MRI scanning pulse sequence that is used to acquire structural data whose tissue contrast parameter is T1-weighted.</core:definition>
         <j.1:tempDefinition rdf:datatype="&xsd;string">An imaging protocol typically using short TE and TR times whose contrast and brightness are predominately determined by T1 signals. This leads to high contrast between white and gray matter and is the basis for high-resolution anatomical brain imaging.</j.1:tempDefinition>
@@ -3359,7 +3359,14 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:hasDefinitionSource rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#UMLS_defSource</j.1:hasDefinitionSource>
     </owl:Class>
     
-
+    <owl:Class rdf:about="&p17;birnlex_xxx_anat_mri_protocol_xxx">
+        <rdfs:label rdf:datatype="&xsd;string">Anatomical MRI protocol</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&p17;birnlex_2251"/>
+        <core:definition rdf:datatype="&xsd;string"></core:definition>
+        <j.1:createdDate rdf:datatype="&xsd;string">2016-02-15</j.1:createdDate>
+        <j.1:hasDefinitionSource rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#UMLS_defSource</j.1:hasDefinitionSource>
+    </owl:Class>
+    
 
     <!-- http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl#birnlex_2178 -->
 
@@ -3619,7 +3626,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
 
     <owl:Class rdf:about="&p17;birnlex_2193">
         <rdfs:label rdf:datatype="&xsd;string">T2 weighted protocol</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&p17;birnlex_2251"/>
+        <rdfs:subClassOf rdf:resource="&p17;birnlex_xxx_anat_mri_protocol_xxx"/>
         <j.1:createdDate rdf:datatype="&xsd;string">2007-03-07</j.1:createdDate>
         <core:definition rdf:datatype="&xsd;string">An MRI scanning pulse sequence that is used to acquire structural data whose tissue contrast parameter is T2-weighted.</core:definition>
         <j.1:tempDefinition rdf:datatype="&xsd;string">An imaging protocol typically using longer TE and TR times whose contrast and brightness are predominately determined by T2 signals (2007-03-07)</j.1:tempDefinition>

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -3365,8 +3365,6 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <core:definition rdf:datatype="&xsd;string"></core:definition>
         <core:definition rdf:datatype="&xsd;string">An anatomical MRI protocol is a structural MRI protocol that is not a diffusion-weighted MRI protocol.</core:definition>        
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-15</j.1:createdDate>
-        <j.1:synonym rdf:datatype="&xsd;string">Conventional anatomical MRI protocol</j.1:synonym>
-        <j.1:synonym rdf:datatype="&xsd;string">Anatomical MRI protocol</j.1:synonym>        
         <j.1:hasDefinitionSource rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#UMLS_defSource</j.1:hasDefinitionSource>
 
     </owl:Class>

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -3365,8 +3365,8 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <core:definition rdf:datatype="&xsd;string"></core:definition>
         <core:definition rdf:datatype="&xsd;string">An anatomical MRI protocol is a structural MRI protocol that is not a diffusion-weighted MRI protocol.</core:definition>        
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-15</j.1:createdDate>
-        <j.1:synonym rdf:datatype="&xsd;string">Conventional anatomical MRI</j.1:synonym>
-        <j.1:synonym rdf:datatype="&xsd;string">Anatomical MRI</j.1:synonym>        
+        <j.1:synonym rdf:datatype="&xsd;string">Conventional anatomical MRI protocol</j.1:synonym>
+        <j.1:synonym rdf:datatype="&xsd;string">Anatomical MRI protocol</j.1:synonym>        
         <j.1:hasDefinitionSource rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#UMLS_defSource</j.1:hasDefinitionSource>
 
     </owl:Class>

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -3363,8 +3363,12 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <rdfs:label rdf:datatype="&xsd;string">Anatomical MRI protocol</rdfs:label>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2251"/>
         <core:definition rdf:datatype="&xsd;string"></core:definition>
+        <core:definition rdf:datatype="&xsd;string">An anatomical MRI protocol is a structural MRI protocol that is not a diffusion-weighted MRI protocol.</core:definition>        
         <j.1:createdDate rdf:datatype="&xsd;string">2016-02-15</j.1:createdDate>
+        <j.1:synonym rdf:datatype="&xsd;string">Conventional anatomical MRI</j.1:synonym>
+        <j.1:synonym rdf:datatype="&xsd;string">Anatomical MRI</j.1:synonym>        
         <j.1:hasDefinitionSource rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#UMLS_defSource</j.1:hasDefinitionSource>
+
     </owl:Class>
     
 

--- a/DigitalEntities/NIF-Investigation.owl
+++ b/DigitalEntities/NIF-Investigation.owl
@@ -4585,6 +4585,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
 
     <owl:Class rdf:about="&p17;birnlex_2251">
         <rdfs:label rdf:datatype="&xsd;string">Structural MRI protocol</rdfs:label>
+        <core:definition rdf:datatype="&xsd;string">A structural MRI protocol is an MRI protocol that provides information to qualitatively and quantitatively describe the shape, size, and integrity of gray and white matter structures in the brain.</core:definition>
         <rdfs:subClassOf rdf:resource="&p17;birnlex_2177"/>
         <j.1:modifiedDate rdf:datatype="&xsd;string">2007-10-09</j.1:modifiedDate>
         <j.1:createdDate rdf:datatype="&xsd;string">2007-10-09</j.1:createdDate>
@@ -4593,6 +4594,7 @@ Newly defined classes: Neuroimaging and Immunolabeling.</core:changeNote>
         <j.1:nifID rdf:datatype="&xsd;string">_7_2.2.1</j.1:nifID>
         <birn_annot:hasBirnlexCurator rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/BIRNLex_annotation_properties.owl#Bill_Bug</birn_annot:hasBirnlexCurator>
         <birn_annot:hasCurationStatus rdf:datatype="&xsd;string">http://ontology.neuinfo.org/NIF/Backend/BIRNLex_annotation_properties.owl#uncurated</birn_annot:hasCurationStatus>
+        <j.1:definingCitationURI rdf:datatype="&xsd;string">http://fmri.ucsd.edu/Research/whatisfmri.html</j.1:definingCitationURI>
     </owl:Class>
     
 

--- a/interlex_reserved.txt
+++ b/interlex_reserved.txt
@@ -3,7 +3,7 @@ ilx_0050000:Positron emission tomography scanner
 ilx_0050001:Single-photon emission computed tomography scanner
 ilx_0050002:Magnetoencephalography machine
 ilx_0050003:Electroencephalography machine
-ilx_0050004:
+ilx_0050004:Anatomical MRI protocol
 ilx_0050005:
 ilx_0050006:
 ilx_0050007:


### PR DESCRIPTION
/!\ This pull request is based on #38, #38 should be reviewed first /!\

-----

This pull request is a companion for #38, to:
 - request interlex identifier `ixl_0050004` for 'Anatomical MRI protocol'. 

This pull request is separate from #38 so that the identifier request can be managed separately  (as discussed in https://github.com/SciCrunch/NIF-Ontology/pull/34#issuecomment-191392605) but, nevertheless it is based on #38 in order to be able to replace the placeholder `birnlex_xxx_anat_mri_protocol_xxx ` used in `DigitalEntities/NIF-Investigation.owl` by the requested id.

@tgbugs: Let me know if this is as expected. Thanks!