### PR TITLE
Missing labels for some NPO terms

### DIFF
--- a/ttl/SPARC_Missing_Labels.ttl
+++ b/ttl/SPARC_Missing_Labels.ttl
@@ -1,0 +1,182 @@
+@prefix FMA: <http://purl.org/sig/ont/fma/fma> .
+@prefix ILX: <http://uri.interlex.org/base/ilx_> .
+@prefix NLX: <http://uri.neuinfo.org/nif/nifstd/nlx_> .
+@prefix ilxtr: <http://uri.interlex.org/tgbugs/uris/readable/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+FMA:53056 rdfs:label "Medial pterygoid nerve" .
+
+FMA:53275 rdfs:label "Stapedius nerve" .
+
+FMA:53291 rdfs:label "Temporal branch of facial nerve" .
+
+FMA:53307 rdfs:label "Zygomatic branch of facial nerve" .
+
+FMA:53310 rdfs:label "Buccal branch of facial nerve" .
+
+FMA:53365 rdfs:label "Marginal mandibular branch of facial nerve" .
+
+FMA:53396 rdfs:label "Cervical branch of facial nerve" .
+
+FMA:53417 rdfs:label "Greater petrosal nerve" .
+
+FMA:53612 rdfs:label "Cardiac branch of vagus nerve" .
+
+FMA:6225 rdfs:label "Esophageal nerve plexus" .
+
+FMA:65515 rdfs:label "Pulmonary branch of vagus nerve" .
+
+FMA:67532 rdfs:label "External carotid nerve plexus" .
+
+FMA:75564 rdfs:label "Set of cardiac branches of thoracic ganglia" .
+
+FMA:75565 rdfs:label "Set of pulmonary branches of thoracic ganglia" .
+
+FMA:75566 rdfs:label "Set of oesophageal branches of thoracic ganglia" .
+
+FMA:7643 rdfs:label "Anterior root of first thoracic nerve" .
+
+FMA:77533 rdfs:label "Tympanic plexus" .
+
+FMA:78480 rdfs:label "Facial colliculus" .
+
+ILX:0485722 rdfs:label "Nodose Ganglion" .
+
+ILX:0505839 rdfs:label "Laryngeal Nerve, Inferior" .
+
+ILX:0738279 rdfs:label "DELETED" .
+
+ILX:0738290 rdfs:label "ICG-MCG sympathetic cord" .
+
+ILX:0738291 rdfs:label "T1-ICG sympathetic cord" .
+
+ILX:0738292 rdfs:label "MCG-SCG sympathetic cord" .
+
+ILX:0738293 rdfs:label "DELETED" .
+
+ILX:0738308 rdfs:label "External branch of inferior laryngeal nerve" .
+
+ILX:0738309 rdfs:label "Internal branch of inferior laryngeal nerve" .
+
+ILX:0738312 rdfs:label "Aortic arch depressor nerve" .
+
+ILX:0738313 rdfs:label "Rami glomi carotici" .
+
+ILX:0738315 rdfs:label "Pharyngeal branch of the Hypoglossal nerve" .
+
+ILX:0738324 rdfs:label "Phrenic nucleus of C4" .
+
+ILX:0738325 rdfs:label "Phrenic nucleus of C5" .
+
+ILX:0738342 rdfs:label "T1 paravertebral ganglion" .
+
+ILX:0738371 rdfs:label "Rexed Lamina VII of T1" .
+
+ILX:0738372 rdfs:label "DELETED" .
+
+ILX:0738373 rdfs:label "Internal branch of superior laryngeal nerve" .
+
+ILX:0738374 rdfs:label "External branch of superior laryngeal nerve" .
+
+ilxtr:Contralateral rdfs:label "Contralateral" .
+
+ilxtr:bladder-dome-vessel-wall rdfs:label "bladder-dome-vessel-wall" .
+
+ilxtr:bladder-dome-wall rdfs:label "bladder-dome-wall" .
+
+ilxtr:bladder-neck-vessel-wall rdfs:label "bladder-neck-vessel-wall" .
+
+ilxtr:bladder-neck-wall rdfs:label "bladder-neck-wall" .
+
+ilxtr:dr-L1 rdfs:label "dorsal root of the L1 spinal segment" .
+
+ilxtr:dr-L2 rdfs:label "dorsal root of the L2 spinal segment" .
+
+ilxtr:dr-L6 rdfs:label "dorsal root of the L6 spinal segment" .
+
+ilxtr:dr-S1 rdfs:label "dorsal root of the S1 spinal segment" .
+
+ilxtr:gr-L1 rdfs:label "gray ramus of the L1 spinal segment" .
+
+ilxtr:gr-L2 rdfs:label "gray ramus of the L2 spinal segment" .
+
+ilxtr:gr-L6 rdfs:label "gray ramus of the L6 spinal segment" .
+
+ilxtr:gr-S1 rdfs:label "gray ramus of the S1 spinal segment" .
+
+ilxtr:nerve-bladder rdfs:label "nerve-bladder" .
+
+ilxtr:sc-L1 rdfs:label "sympathetic chain ganglion of the L1 spinal segment" .
+
+ilxtr:sc-L2 rdfs:label "sympathetic chain ganglion of the L2 spinal segment" .
+
+ilxtr:sc-L3 rdfs:label "sympathetic chain ganglion of the L3 spinal segment" .
+
+ilxtr:sc-L4 rdfs:label "sympathetic chain ganglion of the L4 spinal segment" .
+
+ilxtr:sc-L5 rdfs:label "sympathetic chain ganglion of the L5 spinal segment" .
+
+ilxtr:sc-L6 rdfs:label "sympathetic chain ganglion of the L6 spinal segment" .
+
+ilxtr:sc-S1 rdfs:label "sympathetic chain ganglion of the S1 spinal segment" .
+
+ilxtr:sc-T12 rdfs:label "sympathetic chain ganglion of the T12 spinal segment" .
+
+ilxtr:sc-T13 rdfs:label "sympathetic chain ganglion of the T13 spinal segment" .
+
+ilxtr:spinal-I rdfs:label "spinal-I" .
+
+ilxtr:spinal-II rdfs:label "spinal-II" .
+
+ilxtr:spinal-IX rdfs:label "spinal-IX" .
+
+ilxtr:spinal-L1 rdfs:label "spinal-L1" .
+
+ilxtr:spinal-L2 rdfs:label "spinal-L2" .
+
+ilxtr:spinal-L5 rdfs:label "spinal-L5" .
+
+ilxtr:spinal-L6 rdfs:label "spinal-L6" .
+
+ilxtr:spinal-S1 rdfs:label "spinal-S1" .
+
+ilxtr:spinal-V rdfs:label "spinal-V" .
+
+ilxtr:spinal-VII rdfs:label "spinal-VII" .
+
+ilxtr:spinal-X rdfs:label "spinal-X" .
+
+ilxtr:spinal-white-matter rdfs:label "spinal-white-matter" .
+
+ilxtr:vr-L1 rdfs:label "ventral root of the L1 spinal segment" .
+
+ilxtr:vr-L2 rdfs:label "ventral root of the L2 spinal segment" .
+
+ilxtr:vr-L5 rdfs:label "ventral root of the L5 spinal segment" .
+
+ilxtr:vr-L6 rdfs:label "ventral root of the L6 spinal segment" .
+
+ilxtr:vr-S1 rdfs:label "ventral root of the S1 spinal segment" .
+
+ilxtr:wr-L1 rdfs:label "white ramus of the L1 spinal segment" .
+
+ilxtr:wr-L2 rdfs:label "white ramus of the L2 spinal segment" .
+
+NLX:12056 rdfs:label "Anterior piriform cortex" .
+
+NLX:149264 rdfs:label "Superior paraolivary nucleus" .
+
+NLX:152184 rdfs:label "Retina outer plexiform layer" .
+
+NLX:152528 rdfs:label "Olfactory bulb (accessory) external plexiform layer" .
+
+NLX:153849 rdfs:label "Dorsal cochlear nucleus deep layer" .
+
+NLX:50884 rdfs:label "Ventral nuclei of the lateral lemniscus" .
+
+NLX:63363 rdfs:label "Olfactory bulb (main) internal plexiform layer" .
+
+NLX:66882 rdfs:label "Mediodorsal thalamus" .
+
+NLX:96 rdfs:label "Olfactory bulb main external plexiform layer" .
+


### PR DESCRIPTION
This turtle file contains the missing labels (rdfs:label) for some of the NPO anatomical terms. These will ideally be replaced by UBERON terms eventually. NOTE: This file contains the following three terms with "DELETED" as their labels: ILX:0738279, ILX:0738293, ILX:0738372