### PR TITLE
Dicom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ catalog-v001.xml
 *.wat
 *.orig
 *.nope
+
+notebooks/*

--- a/ttl/generated/DICOM-ILX-mapping.ttl
+++ b/ttl/generated/DICOM-ILX-mapping.ttl
@@ -1,5 +1,5 @@
 @prefix DICOM: <http://uri.interlex.org/dicom/uris/terms/> .
-@prefix ilx: <http://uri.interlex.org/base/ilx_> .
+@prefix ILX: <http://uri.interlex.org/base/ilx_> .
 @prefix ilxtr: <http://uri.interlex.org/tgbugs/uris/readable/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -10,6606 +10,6606 @@
 
 ### Annotations
 
-DICOM:0000_0001 ilxtr:hasIlxId ilx:0381696 .
+DICOM:0000_0001 ilxtr:hasIlxId ILX:0381696 .
 
-DICOM:0000_0002 ilxtr:hasIlxId ilx:0382179 .
+DICOM:0000_0002 ilxtr:hasIlxId ILX:0382179 .
 
-DICOM:0000_0003 ilxtr:hasIlxId ilx:0382134 .
+DICOM:0000_0003 ilxtr:hasIlxId ILX:0382134 .
 
-DICOM:0000_0004 ilxtr:hasIlxId ilx:0382147 .
+DICOM:0000_0004 ilxtr:hasIlxId ILX:0382147 .
 
-DICOM:0000_0005 ilxtr:hasIlxId ilx:0381975 .
+DICOM:0000_0005 ilxtr:hasIlxId ILX:0381975 .
 
-DICOM:0000_0006 ilxtr:hasIlxId ilx:0382712 .
+DICOM:0000_0006 ilxtr:hasIlxId ILX:0382712 .
 
-DICOM:0000_0007 ilxtr:hasIlxId ilx:0382125 .
+DICOM:0000_0007 ilxtr:hasIlxId ILX:0382125 .
 
-DICOM:0000_0008 ilxtr:hasIlxId ilx:0381682 .
+DICOM:0000_0008 ilxtr:hasIlxId ILX:0381682 .
 
-DICOM:0000_0009 ilxtr:hasIlxId ilx:0381831 .
+DICOM:0000_0009 ilxtr:hasIlxId ILX:0381831 .
 
-DICOM:0000_0010 ilxtr:hasIlxId ilx:0381753 .
+DICOM:0000_0010 ilxtr:hasIlxId ILX:0381753 .
 
-DICOM:0000_0011 ilxtr:hasIlxId ilx:0381801 .
+DICOM:0000_0011 ilxtr:hasIlxId ILX:0381801 .
 
-DICOM:0000_0012 ilxtr:hasIlxId ilx:0381679 .
+DICOM:0000_0012 ilxtr:hasIlxId ILX:0381679 .
 
-DICOM:0000_0013 ilxtr:hasIlxId ilx:0382943 .
+DICOM:0000_0013 ilxtr:hasIlxId ILX:0382943 .
 
-DICOM:0000_0014 ilxtr:hasIlxId ilx:0382784 .
+DICOM:0000_0014 ilxtr:hasIlxId ILX:0382784 .
 
-DICOM:0000_0015 ilxtr:hasIlxId ilx:0382357 .
+DICOM:0000_0015 ilxtr:hasIlxId ILX:0382357 .
 
-DICOM:0000_0016 ilxtr:hasIlxId ilx:0381905 .
+DICOM:0000_0016 ilxtr:hasIlxId ILX:0381905 .
 
-DICOM:0000_0017 ilxtr:hasIlxId ilx:0382523 .
+DICOM:0000_0017 ilxtr:hasIlxId ILX:0382523 .
 
-DICOM:0000_0018 ilxtr:hasIlxId ilx:0382759 .
+DICOM:0000_0018 ilxtr:hasIlxId ILX:0382759 .
 
-DICOM:0000_0019 ilxtr:hasIlxId ilx:0381540 .
+DICOM:0000_0019 ilxtr:hasIlxId ILX:0381540 .
 
-DICOM:0000_0020 ilxtr:hasIlxId ilx:0381746 .
+DICOM:0000_0020 ilxtr:hasIlxId ILX:0381746 .
 
-DICOM:0000_0021 ilxtr:hasIlxId ilx:0382387 .
+DICOM:0000_0021 ilxtr:hasIlxId ILX:0382387 .
 
-DICOM:0000_0022 ilxtr:hasIlxId ilx:0382003 .
+DICOM:0000_0022 ilxtr:hasIlxId ILX:0382003 .
 
-DICOM:0000_0023 ilxtr:hasIlxId ilx:0382598 .
+DICOM:0000_0023 ilxtr:hasIlxId ILX:0382598 .
 
-DICOM:0000_0024 ilxtr:hasIlxId ilx:0382535 .
+DICOM:0000_0024 ilxtr:hasIlxId ILX:0382535 .
 
-DICOM:0000_0025 ilxtr:hasIlxId ilx:0382150 .
+DICOM:0000_0025 ilxtr:hasIlxId ILX:0382150 .
 
-DICOM:0000_0026 ilxtr:hasIlxId ilx:0381973 .
+DICOM:0000_0026 ilxtr:hasIlxId ILX:0381973 .
 
-DICOM:0000_0027 ilxtr:hasIlxId ilx:0382627 .
+DICOM:0000_0027 ilxtr:hasIlxId ILX:0382627 .
 
-DICOM:0000_0028 ilxtr:hasIlxId ilx:0381758 .
+DICOM:0000_0028 ilxtr:hasIlxId ILX:0381758 .
 
-DICOM:0000_0029 ilxtr:hasIlxId ilx:0382043 .
+DICOM:0000_0029 ilxtr:hasIlxId ILX:0382043 .
 
-DICOM:0000_0031 ilxtr:hasIlxId ilx:0382925 .
+DICOM:0000_0031 ilxtr:hasIlxId ILX:0382925 .
 
-DICOM:0000_0032 ilxtr:hasIlxId ilx:0382607 .
+DICOM:0000_0032 ilxtr:hasIlxId ILX:0382607 .
 
-DICOM:0000_0033 ilxtr:hasIlxId ilx:0382772 .
+DICOM:0000_0033 ilxtr:hasIlxId ILX:0382772 .
 
-DICOM:0000_0034 ilxtr:hasIlxId ilx:0382122 .
+DICOM:0000_0034 ilxtr:hasIlxId ILX:0382122 .
 
-DICOM:0000_0035 ilxtr:hasIlxId ilx:0382724 .
+DICOM:0000_0035 ilxtr:hasIlxId ILX:0382724 .
 
-DICOM:0000_0036 ilxtr:hasIlxId ilx:0382399 .
+DICOM:0000_0036 ilxtr:hasIlxId ILX:0382399 .
 
-DICOM:0000_0037 ilxtr:hasIlxId ilx:0381945 .
+DICOM:0000_0037 ilxtr:hasIlxId ILX:0381945 .
 
-DICOM:0000_0040 ilxtr:hasIlxId ilx:0381848 .
+DICOM:0000_0040 ilxtr:hasIlxId ILX:0381848 .
 
-DICOM:0000_0041 ilxtr:hasIlxId ilx:0383140 .
+DICOM:0000_0041 ilxtr:hasIlxId ILX:0383140 .
 
-DICOM:0000_0042 ilxtr:hasIlxId ilx:0382657 .
+DICOM:0000_0042 ilxtr:hasIlxId ILX:0382657 .
 
-DICOM:0000_0043 ilxtr:hasIlxId ilx:0382128 .
+DICOM:0000_0043 ilxtr:hasIlxId ILX:0382128 .
 
-DICOM:0000_0044 ilxtr:hasIlxId ilx:0382979 .
+DICOM:0000_0044 ilxtr:hasIlxId ILX:0382979 .
 
-DICOM:0000_0045 ilxtr:hasIlxId ilx:0382313 .
+DICOM:0000_0045 ilxtr:hasIlxId ILX:0382313 .
 
-DICOM:0000_0046 ilxtr:hasIlxId ilx:0382929 .
+DICOM:0000_0046 ilxtr:hasIlxId ILX:0382929 .
 
-DICOM:0000_0047 ilxtr:hasIlxId ilx:0382606 .
+DICOM:0000_0047 ilxtr:hasIlxId ILX:0382606 .
 
-DICOM:0000_0049 ilxtr:hasIlxId ilx:0381841 .
+DICOM:0000_0049 ilxtr:hasIlxId ILX:0381841 .
 
-DICOM:0000_0051 ilxtr:hasIlxId ilx:0381829 .
+DICOM:0000_0051 ilxtr:hasIlxId ILX:0381829 .
 
-DICOM:0000_0052 ilxtr:hasIlxId ilx:0381451 .
+DICOM:0000_0052 ilxtr:hasIlxId ILX:0381451 .
 
-DICOM:0000_0053 ilxtr:hasIlxId ilx:0382085 .
+DICOM:0000_0053 ilxtr:hasIlxId ILX:0382085 .
 
-DICOM:0000_0054 ilxtr:hasIlxId ilx:0383169 .
+DICOM:0000_0054 ilxtr:hasIlxId ILX:0383169 .
 
-DICOM:0000_0055 ilxtr:hasIlxId ilx:0381866 .
+DICOM:0000_0055 ilxtr:hasIlxId ILX:0381866 .
 
-DICOM:0000_0056 ilxtr:hasIlxId ilx:0382883 .
+DICOM:0000_0056 ilxtr:hasIlxId ILX:0382883 .
 
-DICOM:0000_0057 ilxtr:hasIlxId ilx:0381935 .
+DICOM:0000_0057 ilxtr:hasIlxId ILX:0381935 .
 
-DICOM:0000_0058 ilxtr:hasIlxId ilx:0382972 .
+DICOM:0000_0058 ilxtr:hasIlxId ILX:0382972 .
 
-DICOM:0000_0060 ilxtr:hasIlxId ilx:0382488 .
+DICOM:0000_0060 ilxtr:hasIlxId ILX:0382488 .
 
-DICOM:0000_0061 ilxtr:hasIlxId ilx:0382397 .
+DICOM:0000_0061 ilxtr:hasIlxId ILX:0382397 .
 
-DICOM:0000_0062 ilxtr:hasIlxId ilx:0381559 .
+DICOM:0000_0062 ilxtr:hasIlxId ILX:0381559 .
 
-DICOM:0000_0063 ilxtr:hasIlxId ilx:0381476 .
+DICOM:0000_0063 ilxtr:hasIlxId ILX:0381476 .
 
-DICOM:0000_0064 ilxtr:hasIlxId ilx:0383008 .
+DICOM:0000_0064 ilxtr:hasIlxId ILX:0383008 .
 
-DICOM:0000_0065 ilxtr:hasIlxId ilx:0382351 .
+DICOM:0000_0065 ilxtr:hasIlxId ILX:0382351 .
 
-DICOM:0000_0066 ilxtr:hasIlxId ilx:0383016 .
+DICOM:0000_0066 ilxtr:hasIlxId ILX:0383016 .
 
-DICOM:0000_0067 ilxtr:hasIlxId ilx:0382751 .
+DICOM:0000_0067 ilxtr:hasIlxId ILX:0382751 .
 
-DICOM:0000_0068 ilxtr:hasIlxId ilx:0382788 .
+DICOM:0000_0068 ilxtr:hasIlxId ILX:0382788 .
 
-DICOM:0000_0069 ilxtr:hasIlxId ilx:0382518 .
+DICOM:0000_0069 ilxtr:hasIlxId ILX:0382518 .
 
-DICOM:0000_070 ilxtr:hasIlxId ilx:0382091 .
+DICOM:0000_070 ilxtr:hasIlxId ILX:0382091 .
 
-DICOM:0000_0071 ilxtr:hasIlxId ilx:0381767 .
+DICOM:0000_0071 ilxtr:hasIlxId ILX:0381767 .
 
-DICOM:0000_0072 ilxtr:hasIlxId ilx:0381551 .
+DICOM:0000_0072 ilxtr:hasIlxId ILX:0381551 .
 
-DICOM:0000_0073 ilxtr:hasIlxId ilx:0382975 .
+DICOM:0000_0073 ilxtr:hasIlxId ILX:0382975 .
 
-DICOM:0000_0074 ilxtr:hasIlxId ilx:0382335 .
+DICOM:0000_0074 ilxtr:hasIlxId ILX:0382335 .
 
-DICOM:0000_0075 ilxtr:hasIlxId ilx:0382326 .
+DICOM:0000_0075 ilxtr:hasIlxId ILX:0382326 .
 
-DICOM:0000_0076 ilxtr:hasIlxId ilx:0382425 .
+DICOM:0000_0076 ilxtr:hasIlxId ILX:0382425 .
 
-DICOM:0000_0077 ilxtr:hasIlxId ilx:0381913 .
+DICOM:0000_0077 ilxtr:hasIlxId ILX:0381913 .
 
-DICOM:0000_0078 ilxtr:hasIlxId ilx:0382170 .
+DICOM:0000_0078 ilxtr:hasIlxId ILX:0382170 .
 
-DICOM:0000_0079 ilxtr:hasIlxId ilx:0383146 .
+DICOM:0000_0079 ilxtr:hasIlxId ILX:0383146 .
 
-DICOM:0000_0080 ilxtr:hasIlxId ilx:0382047 .
+DICOM:0000_0080 ilxtr:hasIlxId ILX:0382047 .
 
-DICOM:0000_0081 ilxtr:hasIlxId ilx:0381496 .
+DICOM:0000_0081 ilxtr:hasIlxId ILX:0381496 .
 
-DICOM:0000_0082 ilxtr:hasIlxId ilx:0381579 .
+DICOM:0000_0082 ilxtr:hasIlxId ILX:0381579 .
 
-DICOM:0000_0083 ilxtr:hasIlxId ilx:0382463 .
+DICOM:0000_0083 ilxtr:hasIlxId ILX:0382463 .
 
-DICOM:0000_0084 ilxtr:hasIlxId ilx:0382274 .
+DICOM:0000_0084 ilxtr:hasIlxId ILX:0382274 .
 
-DICOM:0000_0085 ilxtr:hasIlxId ilx:0381883 .
+DICOM:0000_0085 ilxtr:hasIlxId ILX:0381883 .
 
-DICOM:0000_0086 ilxtr:hasIlxId ilx:0382413 .
+DICOM:0000_0086 ilxtr:hasIlxId ILX:0382413 .
 
-DICOM:0000_0087 ilxtr:hasIlxId ilx:0382982 .
+DICOM:0000_0087 ilxtr:hasIlxId ILX:0382982 .
 
-DICOM:003A_001A ilxtr:hasIlxId ilx:0110333 .
+DICOM:003A_001A ilxtr:hasIlxId ILX:0110333 .
 
-DICOM:003A_0004 ilxtr:hasIlxId ilx:0112587 .
+DICOM:003A_0004 ilxtr:hasIlxId ILX:0112587 .
 
-DICOM:003A_0005 ilxtr:hasIlxId ilx:0107850 .
+DICOM:003A_0005 ilxtr:hasIlxId ILX:0107850 .
 
-DICOM:003A_0010 ilxtr:hasIlxId ilx:0107851 .
+DICOM:003A_0010 ilxtr:hasIlxId ILX:0107851 .
 
-DICOM:003A_0020 ilxtr:hasIlxId ilx:0107194 .
+DICOM:003A_0020 ilxtr:hasIlxId ILX:0107194 .
 
-DICOM:003A_020A ilxtr:hasIlxId ilx:0110810 .
+DICOM:003A_020A ilxtr:hasIlxId ILX:0110810 .
 
-DICOM:003A_020C ilxtr:hasIlxId ilx:0102031 .
+DICOM:003A_020C ilxtr:hasIlxId ILX:0102031 .
 
-DICOM:003A_021A ilxtr:hasIlxId ilx:0112584 .
+DICOM:003A_021A ilxtr:hasIlxId ILX:0112584 .
 
-DICOM:003A_0200 ilxtr:hasIlxId ilx:0102030 .
+DICOM:003A_0200 ilxtr:hasIlxId ILX:0102030 .
 
-DICOM:003A_0202 ilxtr:hasIlxId ilx:0112585 .
+DICOM:003A_0202 ilxtr:hasIlxId ILX:0112585 .
 
-DICOM:003A_0203 ilxtr:hasIlxId ilx:0102033 .
+DICOM:003A_0203 ilxtr:hasIlxId ILX:0102033 .
 
-DICOM:003A_0205 ilxtr:hasIlxId ilx:0102051 .
+DICOM:003A_0205 ilxtr:hasIlxId ILX:0102051 .
 
-DICOM:003A_0208 ilxtr:hasIlxId ilx:0381786 .
+DICOM:003A_0208 ilxtr:hasIlxId ILX:0381786 .
 
-DICOM:003A_0209 ilxtr:hasIlxId ilx:0102050 .
+DICOM:003A_0209 ilxtr:hasIlxId ILX:0102050 .
 
-DICOM:003A_0210 ilxtr:hasIlxId ilx:0102040 .
+DICOM:003A_0210 ilxtr:hasIlxId ILX:0102040 .
 
-DICOM:003A_0211 ilxtr:hasIlxId ilx:0102042 .
+DICOM:003A_0211 ilxtr:hasIlxId ILX:0102042 .
 
-DICOM:003A_0212 ilxtr:hasIlxId ilx:0102041 .
+DICOM:003A_0212 ilxtr:hasIlxId ILX:0102041 .
 
-DICOM:003A_0213 ilxtr:hasIlxId ilx:0102029 .
+DICOM:003A_0213 ilxtr:hasIlxId ILX:0102029 .
 
-DICOM:003A_0214 ilxtr:hasIlxId ilx:0102052 .
+DICOM:003A_0214 ilxtr:hasIlxId ILX:0102052 .
 
-DICOM:003A_0215 ilxtr:hasIlxId ilx:0102039 .
+DICOM:003A_0215 ilxtr:hasIlxId ILX:0102039 .
 
-DICOM:003A_0218 ilxtr:hasIlxId ilx:0102038 .
+DICOM:003A_0218 ilxtr:hasIlxId ILX:0102038 .
 
-DICOM:003A_0220 ilxtr:hasIlxId ilx:0104234 .
+DICOM:003A_0220 ilxtr:hasIlxId ILX:0104234 .
 
-DICOM:003A_0221 ilxtr:hasIlxId ilx:0104233 .
+DICOM:003A_0221 ilxtr:hasIlxId ILX:0104233 .
 
-DICOM:003A_0222 ilxtr:hasIlxId ilx:0107695 .
+DICOM:003A_0222 ilxtr:hasIlxId ILX:0107695 .
 
-DICOM:003A_0223 ilxtr:hasIlxId ilx:0107694 .
+DICOM:003A_0223 ilxtr:hasIlxId ILX:0107694 .
 
-DICOM:003A_0230 ilxtr:hasIlxId ilx:0383147 .
+DICOM:003A_0230 ilxtr:hasIlxId ILX:0383147 .
 
-DICOM:003A_0231 ilxtr:hasIlxId ilx:0383139 .
+DICOM:003A_0231 ilxtr:hasIlxId ILX:0383139 .
 
-DICOM:003A_0240 ilxtr:hasIlxId ilx:0382361 .
+DICOM:003A_0240 ilxtr:hasIlxId ILX:0382361 .
 
-DICOM:003A_0241 ilxtr:hasIlxId ilx:0381948 .
+DICOM:003A_0241 ilxtr:hasIlxId ILX:0381948 .
 
-DICOM:003A_0242 ilxtr:hasIlxId ilx:0382381 .
+DICOM:003A_0242 ilxtr:hasIlxId ILX:0382381 .
 
-DICOM:003A_0244 ilxtr:hasIlxId ilx:0383130 .
+DICOM:003A_0244 ilxtr:hasIlxId ILX:0383130 .
 
-DICOM:003A_0245 ilxtr:hasIlxId ilx:0381794 .
+DICOM:003A_0245 ilxtr:hasIlxId ILX:0381794 .
 
-DICOM:003A_0246 ilxtr:hasIlxId ilx:0383101 .
+DICOM:003A_0246 ilxtr:hasIlxId ILX:0383101 .
 
-DICOM:003A_0247 ilxtr:hasIlxId ilx:0382024 .
+DICOM:003A_0247 ilxtr:hasIlxId ILX:0382024 .
 
-DICOM:003A_0248 ilxtr:hasIlxId ilx:0381756 .
+DICOM:003A_0248 ilxtr:hasIlxId ILX:0381756 .
 
-DICOM:003A_0300 ilxtr:hasIlxId ilx:0381635 .
+DICOM:003A_0300 ilxtr:hasIlxId ILX:0381635 .
 
-DICOM:003A_0301 ilxtr:hasIlxId ilx:0381662 .
+DICOM:003A_0301 ilxtr:hasIlxId ILX:0381662 .
 
-DICOM:003A_0302 ilxtr:hasIlxId ilx:0381792 .
+DICOM:003A_0302 ilxtr:hasIlxId ILX:0381792 .
 
-DICOM:0004_151A ilxtr:hasIlxId ilx:0383026 .
+DICOM:0004_151A ilxtr:hasIlxId ILX:0383026 .
 
-DICOM:0004_1130 ilxtr:hasIlxId ilx:0381487 .
+DICOM:0004_1130 ilxtr:hasIlxId ILX:0381487 .
 
-DICOM:0004_1141 ilxtr:hasIlxId ilx:0382981 .
+DICOM:0004_1141 ilxtr:hasIlxId ILX:0382981 .
 
-DICOM:0004_1142 ilxtr:hasIlxId ilx:0382643 .
+DICOM:0004_1142 ilxtr:hasIlxId ILX:0382643 .
 
-DICOM:0004_1200 ilxtr:hasIlxId ilx:0381877 .
+DICOM:0004_1200 ilxtr:hasIlxId ILX:0381877 .
 
-DICOM:0004_1202 ilxtr:hasIlxId ilx:0381941 .
+DICOM:0004_1202 ilxtr:hasIlxId ILX:0381941 .
 
-DICOM:0004_1212 ilxtr:hasIlxId ilx:0382700 .
+DICOM:0004_1212 ilxtr:hasIlxId ILX:0382700 .
 
-DICOM:0004_1220 ilxtr:hasIlxId ilx:0381648 .
+DICOM:0004_1220 ilxtr:hasIlxId ILX:0381648 .
 
-DICOM:0004_1400 ilxtr:hasIlxId ilx:0382710 .
+DICOM:0004_1400 ilxtr:hasIlxId ILX:0382710 .
 
-DICOM:0004_1410 ilxtr:hasIlxId ilx:0381795 .
+DICOM:0004_1410 ilxtr:hasIlxId ILX:0381795 .
 
-DICOM:0004_1420 ilxtr:hasIlxId ilx:0382039 .
+DICOM:0004_1420 ilxtr:hasIlxId ILX:0382039 .
 
-DICOM:0004_1430 ilxtr:hasIlxId ilx:0382450 .
+DICOM:0004_1430 ilxtr:hasIlxId ILX:0382450 .
 
-DICOM:0004_1432 ilxtr:hasIlxId ilx:0381681 .
+DICOM:0004_1432 ilxtr:hasIlxId ILX:0381681 .
 
-DICOM:0004_1500 ilxtr:hasIlxId ilx:0381552 .
+DICOM:0004_1500 ilxtr:hasIlxId ILX:0381552 .
 
-DICOM:0004_1511 ilxtr:hasIlxId ilx:0382905 .
+DICOM:0004_1511 ilxtr:hasIlxId ILX:0382905 .
 
-DICOM:0004_1512 ilxtr:hasIlxId ilx:0382854 .
+DICOM:0004_1512 ilxtr:hasIlxId ILX:0382854 .
 
-DICOM:4FFE_0001 ilxtr:hasIlxId ilx:0382861 .
+DICOM:4FFE_0001 ilxtr:hasIlxId ILX:0382861 .
 
-DICOM:7FE0_0008 ilxtr:hasIlxId ilx:0381956 .
+DICOM:7FE0_0008 ilxtr:hasIlxId ILX:0381956 .
 
-DICOM:7FE0_0009 ilxtr:hasIlxId ilx:0382986 .
+DICOM:7FE0_0009 ilxtr:hasIlxId ILX:0382986 .
 
-DICOM:7FE0_0010 ilxtr:hasIlxId ilx:0108950 .
+DICOM:7FE0_0010 ilxtr:hasIlxId ILX:0108950 .
 
-DICOM:0008_001A ilxtr:hasIlxId ilx:0109889 .
+DICOM:0008_001A ilxtr:hasIlxId ILX:0109889 .
 
-DICOM:0008_001B ilxtr:hasIlxId ilx:0382924 .
+DICOM:0008_001B ilxtr:hasIlxId ILX:0382924 .
 
-DICOM:0008_002A ilxtr:hasIlxId ilx:0100257 .
+DICOM:0008_002A ilxtr:hasIlxId ILX:0100257 .
 
-DICOM:0008_0005 ilxtr:hasIlxId ilx:0110852 .
+DICOM:0008_0005 ilxtr:hasIlxId ILX:0110852 .
 
-DICOM:0008_0006 ilxtr:hasIlxId ilx:0382364 .
+DICOM:0008_0006 ilxtr:hasIlxId ILX:0382364 .
 
-DICOM:0008_0008 ilxtr:hasIlxId ilx:0105255 .
+DICOM:0008_0008 ilxtr:hasIlxId ILX:0105255 .
 
-DICOM:0008_009C ilxtr:hasIlxId ilx:0381512 .
+DICOM:0008_009C ilxtr:hasIlxId ILX:0381512 .
 
-DICOM:0008_009D ilxtr:hasIlxId ilx:0382271 .
+DICOM:0008_009D ilxtr:hasIlxId ILX:0382271 .
 
-DICOM:0008_010B ilxtr:hasIlxId ilx:0381943 .
+DICOM:0008_010B ilxtr:hasIlxId ILX:0381943 .
 
-DICOM:0008_010C ilxtr:hasIlxId ilx:0102335 .
+DICOM:0008_010C ilxtr:hasIlxId ILX:0102335 .
 
-DICOM:0008_010D ilxtr:hasIlxId ilx:0382117 .
+DICOM:0008_010D ilxtr:hasIlxId ILX:0382117 .
 
-DICOM:0008_010F ilxtr:hasIlxId ilx:0383060 .
+DICOM:0008_010F ilxtr:hasIlxId ILX:0383060 .
 
-DICOM:0008_0012 ilxtr:hasIlxId ilx:0105506 .
+DICOM:0008_0012 ilxtr:hasIlxId ILX:0105506 .
 
-DICOM:0008_0013 ilxtr:hasIlxId ilx:0105507 .
+DICOM:0008_0013 ilxtr:hasIlxId ILX:0105507 .
 
-DICOM:0008_0014 ilxtr:hasIlxId ilx:0105508 .
+DICOM:0008_0014 ilxtr:hasIlxId ILX:0105508 .
 
-DICOM:0008_0015 ilxtr:hasIlxId ilx:0381548 .
+DICOM:0008_0015 ilxtr:hasIlxId ILX:0381548 .
 
-DICOM:0008_0016 ilxtr:hasIlxId ilx:0110764 .
+DICOM:0008_0016 ilxtr:hasIlxId ILX:0110764 .
 
-DICOM:0008_0018 ilxtr:hasIlxId ilx:0110767 .
+DICOM:0008_0018 ilxtr:hasIlxId ILX:0110767 .
 
-DICOM:0008_0020 ilxtr:hasIlxId ilx:0111138 .
+DICOM:0008_0020 ilxtr:hasIlxId ILX:0111138 .
 
-DICOM:0008_0021 ilxtr:hasIlxId ilx:0110542 .
+DICOM:0008_0021 ilxtr:hasIlxId ILX:0110542 .
 
-DICOM:0008_0022 ilxtr:hasIlxId ilx:0100256 .
+DICOM:0008_0022 ilxtr:hasIlxId ILX:0100256 .
 
-DICOM:0008_0023 ilxtr:hasIlxId ilx:0102506 .
+DICOM:0008_0023 ilxtr:hasIlxId ILX:0102506 .
 
-DICOM:0008_0024 ilxtr:hasIlxId ilx:0108295 .
+DICOM:0008_0024 ilxtr:hasIlxId ILX:0108295 .
 
-DICOM:0008_0030 ilxtr:hasIlxId ilx:0111145 .
+DICOM:0008_0030 ilxtr:hasIlxId ILX:0111145 .
 
-DICOM:0008_030A ilxtr:hasIlxId ilx:0381493 .
+DICOM:0008_030A ilxtr:hasIlxId ILX:0381493 .
 
-DICOM:0008_030B ilxtr:hasIlxId ilx:0382682 .
+DICOM:0008_030B ilxtr:hasIlxId ILX:0382682 .
 
-DICOM:0008_030C ilxtr:hasIlxId ilx:0382277 .
+DICOM:0008_030C ilxtr:hasIlxId ILX:0382277 .
 
-DICOM:0008_030D ilxtr:hasIlxId ilx:0381860 .
+DICOM:0008_030D ilxtr:hasIlxId ILX:0381860 .
 
-DICOM:0008_030E ilxtr:hasIlxId ilx:0382717 .
+DICOM:0008_030E ilxtr:hasIlxId ILX:0382717 .
 
-DICOM:0008_030F ilxtr:hasIlxId ilx:0382092 .
+DICOM:0008_030F ilxtr:hasIlxId ILX:0382092 .
 
-DICOM:0008_0031 ilxtr:hasIlxId ilx:0110547 .
+DICOM:0008_0031 ilxtr:hasIlxId ILX:0110547 .
 
-DICOM:0008_0032 ilxtr:hasIlxId ilx:0100266 .
+DICOM:0008_0032 ilxtr:hasIlxId ILX:0100266 .
 
-DICOM:0008_0033 ilxtr:hasIlxId ilx:0102513 .
+DICOM:0008_0033 ilxtr:hasIlxId ILX:0102513 .
 
-DICOM:0008_0034 ilxtr:hasIlxId ilx:0108303 .
+DICOM:0008_0034 ilxtr:hasIlxId ILX:0108303 .
 
-DICOM:0008_0051 ilxtr:hasIlxId ilx:0382501 .
+DICOM:0008_0051 ilxtr:hasIlxId ILX:0382501 .
 
-DICOM:0008_0053 ilxtr:hasIlxId ilx:0383046 .
+DICOM:0008_0053 ilxtr:hasIlxId ILX:0383046 .
 
-DICOM:0008_0054 ilxtr:hasIlxId ilx:0110059 .
+DICOM:0008_0054 ilxtr:hasIlxId ILX:0110059 .
 
-DICOM:0008_0055 ilxtr:hasIlxId ilx:0383048 .
+DICOM:0008_0055 ilxtr:hasIlxId ILX:0383048 .
 
-DICOM:0008_0056 ilxtr:hasIlxId ilx:0105505 .
+DICOM:0008_0056 ilxtr:hasIlxId ILX:0105505 .
 
-DICOM:0008_0058 ilxtr:hasIlxId ilx:0104082 .
+DICOM:0008_0058 ilxtr:hasIlxId ILX:0104082 .
 
-DICOM:0008_0060 ilxtr:hasIlxId ilx:0107045 .
+DICOM:0008_0060 ilxtr:hasIlxId ILX:0107045 .
 
-DICOM:0008_0061 ilxtr:hasIlxId ilx:0107044 .
+DICOM:0008_0061 ilxtr:hasIlxId ILX:0107044 .
 
-DICOM:0008_0064 ilxtr:hasIlxId ilx:0102546 .
+DICOM:0008_0064 ilxtr:hasIlxId ILX:0102546 .
 
-DICOM:0008_0068 ilxtr:hasIlxId ilx:0109240 .
+DICOM:0008_0068 ilxtr:hasIlxId ILX:0109240 .
 
-DICOM:0008_0070 ilxtr:hasIlxId ilx:0106513 .
+DICOM:0008_0070 ilxtr:hasIlxId ILX:0106513 .
 
-DICOM:0008_0080 ilxtr:hasIlxId ilx:0105513 .
+DICOM:0008_0080 ilxtr:hasIlxId ILX:0105513 .
 
-DICOM:0008_0081 ilxtr:hasIlxId ilx:0105511 .
+DICOM:0008_0081 ilxtr:hasIlxId ILX:0105511 .
 
-DICOM:0008_0082 ilxtr:hasIlxId ilx:0105512 .
+DICOM:0008_0082 ilxtr:hasIlxId ILX:0105512 .
 
-DICOM:0008_0090 ilxtr:hasIlxId ilx:0109808 .
+DICOM:0008_0090 ilxtr:hasIlxId ILX:0109808 .
 
-DICOM:0008_0092 ilxtr:hasIlxId ilx:0109807 .
+DICOM:0008_0092 ilxtr:hasIlxId ILX:0109807 .
 
-DICOM:0008_0094 ilxtr:hasIlxId ilx:0109809 .
+DICOM:0008_0094 ilxtr:hasIlxId ILX:0109809 .
 
-DICOM:0008_0096 ilxtr:hasIlxId ilx:0109806 .
+DICOM:0008_0096 ilxtr:hasIlxId ILX:0109806 .
 
-DICOM:0008_0100 ilxtr:hasIlxId ilx:0102328 .
+DICOM:0008_0100 ilxtr:hasIlxId ILX:0102328 .
 
-DICOM:0008_0102 ilxtr:hasIlxId ilx:0102330 .
+DICOM:0008_0102 ilxtr:hasIlxId ILX:0102330 .
 
-DICOM:0008_0103 ilxtr:hasIlxId ilx:0102336 .
+DICOM:0008_0103 ilxtr:hasIlxId ILX:0102336 .
 
-DICOM:0008_103E ilxtr:hasIlxId ilx:0110543 .
+DICOM:0008_103E ilxtr:hasIlxId ILX:0110543 .
 
-DICOM:0008_103F ilxtr:hasIlxId ilx:0382516 .
+DICOM:0008_103F ilxtr:hasIlxId ILX:0382516 .
 
-DICOM:0008_0104 ilxtr:hasIlxId ilx:0102325 .
+DICOM:0008_0104 ilxtr:hasIlxId ILX:0102325 .
 
-DICOM:0008_0105 ilxtr:hasIlxId ilx:0382628 .
+DICOM:0008_0105 ilxtr:hasIlxId ILX:0382628 .
 
-DICOM:0008_0106 ilxtr:hasIlxId ilx:0382243 .
+DICOM:0008_0106 ilxtr:hasIlxId ILX:0382243 .
 
-DICOM:0008_0107 ilxtr:hasIlxId ilx:0382921 .
+DICOM:0008_0107 ilxtr:hasIlxId ILX:0382921 .
 
-DICOM:0008_0110 ilxtr:hasIlxId ilx:0102332 .
+DICOM:0008_0110 ilxtr:hasIlxId ILX:0102332 .
 
-DICOM:0008_0112 ilxtr:hasIlxId ilx:0102334 .
+DICOM:0008_0112 ilxtr:hasIlxId ILX:0102334 .
 
-DICOM:0008_113A ilxtr:hasIlxId ilx:0109804 .
+DICOM:0008_113A ilxtr:hasIlxId ILX:0109804 .
 
-DICOM:0008_0114 ilxtr:hasIlxId ilx:0102331 .
+DICOM:0008_0114 ilxtr:hasIlxId ILX:0102331 .
 
-DICOM:0008_114A ilxtr:hasIlxId ilx:0109768 .
+DICOM:0008_114A ilxtr:hasIlxId ILX:0109768 .
 
-DICOM:0008_114B ilxtr:hasIlxId ilx:0381940 .
+DICOM:0008_114B ilxtr:hasIlxId ILX:0381940 .
 
-DICOM:0008_0115 ilxtr:hasIlxId ilx:0102333 .
+DICOM:0008_0115 ilxtr:hasIlxId ILX:0102333 .
 
-DICOM:0008_115A ilxtr:hasIlxId ilx:0110765 .
+DICOM:0008_115A ilxtr:hasIlxId ILX:0110765 .
 
-DICOM:0008_0116 ilxtr:hasIlxId ilx:0109973 .
+DICOM:0008_0116 ilxtr:hasIlxId ILX:0109973 .
 
-DICOM:0008_0118 ilxtr:hasIlxId ilx:0382707 .
+DICOM:0008_0118 ilxtr:hasIlxId ILX:0382707 .
 
-DICOM:0008_0119 ilxtr:hasIlxId ilx:0382098 .
+DICOM:0008_0119 ilxtr:hasIlxId ILX:0382098 .
 
-DICOM:0008_0120 ilxtr:hasIlxId ilx:0381644 .
+DICOM:0008_0120 ilxtr:hasIlxId ILX:0381644 .
 
-DICOM:0008_0121 ilxtr:hasIlxId ilx:0383106 .
+DICOM:0008_0121 ilxtr:hasIlxId ILX:0383106 .
 
-DICOM:0008_0122 ilxtr:hasIlxId ilx:0382442 .
+DICOM:0008_0122 ilxtr:hasIlxId ILX:0382442 .
 
-DICOM:0008_0123 ilxtr:hasIlxId ilx:0383107 .
+DICOM:0008_0123 ilxtr:hasIlxId ILX:0383107 .
 
-DICOM:0008_0124 ilxtr:hasIlxId ilx:0381730 .
+DICOM:0008_0124 ilxtr:hasIlxId ILX:0381730 .
 
-DICOM:0008_0201 ilxtr:hasIlxId ilx:0111761 .
+DICOM:0008_0201 ilxtr:hasIlxId ILX:0111761 .
 
-DICOM:0008_212A ilxtr:hasIlxId ilx:0107849 .
+DICOM:0008_212A ilxtr:hasIlxId ILX:0107849 .
 
-DICOM:0008_0220 ilxtr:hasIlxId ilx:0382081 .
+DICOM:0008_0220 ilxtr:hasIlxId ILX:0382081 .
 
-DICOM:0008_0221 ilxtr:hasIlxId ilx:0381804 .
+DICOM:0008_0221 ilxtr:hasIlxId ILX:0381804 .
 
-DICOM:0008_0222 ilxtr:hasIlxId ilx:0382727 .
+DICOM:0008_0222 ilxtr:hasIlxId ILX:0382727 .
 
-DICOM:0008_0300 ilxtr:hasIlxId ilx:0381692 .
+DICOM:0008_0300 ilxtr:hasIlxId ILX:0381692 .
 
-DICOM:0008_0301 ilxtr:hasIlxId ilx:0382299 .
+DICOM:0008_0301 ilxtr:hasIlxId ILX:0382299 .
 
-DICOM:0008_0302 ilxtr:hasIlxId ilx:0381958 .
+DICOM:0008_0302 ilxtr:hasIlxId ILX:0381958 .
 
-DICOM:0008_0303 ilxtr:hasIlxId ilx:0382527 .
+DICOM:0008_0303 ilxtr:hasIlxId ILX:0382527 .
 
-DICOM:0008_0304 ilxtr:hasIlxId ilx:0382311 .
+DICOM:0008_0304 ilxtr:hasIlxId ILX:0382311 .
 
-DICOM:0008_0305 ilxtr:hasIlxId ilx:0382570 .
+DICOM:0008_0305 ilxtr:hasIlxId ILX:0382570 .
 
-DICOM:0008_0306 ilxtr:hasIlxId ilx:0382622 .
+DICOM:0008_0306 ilxtr:hasIlxId ILX:0382622 .
 
-DICOM:0008_0307 ilxtr:hasIlxId ilx:0382207 .
+DICOM:0008_0307 ilxtr:hasIlxId ILX:0382207 .
 
-DICOM:0008_0308 ilxtr:hasIlxId ilx:0381727 .
+DICOM:0008_0308 ilxtr:hasIlxId ILX:0381727 .
 
-DICOM:0008_0309 ilxtr:hasIlxId ilx:0381880 .
+DICOM:0008_0309 ilxtr:hasIlxId ILX:0381880 .
 
-DICOM:0008_0310 ilxtr:hasIlxId ilx:0381606 .
+DICOM:0008_0310 ilxtr:hasIlxId ILX:0381606 .
 
-DICOM:0008_1010 ilxtr:hasIlxId ilx:0111027 .
+DICOM:0008_1010 ilxtr:hasIlxId ILX:0111027 .
 
-DICOM:0008_1030 ilxtr:hasIlxId ilx:0111139 .
+DICOM:0008_1030 ilxtr:hasIlxId ILX:0111139 .
 
-DICOM:0008_1032 ilxtr:hasIlxId ilx:0109380 .
+DICOM:0008_1032 ilxtr:hasIlxId ILX:0109380 .
 
-DICOM:0008_1040 ilxtr:hasIlxId ilx:0381511 .
+DICOM:0008_1040 ilxtr:hasIlxId ILX:0381511 .
 
-DICOM:0008_1048 ilxtr:hasIlxId ilx:0108863 .
+DICOM:0008_1048 ilxtr:hasIlxId ILX:0108863 .
 
-DICOM:0008_1049 ilxtr:hasIlxId ilx:0108864 .
+DICOM:0008_1049 ilxtr:hasIlxId ILX:0108864 .
 
-DICOM:0008_1050 ilxtr:hasIlxId ilx:0108709 .
+DICOM:0008_1050 ilxtr:hasIlxId ILX:0108709 .
 
-DICOM:0008_1052 ilxtr:hasIlxId ilx:0108708 .
+DICOM:0008_1052 ilxtr:hasIlxId ILX:0108708 .
 
-DICOM:0008_1060 ilxtr:hasIlxId ilx:0107294 .
+DICOM:0008_1060 ilxtr:hasIlxId ILX:0107294 .
 
-DICOM:0008_1062 ilxtr:hasIlxId ilx:0108865 .
+DICOM:0008_1062 ilxtr:hasIlxId ILX:0108865 .
 
-DICOM:0008_1070 ilxtr:hasIlxId ilx:0108056 .
+DICOM:0008_1070 ilxtr:hasIlxId ILX:0108056 .
 
-DICOM:0008_1072 ilxtr:hasIlxId ilx:0108055 .
+DICOM:0008_1072 ilxtr:hasIlxId ILX:0108055 .
 
-DICOM:0008_1080 ilxtr:hasIlxId ilx:0100336 .
+DICOM:0008_1080 ilxtr:hasIlxId ILX:0100336 .
 
-DICOM:0008_1084 ilxtr:hasIlxId ilx:0100335 .
+DICOM:0008_1084 ilxtr:hasIlxId ILX:0100335 .
 
-DICOM:0008_1090 ilxtr:hasIlxId ilx:0106514 .
+DICOM:0008_1090 ilxtr:hasIlxId ILX:0106514 .
 
-DICOM:0008_1100 ilxtr:hasIlxId ilx:0109784 .
+DICOM:0008_1100 ilxtr:hasIlxId ILX:0109784 .
 
-DICOM:0008_1110 ilxtr:hasIlxId ilx:0109797 .
+DICOM:0008_1110 ilxtr:hasIlxId ILX:0109797 .
 
-DICOM:0008_1111 ilxtr:hasIlxId ilx:0109777 .
+DICOM:0008_1111 ilxtr:hasIlxId ILX:0109777 .
 
-DICOM:0008_1115 ilxtr:hasIlxId ilx:0109788 .
+DICOM:0008_1115 ilxtr:hasIlxId ILX:0109788 .
 
-DICOM:0008_1120 ilxtr:hasIlxId ilx:0109775 .
+DICOM:0008_1120 ilxtr:hasIlxId ILX:0109775 .
 
-DICOM:0008_1125 ilxtr:hasIlxId ilx:0109802 .
+DICOM:0008_1125 ilxtr:hasIlxId ILX:0109802 .
 
-DICOM:0008_1130 ilxtr:hasIlxId ilx:0109773 .
+DICOM:0008_1130 ilxtr:hasIlxId ILX:0109773 .
 
-DICOM:0008_1134 ilxtr:hasIlxId ilx:0382804 .
+DICOM:0008_1134 ilxtr:hasIlxId ILX:0382804 .
 
-DICOM:0008_1140 ilxtr:hasIlxId ilx:0109767 .
+DICOM:0008_1140 ilxtr:hasIlxId ILX:0109767 .
 
-DICOM:0008_1145 ilxtr:hasIlxId ilx:0109750 .
+DICOM:0008_1145 ilxtr:hasIlxId ILX:0109750 .
 
-DICOM:0008_1150 ilxtr:hasIlxId ilx:0109789 .
+DICOM:0008_1150 ilxtr:hasIlxId ILX:0109789 .
 
-DICOM:0008_1155 ilxtr:hasIlxId ilx:0109790 .
+DICOM:0008_1155 ilxtr:hasIlxId ILX:0109790 .
 
-DICOM:0008_1160 ilxtr:hasIlxId ilx:0109758 .
+DICOM:0008_1160 ilxtr:hasIlxId ILX:0109758 .
 
-DICOM:0008_1161 ilxtr:hasIlxId ilx:0382881 .
+DICOM:0008_1161 ilxtr:hasIlxId ILX:0382881 .
 
-DICOM:0008_1162 ilxtr:hasIlxId ilx:0381712 .
+DICOM:0008_1162 ilxtr:hasIlxId ILX:0381712 .
 
-DICOM:0008_1163 ilxtr:hasIlxId ilx:0381724 .
+DICOM:0008_1163 ilxtr:hasIlxId ILX:0381724 .
 
-DICOM:0008_1164 ilxtr:hasIlxId ilx:0381520 .
+DICOM:0008_1164 ilxtr:hasIlxId ILX:0381520 .
 
-DICOM:0008_1167 ilxtr:hasIlxId ilx:0381553 .
+DICOM:0008_1167 ilxtr:hasIlxId ILX:0381553 .
 
-DICOM:0008_1195 ilxtr:hasIlxId ilx:0111860 .
+DICOM:0008_1195 ilxtr:hasIlxId ILX:0111860 .
 
-DICOM:0008_1197 ilxtr:hasIlxId ilx:0104083 .
+DICOM:0008_1197 ilxtr:hasIlxId ILX:0104083 .
 
-DICOM:0008_1199 ilxtr:hasIlxId ilx:0109791 .
+DICOM:0008_1199 ilxtr:hasIlxId ILX:0109791 .
 
-DICOM:0008_1200 ilxtr:hasIlxId ilx:0111131 .
+DICOM:0008_1200 ilxtr:hasIlxId ILX:0111131 .
 
-DICOM:0008_1250 ilxtr:hasIlxId ilx:0109891 .
+DICOM:0008_1250 ilxtr:hasIlxId ILX:0109891 .
 
-DICOM:0008_2111 ilxtr:hasIlxId ilx:0103098 .
+DICOM:0008_2111 ilxtr:hasIlxId ILX:0103098 .
 
-DICOM:0008_2112 ilxtr:hasIlxId ilx:0110793 .
+DICOM:0008_2112 ilxtr:hasIlxId ILX:0110793 .
 
-DICOM:0008_2120 ilxtr:hasIlxId ilx:0111013 .
+DICOM:0008_2120 ilxtr:hasIlxId ILX:0111013 .
 
-DICOM:0008_2122 ilxtr:hasIlxId ilx:0111014 .
+DICOM:0008_2122 ilxtr:hasIlxId ILX:0111014 .
 
-DICOM:0008_2124 ilxtr:hasIlxId ilx:0107839 .
+DICOM:0008_2124 ilxtr:hasIlxId ILX:0107839 .
 
-DICOM:0008_2127 ilxtr:hasIlxId ilx:0112475 .
+DICOM:0008_2127 ilxtr:hasIlxId ILX:0112475 .
 
-DICOM:0008_2128 ilxtr:hasIlxId ilx:0112476 .
+DICOM:0008_2128 ilxtr:hasIlxId ILX:0112476 .
 
-DICOM:0008_2129 ilxtr:hasIlxId ilx:0107819 .
+DICOM:0008_2129 ilxtr:hasIlxId ILX:0107819 .
 
-DICOM:0008_2130 ilxtr:hasIlxId ilx:0103990 .
+DICOM:0008_2130 ilxtr:hasIlxId ILX:0103990 .
 
-DICOM:0008_2132 ilxtr:hasIlxId ilx:0103993 .
+DICOM:0008_2132 ilxtr:hasIlxId ILX:0103993 .
 
-DICOM:0008_2133 ilxtr:hasIlxId ilx:0381870 .
+DICOM:0008_2133 ilxtr:hasIlxId ILX:0381870 .
 
-DICOM:0008_2134 ilxtr:hasIlxId ilx:0381624 .
+DICOM:0008_2134 ilxtr:hasIlxId ILX:0381624 .
 
-DICOM:0008_2135 ilxtr:hasIlxId ilx:0382612 .
+DICOM:0008_2135 ilxtr:hasIlxId ILX:0382612 .
 
-DICOM:0008_2142 ilxtr:hasIlxId ilx:0381812 .
+DICOM:0008_2142 ilxtr:hasIlxId ILX:0381812 .
 
-DICOM:0008_2143 ilxtr:hasIlxId ilx:0382057 .
+DICOM:0008_2143 ilxtr:hasIlxId ILX:0382057 .
 
-DICOM:0008_2218 ilxtr:hasIlxId ilx:0100609 .
+DICOM:0008_2218 ilxtr:hasIlxId ILX:0100609 .
 
-DICOM:0008_2220 ilxtr:hasIlxId ilx:0100608 .
+DICOM:0008_2220 ilxtr:hasIlxId ILX:0100608 .
 
-DICOM:0008_2228 ilxtr:hasIlxId ilx:0109262 .
+DICOM:0008_2228 ilxtr:hasIlxId ILX:0109262 .
 
-DICOM:0008_2229 ilxtr:hasIlxId ilx:0100610 .
+DICOM:0008_2229 ilxtr:hasIlxId ILX:0100610 .
 
-DICOM:0008_2230 ilxtr:hasIlxId ilx:0109261 .
+DICOM:0008_2230 ilxtr:hasIlxId ILX:0109261 .
 
-DICOM:0008_2240 ilxtr:hasIlxId ilx:0111869 .
+DICOM:0008_2240 ilxtr:hasIlxId ILX:0111869 .
 
-DICOM:0008_2242 ilxtr:hasIlxId ilx:0111868 .
+DICOM:0008_2242 ilxtr:hasIlxId ILX:0111868 .
 
-DICOM:0008_2244 ilxtr:hasIlxId ilx:0111867 .
+DICOM:0008_2244 ilxtr:hasIlxId ILX:0111867 .
 
-DICOM:0008_2246 ilxtr:hasIlxId ilx:0111866 .
+DICOM:0008_2246 ilxtr:hasIlxId ILX:0111866 .
 
-DICOM:0008_3010 ilxtr:hasIlxId ilx:0382337 .
+DICOM:0008_3010 ilxtr:hasIlxId ILX:0382337 .
 
-DICOM:0008_3011 ilxtr:hasIlxId ilx:0381586 .
+DICOM:0008_3011 ilxtr:hasIlxId ILX:0381586 .
 
-DICOM:0008_3012 ilxtr:hasIlxId ilx:0381929 .
+DICOM:0008_3012 ilxtr:hasIlxId ILX:0381929 .
 
-DICOM:0008_9007 ilxtr:hasIlxId ilx:0104423 .
+DICOM:0008_9007 ilxtr:hasIlxId ILX:0104423 .
 
-DICOM:0008_9092 ilxtr:hasIlxId ilx:0109765 .
+DICOM:0008_9092 ilxtr:hasIlxId ILX:0109765 .
 
-DICOM:0008_9121 ilxtr:hasIlxId ilx:0109780 .
+DICOM:0008_9121 ilxtr:hasIlxId ILX:0109780 .
 
-DICOM:0008_9123 ilxtr:hasIlxId ilx:0102628 .
+DICOM:0008_9123 ilxtr:hasIlxId ILX:0102628 .
 
-DICOM:0008_9124 ilxtr:hasIlxId ilx:0382783 .
+DICOM:0008_9124 ilxtr:hasIlxId ILX:0382783 .
 
-DICOM:0008_9154 ilxtr:hasIlxId ilx:0110792 .
+DICOM:0008_9154 ilxtr:hasIlxId ILX:0110792 .
 
-DICOM:0008_9205 ilxtr:hasIlxId ilx:0383081 .
+DICOM:0008_9205 ilxtr:hasIlxId ILX:0383081 .
 
-DICOM:0008_9206 ilxtr:hasIlxId ilx:0112563 .
+DICOM:0008_9206 ilxtr:hasIlxId ILX:0112563 .
 
-DICOM:0008_9207 ilxtr:hasIlxId ilx:0112560 .
+DICOM:0008_9207 ilxtr:hasIlxId ILX:0112560 .
 
-DICOM:0008_9208 ilxtr:hasIlxId ilx:0102432 .
+DICOM:0008_9208 ilxtr:hasIlxId ILX:0102432 .
 
-DICOM:0008_9209 ilxtr:hasIlxId ilx:0100255 .
+DICOM:0008_9209 ilxtr:hasIlxId ILX:0100255 .
 
-DICOM:0008_9215 ilxtr:hasIlxId ilx:0103097 .
+DICOM:0008_9215 ilxtr:hasIlxId ILX:0103097 .
 
-DICOM:0008_9237 ilxtr:hasIlxId ilx:0109764 .
+DICOM:0008_9237 ilxtr:hasIlxId ILX:0109764 .
 
-DICOM:0008_9458 ilxtr:hasIlxId ilx:0381833 .
+DICOM:0008_9458 ilxtr:hasIlxId ILX:0381833 .
 
-DICOM:0008_9459 ilxtr:hasIlxId ilx:0382805 .
+DICOM:0008_9459 ilxtr:hasIlxId ILX:0382805 .
 
-DICOM:0008_9460 ilxtr:hasIlxId ilx:0382633 .
+DICOM:0008_9460 ilxtr:hasIlxId ILX:0382633 .
 
-DICOM:0010_0010 ilxtr:hasIlxId ilx:0108612 .
+DICOM:0010_0010 ilxtr:hasIlxId ILX:0108612 .
 
-DICOM:0010_0020 ilxtr:hasIlxId ilx:0108589 .
+DICOM:0010_0020 ilxtr:hasIlxId ILX:0108589 .
 
-DICOM:0010_0021 ilxtr:hasIlxId ilx:0105756 .
+DICOM:0010_0021 ilxtr:hasIlxId ILX:0105756 .
 
-DICOM:0010_21A0 ilxtr:hasIlxId ilx:0110695 .
+DICOM:0010_21A0 ilxtr:hasIlxId ILX:0110695 .
 
-DICOM:0010_21B0 ilxtr:hasIlxId ilx:0100311 .
+DICOM:0010_21B0 ilxtr:hasIlxId ILX:0100311 .
 
-DICOM:0010_21C0 ilxtr:hasIlxId ilx:0109211 .
+DICOM:0010_21C0 ilxtr:hasIlxId ILX:0109211 .
 
-DICOM:0010_21D0 ilxtr:hasIlxId ilx:0106030 .
+DICOM:0010_21D0 ilxtr:hasIlxId ILX:0106030 .
 
-DICOM:0010_21F0 ilxtr:hasIlxId ilx:0108615 .
+DICOM:0010_21F0 ilxtr:hasIlxId ILX:0108615 .
 
-DICOM:0010_0022 ilxtr:hasIlxId ilx:0381600 .
+DICOM:0010_0022 ilxtr:hasIlxId ILX:0381600 .
 
-DICOM:0010_0024 ilxtr:hasIlxId ilx:0382124 .
+DICOM:0010_0024 ilxtr:hasIlxId ILX:0382124 .
 
-DICOM:0010_0026 ilxtr:hasIlxId ilx:0382394 .
+DICOM:0010_0026 ilxtr:hasIlxId ILX:0382394 .
 
-DICOM:0010_0027 ilxtr:hasIlxId ilx:0382332 .
+DICOM:0010_0027 ilxtr:hasIlxId ILX:0382332 .
 
-DICOM:0010_0028 ilxtr:hasIlxId ilx:0381897 .
+DICOM:0010_0028 ilxtr:hasIlxId ILX:0381897 .
 
-DICOM:0010_0030 ilxtr:hasIlxId ilx:0108606 .
+DICOM:0010_0030 ilxtr:hasIlxId ILX:0108606 .
 
-DICOM:0010_0032 ilxtr:hasIlxId ilx:0108608 .
+DICOM:0010_0032 ilxtr:hasIlxId ILX:0108608 .
 
-DICOM:0010_0033 ilxtr:hasIlxId ilx:0382163 .
+DICOM:0010_0033 ilxtr:hasIlxId ILX:0382163 .
 
-DICOM:0010_0034 ilxtr:hasIlxId ilx:0382416 .
+DICOM:0010_0034 ilxtr:hasIlxId ILX:0382416 .
 
-DICOM:0010_0035 ilxtr:hasIlxId ilx:0382257 .
+DICOM:0010_0035 ilxtr:hasIlxId ILX:0382257 .
 
-DICOM:0010_0040 ilxtr:hasIlxId ilx:0108616 .
+DICOM:0010_0040 ilxtr:hasIlxId ILX:0108616 .
 
-DICOM:0010_0050 ilxtr:hasIlxId ilx:0108610 .
+DICOM:0010_0050 ilxtr:hasIlxId ILX:0108610 .
 
-DICOM:0010_0101 ilxtr:hasIlxId ilx:0108614 .
+DICOM:0010_0101 ilxtr:hasIlxId ILX:0108614 .
 
-DICOM:0010_0102 ilxtr:hasIlxId ilx:0108613 .
+DICOM:0010_0102 ilxtr:hasIlxId ILX:0108613 .
 
-DICOM:0010_0200 ilxtr:hasIlxId ilx:0381893 .
+DICOM:0010_0200 ilxtr:hasIlxId ILX:0381893 .
 
-DICOM:0010_0212 ilxtr:hasIlxId ilx:0382014 .
+DICOM:0010_0212 ilxtr:hasIlxId ILX:0382014 .
 
-DICOM:0010_0213 ilxtr:hasIlxId ilx:0382283 .
+DICOM:0010_0213 ilxtr:hasIlxId ILX:0382283 .
 
-DICOM:0010_0214 ilxtr:hasIlxId ilx:0381602 .
+DICOM:0010_0214 ilxtr:hasIlxId ILX:0381602 .
 
-DICOM:0010_0215 ilxtr:hasIlxId ilx:0382736 .
+DICOM:0010_0215 ilxtr:hasIlxId ILX:0382736 .
 
-DICOM:0010_0216 ilxtr:hasIlxId ilx:0382837 .
+DICOM:0010_0216 ilxtr:hasIlxId ILX:0382837 .
 
-DICOM:0010_0217 ilxtr:hasIlxId ilx:0382148 .
+DICOM:0010_0217 ilxtr:hasIlxId ILX:0382148 .
 
-DICOM:0010_0218 ilxtr:hasIlxId ilx:0381930 .
+DICOM:0010_0218 ilxtr:hasIlxId ILX:0381930 .
 
-DICOM:0010_0219 ilxtr:hasIlxId ilx:0382565 .
+DICOM:0010_0219 ilxtr:hasIlxId ILX:0382565 .
 
-DICOM:0010_0221 ilxtr:hasIlxId ilx:0381835 .
+DICOM:0010_0221 ilxtr:hasIlxId ILX:0381835 .
 
-DICOM:0010_0222 ilxtr:hasIlxId ilx:0382444 .
+DICOM:0010_0222 ilxtr:hasIlxId ILX:0382444 .
 
-DICOM:0010_0223 ilxtr:hasIlxId ilx:0382648 .
+DICOM:0010_0223 ilxtr:hasIlxId ILX:0382648 .
 
-DICOM:0010_0229 ilxtr:hasIlxId ilx:0382343 .
+DICOM:0010_0229 ilxtr:hasIlxId ILX:0382343 .
 
-DICOM:0010_1000 ilxtr:hasIlxId ilx:0108277 .
+DICOM:0010_1000 ilxtr:hasIlxId ILX:0108277 .
 
-DICOM:0010_1001 ilxtr:hasIlxId ilx:0108278 .
+DICOM:0010_1001 ilxtr:hasIlxId ILX:0108278 .
 
-DICOM:0010_1002 ilxtr:hasIlxId ilx:0383087 .
+DICOM:0010_1002 ilxtr:hasIlxId ILX:0383087 .
 
-DICOM:0010_1005 ilxtr:hasIlxId ilx:0108607 .
+DICOM:0010_1005 ilxtr:hasIlxId ILX:0108607 .
 
-DICOM:0010_1010 ilxtr:hasIlxId ilx:0108605 .
+DICOM:0010_1010 ilxtr:hasIlxId ILX:0108605 .
 
-DICOM:0010_1020 ilxtr:hasIlxId ilx:0108617 .
+DICOM:0010_1020 ilxtr:hasIlxId ILX:0108617 .
 
-DICOM:0010_1021 ilxtr:hasIlxId ilx:0382339 .
+DICOM:0010_1021 ilxtr:hasIlxId ILX:0382339 .
 
-DICOM:0010_1022 ilxtr:hasIlxId ilx:0381748 .
+DICOM:0010_1022 ilxtr:hasIlxId ILX:0381748 .
 
-DICOM:0010_1023 ilxtr:hasIlxId ilx:0382814 .
+DICOM:0010_1023 ilxtr:hasIlxId ILX:0382814 .
 
-DICOM:0010_1024 ilxtr:hasIlxId ilx:0381473 .
+DICOM:0010_1024 ilxtr:hasIlxId ILX:0381473 .
 
-DICOM:0010_1030 ilxtr:hasIlxId ilx:0108619 .
+DICOM:0010_1030 ilxtr:hasIlxId ILX:0108619 .
 
-DICOM:0010_1040 ilxtr:hasIlxId ilx:0108604 .
+DICOM:0010_1040 ilxtr:hasIlxId ILX:0108604 .
 
-DICOM:0010_1060 ilxtr:hasIlxId ilx:0108611 .
+DICOM:0010_1060 ilxtr:hasIlxId ILX:0108611 .
 
-DICOM:0010_1080 ilxtr:hasIlxId ilx:0106978 .
+DICOM:0010_1080 ilxtr:hasIlxId ILX:0106978 .
 
-DICOM:0010_1081 ilxtr:hasIlxId ilx:0101445 .
+DICOM:0010_1081 ilxtr:hasIlxId ILX:0101445 .
 
-DICOM:0010_1090 ilxtr:hasIlxId ilx:0106720 .
+DICOM:0010_1090 ilxtr:hasIlxId ILX:0106720 .
 
-DICOM:0010_1100 ilxtr:hasIlxId ilx:0382455 .
+DICOM:0010_1100 ilxtr:hasIlxId ILX:0382455 .
 
-DICOM:0010_2000 ilxtr:hasIlxId ilx:0106719 .
+DICOM:0010_2000 ilxtr:hasIlxId ILX:0106719 .
 
-DICOM:0010_2110 ilxtr:hasIlxId ilx:0102532 .
+DICOM:0010_2110 ilxtr:hasIlxId ILX:0102532 .
 
-DICOM:0010_2150 ilxtr:hasIlxId ilx:0102601 .
+DICOM:0010_2150 ilxtr:hasIlxId ILX:0102601 .
 
-DICOM:0010_2152 ilxtr:hasIlxId ilx:0109827 .
+DICOM:0010_2152 ilxtr:hasIlxId ILX:0109827 .
 
-DICOM:0010_2154 ilxtr:hasIlxId ilx:0108618 .
+DICOM:0010_2154 ilxtr:hasIlxId ILX:0108618 .
 
-DICOM:0010_2160 ilxtr:hasIlxId ilx:0103954 .
+DICOM:0010_2160 ilxtr:hasIlxId ILX:0103954 .
 
-DICOM:0010_2180 ilxtr:hasIlxId ilx:0107886 .
+DICOM:0010_2180 ilxtr:hasIlxId ILX:0107886 .
 
-DICOM:0010_2201 ilxtr:hasIlxId ilx:0381845 .
+DICOM:0010_2201 ilxtr:hasIlxId ILX:0381845 .
 
-DICOM:0010_2202 ilxtr:hasIlxId ilx:0382212 .
+DICOM:0010_2202 ilxtr:hasIlxId ILX:0382212 .
 
-DICOM:0010_2203 ilxtr:hasIlxId ilx:0381964 .
+DICOM:0010_2203 ilxtr:hasIlxId ILX:0381964 .
 
-DICOM:0010_2210 ilxtr:hasIlxId ilx:0381914 .
+DICOM:0010_2210 ilxtr:hasIlxId ILX:0381914 .
 
-DICOM:0010_2292 ilxtr:hasIlxId ilx:0382184 .
+DICOM:0010_2292 ilxtr:hasIlxId ILX:0382184 .
 
-DICOM:0010_2293 ilxtr:hasIlxId ilx:0382165 .
+DICOM:0010_2293 ilxtr:hasIlxId ILX:0382165 .
 
-DICOM:0010_2294 ilxtr:hasIlxId ilx:0381465 .
+DICOM:0010_2294 ilxtr:hasIlxId ILX:0381465 .
 
-DICOM:0010_2295 ilxtr:hasIlxId ilx:0381814 .
+DICOM:0010_2295 ilxtr:hasIlxId ILX:0381814 .
 
-DICOM:0010_2296 ilxtr:hasIlxId ilx:0382142 .
+DICOM:0010_2296 ilxtr:hasIlxId ILX:0382142 .
 
-DICOM:0010_2297 ilxtr:hasIlxId ilx:0383132 .
+DICOM:0010_2297 ilxtr:hasIlxId ILX:0383132 .
 
-DICOM:0010_2298 ilxtr:hasIlxId ilx:0382440 .
+DICOM:0010_2298 ilxtr:hasIlxId ILX:0382440 .
 
-DICOM:0010_2299 ilxtr:hasIlxId ilx:0383178 .
+DICOM:0010_2299 ilxtr:hasIlxId ILX:0383178 .
 
-DICOM:0010_4000 ilxtr:hasIlxId ilx:0108585 .
+DICOM:0010_4000 ilxtr:hasIlxId ILX:0108585 .
 
-DICOM:0012_0010 ilxtr:hasIlxId ilx:0382049 .
+DICOM:0012_0010 ilxtr:hasIlxId ILX:0382049 .
 
-DICOM:0012_0020 ilxtr:hasIlxId ilx:0382492 .
+DICOM:0012_0020 ilxtr:hasIlxId ILX:0382492 .
 
-DICOM:0012_0021 ilxtr:hasIlxId ilx:0381711 .
+DICOM:0012_0021 ilxtr:hasIlxId ILX:0381711 .
 
-DICOM:0012_0030 ilxtr:hasIlxId ilx:0382895 .
+DICOM:0012_0030 ilxtr:hasIlxId ILX:0382895 .
 
-DICOM:0012_0031 ilxtr:hasIlxId ilx:0381978 .
+DICOM:0012_0031 ilxtr:hasIlxId ILX:0381978 .
 
-DICOM:0012_0040 ilxtr:hasIlxId ilx:0381751 .
+DICOM:0012_0040 ilxtr:hasIlxId ILX:0381751 .
 
-DICOM:0012_0042 ilxtr:hasIlxId ilx:0382160 .
+DICOM:0012_0042 ilxtr:hasIlxId ILX:0382160 .
 
-DICOM:0012_0050 ilxtr:hasIlxId ilx:0381907 .
+DICOM:0012_0050 ilxtr:hasIlxId ILX:0381907 .
 
-DICOM:0012_0051 ilxtr:hasIlxId ilx:0382151 .
+DICOM:0012_0051 ilxtr:hasIlxId ILX:0382151 .
 
-DICOM:0012_0060 ilxtr:hasIlxId ilx:0382132 .
+DICOM:0012_0060 ilxtr:hasIlxId ILX:0382132 .
 
-DICOM:0012_0062 ilxtr:hasIlxId ilx:0382245 .
+DICOM:0012_0062 ilxtr:hasIlxId ILX:0382245 .
 
-DICOM:0012_0063 ilxtr:hasIlxId ilx:0383134 .
+DICOM:0012_0063 ilxtr:hasIlxId ILX:0383134 .
 
-DICOM:0012_0064 ilxtr:hasIlxId ilx:0382365 .
+DICOM:0012_0064 ilxtr:hasIlxId ILX:0382365 .
 
-DICOM:0012_0071 ilxtr:hasIlxId ilx:0382297 .
+DICOM:0012_0071 ilxtr:hasIlxId ILX:0382297 .
 
-DICOM:0012_0072 ilxtr:hasIlxId ilx:0381657 .
+DICOM:0012_0072 ilxtr:hasIlxId ILX:0381657 .
 
-DICOM:0012_0081 ilxtr:hasIlxId ilx:0382089 .
+DICOM:0012_0081 ilxtr:hasIlxId ILX:0382089 .
 
-DICOM:0012_0082 ilxtr:hasIlxId ilx:0381896 .
+DICOM:0012_0082 ilxtr:hasIlxId ILX:0381896 .
 
-DICOM:0012_0083 ilxtr:hasIlxId ilx:0382153 .
+DICOM:0012_0083 ilxtr:hasIlxId ILX:0382153 .
 
-DICOM:0012_0084 ilxtr:hasIlxId ilx:0382910 .
+DICOM:0012_0084 ilxtr:hasIlxId ILX:0382910 .
 
-DICOM:0012_0085 ilxtr:hasIlxId ilx:0381980 .
+DICOM:0012_0085 ilxtr:hasIlxId ILX:0381980 .
 
-DICOM:0012_0086 ilxtr:hasIlxId ilx:0381583 .
+DICOM:0012_0086 ilxtr:hasIlxId ILX:0381583 .
 
-DICOM:0012_0087 ilxtr:hasIlxId ilx:0382477 .
+DICOM:0012_0087 ilxtr:hasIlxId ILX:0382477 .
 
-DICOM:0018_002A ilxtr:hasIlxId ilx:0382566 .
+DICOM:0018_002A ilxtr:hasIlxId ILX:0382566 .
 
-DICOM:0018_003A ilxtr:hasIlxId ilx:0105631 .
+DICOM:0018_003A ilxtr:hasIlxId ILX:0105631 .
 
-DICOM:0018_0010 ilxtr:hasIlxId ilx:0382888 .
+DICOM:0018_0010 ilxtr:hasIlxId ILX:0382888 .
 
-DICOM:0018_11A0 ilxtr:hasIlxId ilx:0101376 .
+DICOM:0018_11A0 ilxtr:hasIlxId ILX:0101376 .
 
-DICOM:0018_11A2 ilxtr:hasIlxId ilx:0102442 .
+DICOM:0018_11A2 ilxtr:hasIlxId ILX:0102442 .
 
-DICOM:0018_11A4 ilxtr:hasIlxId ilx:0382116 .
+DICOM:0018_11A4 ilxtr:hasIlxId ILX:0382116 .
 
-DICOM:0018_0012 ilxtr:hasIlxId ilx:0381503 .
+DICOM:0018_0012 ilxtr:hasIlxId ILX:0381503 .
 
-DICOM:0018_0013 ilxtr:hasIlxId ilx:0382447 .
+DICOM:0018_0013 ilxtr:hasIlxId ILX:0382447 .
 
-DICOM:0018_0014 ilxtr:hasIlxId ilx:0381672 .
+DICOM:0018_0014 ilxtr:hasIlxId ILX:0381672 .
 
-DICOM:0018_0015 ilxtr:hasIlxId ilx:0101375 .
+DICOM:0018_0015 ilxtr:hasIlxId ILX:0101375 .
 
-DICOM:0018_0020 ilxtr:hasIlxId ilx:0110369 .
+DICOM:0018_0020 ilxtr:hasIlxId ILX:0110369 .
 
-DICOM:0018_0021 ilxtr:hasIlxId ilx:0110526 .
+DICOM:0018_0021 ilxtr:hasIlxId ILX:0110526 .
 
-DICOM:0018_0022 ilxtr:hasIlxId ilx:0383145 .
+DICOM:0018_0022 ilxtr:hasIlxId ILX:0383145 .
 
-DICOM:0018_0023 ilxtr:hasIlxId ilx:0107145 .
+DICOM:0018_0023 ilxtr:hasIlxId ILX:0107145 .
 
-DICOM:0018_0024 ilxtr:hasIlxId ilx:0110523 .
+DICOM:0018_0024 ilxtr:hasIlxId ILX:0110523 .
 
-DICOM:0018_0025 ilxtr:hasIlxId ilx:0100622 .
+DICOM:0018_0025 ilxtr:hasIlxId ILX:0100622 .
 
-DICOM:0018_0026 ilxtr:hasIlxId ilx:0105634 .
+DICOM:0018_0026 ilxtr:hasIlxId ILX:0105634 .
 
-DICOM:0018_0027 ilxtr:hasIlxId ilx:0105637 .
+DICOM:0018_0027 ilxtr:hasIlxId ILX:0105637 .
 
-DICOM:0018_0028 ilxtr:hasIlxId ilx:0105633 .
+DICOM:0018_0028 ilxtr:hasIlxId ILX:0105633 .
 
-DICOM:0018_0029 ilxtr:hasIlxId ilx:0105632 .
+DICOM:0018_0029 ilxtr:hasIlxId ILX:0105632 .
 
-DICOM:0018_0031 ilxtr:hasIlxId ilx:0109625 .
+DICOM:0018_0031 ilxtr:hasIlxId ILX:0109625 .
 
-DICOM:0018_0034 ilxtr:hasIlxId ilx:0105635 .
+DICOM:0018_0034 ilxtr:hasIlxId ILX:0105635 .
 
-DICOM:0018_0035 ilxtr:hasIlxId ilx:0105636 .
+DICOM:0018_0035 ilxtr:hasIlxId ILX:0105636 .
 
-DICOM:0018_0036 ilxtr:hasIlxId ilx:0105638 .
+DICOM:0018_0036 ilxtr:hasIlxId ILX:0105638 .
 
-DICOM:0018_0038 ilxtr:hasIlxId ilx:0105639 .
+DICOM:0018_0038 ilxtr:hasIlxId ILX:0105639 .
 
-DICOM:0018_0039 ilxtr:hasIlxId ilx:0111678 .
+DICOM:0018_0039 ilxtr:hasIlxId ILX:0111678 .
 
-DICOM:0018_0040 ilxtr:hasIlxId ilx:0382195 .
+DICOM:0018_0040 ilxtr:hasIlxId ILX:0382195 .
 
-DICOM:0018_0042 ilxtr:hasIlxId ilx:0382911 .
+DICOM:0018_0042 ilxtr:hasIlxId ILX:0382911 .
 
-DICOM:0018_0050 ilxtr:hasIlxId ilx:0110673 .
+DICOM:0018_0050 ilxtr:hasIlxId ILX:0110673 .
 
-DICOM:0018_0060 ilxtr:hasIlxId ilx:0105932 .
+DICOM:0018_0060 ilxtr:hasIlxId ILX:0105932 .
 
-DICOM:0018_0070 ilxtr:hasIlxId ilx:0102602 .
+DICOM:0018_0070 ilxtr:hasIlxId ILX:0102602 .
 
-DICOM:0018_0071 ilxtr:hasIlxId ilx:0100264 .
+DICOM:0018_0071 ilxtr:hasIlxId ILX:0100264 .
 
-DICOM:0018_0072 ilxtr:hasIlxId ilx:0382806 .
+DICOM:0018_0072 ilxtr:hasIlxId ILX:0382806 .
 
-DICOM:0018_0073 ilxtr:hasIlxId ilx:0100262 .
+DICOM:0018_0073 ilxtr:hasIlxId ILX:0100262 .
 
-DICOM:0018_0074 ilxtr:hasIlxId ilx:0100263 .
+DICOM:0018_0074 ilxtr:hasIlxId ILX:0100263 .
 
-DICOM:0018_0075 ilxtr:hasIlxId ilx:0383188 .
+DICOM:0018_0075 ilxtr:hasIlxId ILX:0383188 .
 
-DICOM:0018_0080 ilxtr:hasIlxId ilx:0109921 .
+DICOM:0018_0080 ilxtr:hasIlxId ILX:0109921 .
 
-DICOM:0018_0081 ilxtr:hasIlxId ilx:0103661 .
+DICOM:0018_0081 ilxtr:hasIlxId ILX:0103661 .
 
-DICOM:0018_0082 ilxtr:hasIlxId ilx:0105678 .
+DICOM:0018_0082 ilxtr:hasIlxId ILX:0105678 .
 
-DICOM:0018_0083 ilxtr:hasIlxId ilx:0107806 .
+DICOM:0018_0083 ilxtr:hasIlxId ILX:0107806 .
 
-DICOM:0018_0084 ilxtr:hasIlxId ilx:0105262 .
+DICOM:0018_0084 ilxtr:hasIlxId ILX:0105262 .
 
-DICOM:0018_0085 ilxtr:hasIlxId ilx:0105256 .
+DICOM:0018_0085 ilxtr:hasIlxId ILX:0105256 .
 
-DICOM:0018_0086 ilxtr:hasIlxId ilx:0103658 .
+DICOM:0018_0086 ilxtr:hasIlxId ILX:0103658 .
 
-DICOM:0018_0087 ilxtr:hasIlxId ilx:0106456 .
+DICOM:0018_0087 ilxtr:hasIlxId ILX:0106456 .
 
-DICOM:0018_0088 ilxtr:hasIlxId ilx:0110817 .
+DICOM:0018_0088 ilxtr:hasIlxId ILX:0110817 .
 
-DICOM:0018_0089 ilxtr:hasIlxId ilx:0107832 .
+DICOM:0018_0089 ilxtr:hasIlxId ILX:0107832 .
 
-DICOM:0018_0090 ilxtr:hasIlxId ilx:0382592 .
+DICOM:0018_0090 ilxtr:hasIlxId ILX:0382592 .
 
-DICOM:0018_0091 ilxtr:hasIlxId ilx:0103662 .
+DICOM:0018_0091 ilxtr:hasIlxId ILX:0103662 .
 
-DICOM:0018_0093 ilxtr:hasIlxId ilx:0108680 .
+DICOM:0018_0093 ilxtr:hasIlxId ILX:0108680 .
 
-DICOM:0018_0094 ilxtr:hasIlxId ilx:0108679 .
+DICOM:0018_0094 ilxtr:hasIlxId ILX:0108679 .
 
-DICOM:0018_0095 ilxtr:hasIlxId ilx:0108943 .
+DICOM:0018_0095 ilxtr:hasIlxId ILX:0108943 .
 
-DICOM:0018_100A ilxtr:hasIlxId ilx:0381510 .
+DICOM:0018_100A ilxtr:hasIlxId ILX:0381510 .
 
-DICOM:0018_101A ilxtr:hasIlxId ilx:0104895 .
+DICOM:0018_101A ilxtr:hasIlxId ILX:0104895 .
 
-DICOM:0018_101B ilxtr:hasIlxId ilx:0104893 .
+DICOM:0018_101B ilxtr:hasIlxId ILX:0104893 .
 
-DICOM:0018_106A ilxtr:hasIlxId ilx:0111419 .
+DICOM:0018_106A ilxtr:hasIlxId ILX:0111419 .
 
-DICOM:0018_106C ilxtr:hasIlxId ilx:0111417 .
+DICOM:0018_106C ilxtr:hasIlxId ILX:0111417 .
 
-DICOM:0018_106E ilxtr:hasIlxId ilx:0111970 .
+DICOM:0018_106E ilxtr:hasIlxId ILX:0111970 .
 
-DICOM:0018_113A ilxtr:hasIlxId ilx:0383183 .
+DICOM:0018_113A ilxtr:hasIlxId ILX:0383183 .
 
-DICOM:0018_115A ilxtr:hasIlxId ilx:0109613 .
+DICOM:0018_115A ilxtr:hasIlxId ILX:0109613 .
 
-DICOM:0018_115E ilxtr:hasIlxId ilx:0105229 .
+DICOM:0018_115E ilxtr:hasIlxId ILX:0105229 .
 
-DICOM:0018_601A ilxtr:hasIlxId ilx:0109825 .
+DICOM:0018_601A ilxtr:hasIlxId ILX:0109825 .
 
-DICOM:0018_601C ilxtr:hasIlxId ilx:0109822 .
+DICOM:0018_601C ilxtr:hasIlxId ILX:0109822 .
 
-DICOM:0018_601E ilxtr:hasIlxId ilx:0109823 .
+DICOM:0018_601E ilxtr:hasIlxId ILX:0109823 .
 
-DICOM:0018_602A ilxtr:hasIlxId ilx:0109733 .
+DICOM:0018_602A ilxtr:hasIlxId ILX:0109733 .
 
-DICOM:0018_602C ilxtr:hasIlxId ilx:0108854 .
+DICOM:0018_602C ilxtr:hasIlxId ILX:0108854 .
 
-DICOM:0018_602E ilxtr:hasIlxId ilx:0108855 .
+DICOM:0018_602E ilxtr:hasIlxId ILX:0108855 .
 
-DICOM:0018_603B ilxtr:hasIlxId ilx:0103407 .
+DICOM:0018_603B ilxtr:hasIlxId ILX:0103407 .
 
-DICOM:0018_603D ilxtr:hasIlxId ilx:0111782 .
+DICOM:0018_603D ilxtr:hasIlxId ILX:0111782 .
 
-DICOM:0018_603F ilxtr:hasIlxId ilx:0111784 .
+DICOM:0018_603F ilxtr:hasIlxId ILX:0111784 .
 
-DICOM:0018_604A ilxtr:hasIlxId ilx:0108949 .
+DICOM:0018_604A ilxtr:hasIlxId ILX:0108949 .
 
-DICOM:0018_604C ilxtr:hasIlxId ilx:0108947 .
+DICOM:0018_604C ilxtr:hasIlxId ILX:0108947 .
 
-DICOM:0018_604E ilxtr:hasIlxId ilx:0108944 .
+DICOM:0018_604E ilxtr:hasIlxId ILX:0108944 .
 
-DICOM:0018_605A ilxtr:hasIlxId ilx:0111460 .
+DICOM:0018_605A ilxtr:hasIlxId ILX:0111460 .
 
-DICOM:0018_700A ilxtr:hasIlxId ilx:0103145 .
+DICOM:0018_700A ilxtr:hasIlxId ILX:0103145 .
 
-DICOM:0018_700C ilxtr:hasIlxId ilx:0102842 .
+DICOM:0018_700C ilxtr:hasIlxId ILX:0102842 .
 
-DICOM:0018_700E ilxtr:hasIlxId ilx:0111751 .
+DICOM:0018_700E ilxtr:hasIlxId ILX:0111751 .
 
-DICOM:0018_701A ilxtr:hasIlxId ilx:0103138 .
+DICOM:0018_701A ilxtr:hasIlxId ILX:0103138 .
 
-DICOM:0018_702A ilxtr:hasIlxId ilx:0103148 .
+DICOM:0018_702A ilxtr:hasIlxId ILX:0103148 .
 
-DICOM:0018_702B ilxtr:hasIlxId ilx:0103149 .
+DICOM:0018_702B ilxtr:hasIlxId ILX:0103149 .
 
-DICOM:0018_704C ilxtr:hasIlxId ilx:0104788 .
+DICOM:0018_704C ilxtr:hasIlxId ILX:0104788 .
 
-DICOM:0018_925A ilxtr:hasIlxId ilx:0382821 .
+DICOM:0018_925A ilxtr:hasIlxId ILX:0382821 .
 
-DICOM:0018_925B ilxtr:hasIlxId ilx:0382435 .
+DICOM:0018_925B ilxtr:hasIlxId ILX:0382435 .
 
-DICOM:0018_925C ilxtr:hasIlxId ilx:0381985 .
+DICOM:0018_925C ilxtr:hasIlxId ILX:0381985 .
 
-DICOM:0018_925D ilxtr:hasIlxId ilx:0382358 .
+DICOM:0018_925D ilxtr:hasIlxId ILX:0382358 .
 
-DICOM:0018_925E ilxtr:hasIlxId ilx:0381849 .
+DICOM:0018_925E ilxtr:hasIlxId ILX:0381849 .
 
-DICOM:0018_925F ilxtr:hasIlxId ilx:0382000 .
+DICOM:0018_925F ilxtr:hasIlxId ILX:0382000 .
 
-DICOM:0018_980C ilxtr:hasIlxId ilx:0382363 .
+DICOM:0018_980C ilxtr:hasIlxId ILX:0382363 .
 
-DICOM:0018_980D ilxtr:hasIlxId ilx:0381895 .
+DICOM:0018_980D ilxtr:hasIlxId ILX:0381895 .
 
-DICOM:0018_980E ilxtr:hasIlxId ilx:0383168 .
+DICOM:0018_980E ilxtr:hasIlxId ILX:0383168 .
 
-DICOM:0018_980F ilxtr:hasIlxId ilx:0382260 .
+DICOM:0018_980F ilxtr:hasIlxId ILX:0382260 .
 
-DICOM:0018_990A ilxtr:hasIlxId ilx:0381828 .
+DICOM:0018_990A ilxtr:hasIlxId ILX:0381828 .
 
-DICOM:0018_990B ilxtr:hasIlxId ilx:0382899 .
+DICOM:0018_990B ilxtr:hasIlxId ILX:0382899 .
 
-DICOM:0018_990C ilxtr:hasIlxId ilx:0382374 .
+DICOM:0018_990C ilxtr:hasIlxId ILX:0382374 .
 
-DICOM:0018_990D ilxtr:hasIlxId ilx:0382968 .
+DICOM:0018_990D ilxtr:hasIlxId ILX:0382968 .
 
-DICOM:0018_990E ilxtr:hasIlxId ilx:0382355 .
+DICOM:0018_990E ilxtr:hasIlxId ILX:0382355 .
 
-DICOM:0018_990F ilxtr:hasIlxId ilx:0382464 .
+DICOM:0018_990F ilxtr:hasIlxId ILX:0382464 .
 
-DICOM:0018_991A ilxtr:hasIlxId ilx:0382915 .
+DICOM:0018_991A ilxtr:hasIlxId ILX:0382915 .
 
-DICOM:0018_991B ilxtr:hasIlxId ilx:0382403 .
+DICOM:0018_991B ilxtr:hasIlxId ILX:0382403 .
 
-DICOM:0018_991C ilxtr:hasIlxId ilx:0382964 .
+DICOM:0018_991C ilxtr:hasIlxId ILX:0382964 .
 
-DICOM:0018_991D ilxtr:hasIlxId ilx:0381654 .
+DICOM:0018_991D ilxtr:hasIlxId ILX:0381654 .
 
-DICOM:0018_991E ilxtr:hasIlxId ilx:0382699 .
+DICOM:0018_991E ilxtr:hasIlxId ILX:0382699 .
 
-DICOM:0018_991F ilxtr:hasIlxId ilx:0381921 .
+DICOM:0018_991F ilxtr:hasIlxId ILX:0381921 .
 
-DICOM:0018_993A ilxtr:hasIlxId ilx:0381460 .
+DICOM:0018_993A ilxtr:hasIlxId ILX:0381460 .
 
-DICOM:0018_993B ilxtr:hasIlxId ilx:0381763 .
+DICOM:0018_993B ilxtr:hasIlxId ILX:0381763 .
 
-DICOM:0018_993C ilxtr:hasIlxId ilx:0381639 .
+DICOM:0018_993C ilxtr:hasIlxId ILX:0381639 .
 
-DICOM:0018_993D ilxtr:hasIlxId ilx:0383151 .
+DICOM:0018_993D ilxtr:hasIlxId ILX:0383151 .
 
-DICOM:0018_993E ilxtr:hasIlxId ilx:0382099 .
+DICOM:0018_993E ilxtr:hasIlxId ILX:0382099 .
 
-DICOM:0018_1000 ilxtr:hasIlxId ilx:0103170 .
+DICOM:0018_1000 ilxtr:hasIlxId ILX:0103170 .
 
-DICOM:0018_1002 ilxtr:hasIlxId ilx:0382596 .
+DICOM:0018_1002 ilxtr:hasIlxId ILX:0382596 .
 
-DICOM:0018_1003 ilxtr:hasIlxId ilx:0382114 .
+DICOM:0018_1003 ilxtr:hasIlxId ILX:0382114 .
 
-DICOM:0018_1004 ilxtr:hasIlxId ilx:0381687 .
+DICOM:0018_1004 ilxtr:hasIlxId ILX:0381687 .
 
-DICOM:0018_1005 ilxtr:hasIlxId ilx:0381504 .
+DICOM:0018_1005 ilxtr:hasIlxId ILX:0381504 .
 
-DICOM:0018_1006 ilxtr:hasIlxId ilx:0382931 .
+DICOM:0018_1006 ilxtr:hasIlxId ILX:0382931 .
 
-DICOM:0018_1007 ilxtr:hasIlxId ilx:0383052 .
+DICOM:0018_1007 ilxtr:hasIlxId ILX:0383052 .
 
-DICOM:0018_1008 ilxtr:hasIlxId ilx:0382948 .
+DICOM:0018_1008 ilxtr:hasIlxId ILX:0382948 .
 
-DICOM:0018_1009 ilxtr:hasIlxId ilx:0382553 .
+DICOM:0018_1009 ilxtr:hasIlxId ILX:0382553 .
 
-DICOM:0018_1010 ilxtr:hasIlxId ilx:0110434 .
+DICOM:0018_1010 ilxtr:hasIlxId ILX:0110434 .
 
-DICOM:0018_1011 ilxtr:hasIlxId ilx:0104892 .
+DICOM:0018_1011 ilxtr:hasIlxId ILX:0104892 .
 
-DICOM:0018_1012 ilxtr:hasIlxId ilx:0102843 .
+DICOM:0018_1012 ilxtr:hasIlxId ILX:0102843 .
 
-DICOM:0018_1014 ilxtr:hasIlxId ilx:0111752 .
+DICOM:0018_1014 ilxtr:hasIlxId ILX:0111752 .
 
-DICOM:0018_1016 ilxtr:hasIlxId ilx:0110435 .
+DICOM:0018_1016 ilxtr:hasIlxId ILX:0110435 .
 
-DICOM:0018_1017 ilxtr:hasIlxId ilx:0104894 .
+DICOM:0018_1017 ilxtr:hasIlxId ILX:0104894 .
 
-DICOM:0018_1018 ilxtr:hasIlxId ilx:0110436 .
+DICOM:0018_1018 ilxtr:hasIlxId ILX:0110436 .
 
-DICOM:0018_1019 ilxtr:hasIlxId ilx:0110437 .
+DICOM:0018_1019 ilxtr:hasIlxId ILX:0110437 .
 
-DICOM:0018_1020 ilxtr:hasIlxId ilx:0110725 .
+DICOM:0018_1020 ilxtr:hasIlxId ILX:0110725 .
 
-DICOM:0018_1022 ilxtr:hasIlxId ilx:0112471 .
+DICOM:0018_1022 ilxtr:hasIlxId ILX:0112471 .
 
-DICOM:0018_1023 ilxtr:hasIlxId ilx:0103255 .
+DICOM:0018_1023 ilxtr:hasIlxId ILX:0103255 .
 
-DICOM:0018_1030 ilxtr:hasIlxId ilx:0109467 .
+DICOM:0018_1030 ilxtr:hasIlxId ILX:0109467 .
 
-DICOM:0018_1040 ilxtr:hasIlxId ilx:0381684 .
+DICOM:0018_1040 ilxtr:hasIlxId ILX:0381684 .
 
-DICOM:0018_1041 ilxtr:hasIlxId ilx:0382180 .
+DICOM:0018_1041 ilxtr:hasIlxId ILX:0382180 .
 
-DICOM:0018_1042 ilxtr:hasIlxId ilx:0381731 .
+DICOM:0018_1042 ilxtr:hasIlxId ILX:0381731 .
 
-DICOM:0018_1043 ilxtr:hasIlxId ilx:0382836 .
+DICOM:0018_1043 ilxtr:hasIlxId ILX:0382836 .
 
-DICOM:0018_1044 ilxtr:hasIlxId ilx:0382495 .
+DICOM:0018_1044 ilxtr:hasIlxId ILX:0382495 .
 
-DICOM:0018_1045 ilxtr:hasIlxId ilx:0111433 .
+DICOM:0018_1045 ilxtr:hasIlxId ILX:0111433 .
 
-DICOM:0018_1046 ilxtr:hasIlxId ilx:0381571 .
+DICOM:0018_1046 ilxtr:hasIlxId ILX:0381571 .
 
-DICOM:0018_1047 ilxtr:hasIlxId ilx:0381950 .
+DICOM:0018_1047 ilxtr:hasIlxId ILX:0381950 .
 
-DICOM:0018_1048 ilxtr:hasIlxId ilx:0382992 .
+DICOM:0018_1048 ilxtr:hasIlxId ILX:0382992 .
 
-DICOM:0018_1049 ilxtr:hasIlxId ilx:0382800 .
+DICOM:0018_1049 ilxtr:hasIlxId ILX:0382800 .
 
-DICOM:0018_1050 ilxtr:hasIlxId ilx:0110831 .
+DICOM:0018_1050 ilxtr:hasIlxId ILX:0110831 .
 
-DICOM:0018_1060 ilxtr:hasIlxId ilx:0111972 .
+DICOM:0018_1060 ilxtr:hasIlxId ILX:0111972 .
 
-DICOM:0018_1061 ilxtr:hasIlxId ilx:0111971 .
+DICOM:0018_1061 ilxtr:hasIlxId ILX:0111971 .
 
-DICOM:0018_1062 ilxtr:hasIlxId ilx:0107646 .
+DICOM:0018_1062 ilxtr:hasIlxId ILX:0107646 .
 
-DICOM:0018_1063 ilxtr:hasIlxId ilx:0382785 .
+DICOM:0018_1063 ilxtr:hasIlxId ILX:0382785 .
 
-DICOM:0018_1064 ilxtr:hasIlxId ilx:0104425 .
+DICOM:0018_1064 ilxtr:hasIlxId ILX:0104425 .
 
-DICOM:0018_1065 ilxtr:hasIlxId ilx:0382617 .
+DICOM:0018_1065 ilxtr:hasIlxId ILX:0382617 .
 
-DICOM:0018_1066 ilxtr:hasIlxId ilx:0383090 .
+DICOM:0018_1066 ilxtr:hasIlxId ILX:0383090 .
 
-DICOM:0018_1067 ilxtr:hasIlxId ilx:0382542 .
+DICOM:0018_1067 ilxtr:hasIlxId ILX:0382542 .
 
-DICOM:0018_1068 ilxtr:hasIlxId ilx:0107195 .
+DICOM:0018_1068 ilxtr:hasIlxId ILX:0107195 .
 
-DICOM:0018_1069 ilxtr:hasIlxId ilx:0111973 .
+DICOM:0018_1069 ilxtr:hasIlxId ILX:0111973 .
 
-DICOM:0018_1070 ilxtr:hasIlxId ilx:0109628 .
+DICOM:0018_1070 ilxtr:hasIlxId ILX:0109628 .
 
-DICOM:0018_1071 ilxtr:hasIlxId ilx:0109632 .
+DICOM:0018_1071 ilxtr:hasIlxId ILX:0109632 .
 
-DICOM:0018_1072 ilxtr:hasIlxId ilx:0109630 .
+DICOM:0018_1072 ilxtr:hasIlxId ILX:0109630 .
 
-DICOM:0018_1073 ilxtr:hasIlxId ilx:0109631 .
+DICOM:0018_1073 ilxtr:hasIlxId ILX:0109631 .
 
-DICOM:0018_1074 ilxtr:hasIlxId ilx:0109624 .
+DICOM:0018_1074 ilxtr:hasIlxId ILX:0109624 .
 
-DICOM:0018_1075 ilxtr:hasIlxId ilx:0109622 .
+DICOM:0018_1075 ilxtr:hasIlxId ILX:0109622 .
 
-DICOM:0018_1076 ilxtr:hasIlxId ilx:0109623 .
+DICOM:0018_1076 ilxtr:hasIlxId ILX:0109623 .
 
-DICOM:0018_1077 ilxtr:hasIlxId ilx:0109629 .
+DICOM:0018_1077 ilxtr:hasIlxId ILX:0109629 .
 
-DICOM:0018_1079 ilxtr:hasIlxId ilx:0382522 .
+DICOM:0018_1079 ilxtr:hasIlxId ILX:0382522 .
 
-DICOM:0018_1080 ilxtr:hasIlxId ilx:0101158 .
+DICOM:0018_1080 ilxtr:hasIlxId ILX:0101158 .
 
-DICOM:0018_1081 ilxtr:hasIlxId ilx:0382860 .
+DICOM:0018_1081 ilxtr:hasIlxId ILX:0382860 .
 
-DICOM:0018_1082 ilxtr:hasIlxId ilx:0382230 .
+DICOM:0018_1082 ilxtr:hasIlxId ILX:0382230 .
 
-DICOM:0018_1083 ilxtr:hasIlxId ilx:0382990 .
+DICOM:0018_1083 ilxtr:hasIlxId ILX:0382990 .
 
-DICOM:0018_1084 ilxtr:hasIlxId ilx:0381702 .
+DICOM:0018_1084 ilxtr:hasIlxId ILX:0381702 .
 
-DICOM:0018_1085 ilxtr:hasIlxId ilx:0109551 .
+DICOM:0018_1085 ilxtr:hasIlxId ILX:0109551 .
 
-DICOM:0018_1086 ilxtr:hasIlxId ilx:0110662 .
+DICOM:0018_1086 ilxtr:hasIlxId ILX:0110662 .
 
-DICOM:0018_1088 ilxtr:hasIlxId ilx:0104915 .
+DICOM:0018_1088 ilxtr:hasIlxId ILX:0104915 .
 
-DICOM:0018_1090 ilxtr:hasIlxId ilx:0101665 .
+DICOM:0018_1090 ilxtr:hasIlxId ILX:0101665 .
 
-DICOM:0018_1094 ilxtr:hasIlxId ilx:0111975 .
+DICOM:0018_1094 ilxtr:hasIlxId ILX:0111975 .
 
-DICOM:0018_1100 ilxtr:hasIlxId ilx:0109703 .
+DICOM:0018_1100 ilxtr:hasIlxId ILX:0109703 .
 
-DICOM:0018_1110 ilxtr:hasIlxId ilx:0103339 .
+DICOM:0018_1110 ilxtr:hasIlxId ILX:0103339 .
 
-DICOM:0018_1111 ilxtr:hasIlxId ilx:0382691 .
+DICOM:0018_1111 ilxtr:hasIlxId ILX:0382691 .
 
-DICOM:0018_1114 ilxtr:hasIlxId ilx:0103934 .
+DICOM:0018_1114 ilxtr:hasIlxId ILX:0103934 .
 
-DICOM:0018_1120 ilxtr:hasIlxId ilx:0382540 .
+DICOM:0018_1120 ilxtr:hasIlxId ILX:0382540 .
 
-DICOM:0018_1121 ilxtr:hasIlxId ilx:0382721 .
+DICOM:0018_1121 ilxtr:hasIlxId ILX:0382721 .
 
-DICOM:0018_1130 ilxtr:hasIlxId ilx:0382234 .
+DICOM:0018_1130 ilxtr:hasIlxId ILX:0382234 .
 
-DICOM:0018_1131 ilxtr:hasIlxId ilx:0111477 .
+DICOM:0018_1131 ilxtr:hasIlxId ILX:0111477 .
 
-DICOM:0018_1134 ilxtr:hasIlxId ilx:0111459 .
+DICOM:0018_1134 ilxtr:hasIlxId ILX:0111459 .
 
-DICOM:0018_1135 ilxtr:hasIlxId ilx:0111479 .
+DICOM:0018_1135 ilxtr:hasIlxId ILX:0111479 .
 
-DICOM:0018_1136 ilxtr:hasIlxId ilx:0111457 .
+DICOM:0018_1136 ilxtr:hasIlxId ILX:0111457 .
 
-DICOM:0018_1137 ilxtr:hasIlxId ilx:0111458 .
+DICOM:0018_1137 ilxtr:hasIlxId ILX:0111458 .
 
-DICOM:0018_1138 ilxtr:hasIlxId ilx:0111456 .
+DICOM:0018_1138 ilxtr:hasIlxId ILX:0111456 .
 
-DICOM:0018_1140 ilxtr:hasIlxId ilx:0383020 .
+DICOM:0018_1140 ilxtr:hasIlxId ILX:0383020 .
 
-DICOM:0018_1142 ilxtr:hasIlxId ilx:0109601 .
+DICOM:0018_1142 ilxtr:hasIlxId ILX:0109601 .
 
-DICOM:0018_1143 ilxtr:hasIlxId ilx:0110363 .
+DICOM:0018_1143 ilxtr:hasIlxId ILX:0110363 .
 
-DICOM:0018_1144 ilxtr:hasIlxId ilx:0100628 .
+DICOM:0018_1144 ilxtr:hasIlxId ILX:0100628 .
 
-DICOM:0018_1145 ilxtr:hasIlxId ilx:0101880 .
+DICOM:0018_1145 ilxtr:hasIlxId ILX:0101880 .
 
-DICOM:0018_1147 ilxtr:hasIlxId ilx:0104213 .
+DICOM:0018_1147 ilxtr:hasIlxId ILX:0104213 .
 
-DICOM:0018_1149 ilxtr:hasIlxId ilx:0104209 .
+DICOM:0018_1149 ilxtr:hasIlxId ILX:0104209 .
 
-DICOM:0018_1150 ilxtr:hasIlxId ilx:0104031 .
+DICOM:0018_1150 ilxtr:hasIlxId ILX:0104031 .
 
-DICOM:0018_1151 ilxtr:hasIlxId ilx:0382976 .
+DICOM:0018_1151 ilxtr:hasIlxId ILX:0382976 .
 
-DICOM:0018_1152 ilxtr:hasIlxId ilx:0381739 .
+DICOM:0018_1152 ilxtr:hasIlxId ILX:0381739 .
 
-DICOM:0018_1153 ilxtr:hasIlxId ilx:0382317 .
+DICOM:0018_1153 ilxtr:hasIlxId ILX:0382317 .
 
-DICOM:0018_1154 ilxtr:hasIlxId ilx:0101029 .
+DICOM:0018_1154 ilxtr:hasIlxId ILX:0101029 .
 
-DICOM:0018_1155 ilxtr:hasIlxId ilx:0109616 .
+DICOM:0018_1155 ilxtr:hasIlxId ILX:0109616 .
 
-DICOM:0018_1156 ilxtr:hasIlxId ilx:0109714 .
+DICOM:0018_1156 ilxtr:hasIlxId ILX:0109714 .
 
-DICOM:0018_1160 ilxtr:hasIlxId ilx:0104240 .
+DICOM:0018_1160 ilxtr:hasIlxId ILX:0104240 .
 
-DICOM:0018_1161 ilxtr:hasIlxId ilx:0112119 .
+DICOM:0018_1161 ilxtr:hasIlxId ILX:0112119 .
 
-DICOM:0018_1162 ilxtr:hasIlxId ilx:0105535 .
+DICOM:0018_1162 ilxtr:hasIlxId ILX:0105535 .
 
-DICOM:0018_1164 ilxtr:hasIlxId ilx:0381954 .
+DICOM:0018_1164 ilxtr:hasIlxId ILX:0381954 .
 
-DICOM:0018_1166 ilxtr:hasIlxId ilx:0104782 .
+DICOM:0018_1166 ilxtr:hasIlxId ILX:0104782 .
 
-DICOM:0018_1170 ilxtr:hasIlxId ilx:0382080 .
+DICOM:0018_1170 ilxtr:hasIlxId ILX:0382080 .
 
-DICOM:0018_1180 ilxtr:hasIlxId ilx:0382467 .
+DICOM:0018_1180 ilxtr:hasIlxId ILX:0382467 .
 
-DICOM:0018_1181 ilxtr:hasIlxId ilx:0102379 .
+DICOM:0018_1181 ilxtr:hasIlxId ILX:0102379 .
 
-DICOM:0018_1182 ilxtr:hasIlxId ilx:0104340 .
+DICOM:0018_1182 ilxtr:hasIlxId ILX:0104340 .
 
-DICOM:0018_1183 ilxtr:hasIlxId ilx:0112675 .
+DICOM:0018_1183 ilxtr:hasIlxId ILX:0112675 .
 
-DICOM:0018_1184 ilxtr:hasIlxId ilx:0112697 .
+DICOM:0018_1184 ilxtr:hasIlxId ILX:0112697 .
 
-DICOM:0018_1190 ilxtr:hasIlxId ilx:0382241 .
+DICOM:0018_1190 ilxtr:hasIlxId ILX:0382241 .
 
-DICOM:0018_1191 ilxtr:hasIlxId ilx:0100651 .
+DICOM:0018_1191 ilxtr:hasIlxId ILX:0100651 .
 
-DICOM:0018_1200 ilxtr:hasIlxId ilx:0102841 .
+DICOM:0018_1200 ilxtr:hasIlxId ILX:0102841 .
 
-DICOM:0018_1201 ilxtr:hasIlxId ilx:0111750 .
+DICOM:0018_1201 ilxtr:hasIlxId ILX:0111750 .
 
-DICOM:0018_1210 ilxtr:hasIlxId ilx:0381798 .
+DICOM:0018_1210 ilxtr:hasIlxId ILX:0381798 .
 
-DICOM:0018_1242 ilxtr:hasIlxId ilx:0381928 .
+DICOM:0018_1242 ilxtr:hasIlxId ILX:0381928 .
 
-DICOM:0018_1243 ilxtr:hasIlxId ilx:0102598 .
+DICOM:0018_1243 ilxtr:hasIlxId ILX:0102598 .
 
-DICOM:0018_1244 ilxtr:hasIlxId ilx:0382841 .
+DICOM:0018_1244 ilxtr:hasIlxId ILX:0382841 .
 
-DICOM:0018_1250 ilxtr:hasIlxId ilx:0109686 .
+DICOM:0018_1250 ilxtr:hasIlxId ILX:0109686 .
 
-DICOM:0018_1251 ilxtr:hasIlxId ilx:0111892 .
+DICOM:0018_1251 ilxtr:hasIlxId ILX:0111892 .
 
-DICOM:0018_1260 ilxtr:hasIlxId ilx:0383039 .
+DICOM:0018_1260 ilxtr:hasIlxId ILX:0383039 .
 
-DICOM:0018_1261 ilxtr:hasIlxId ilx:0382989 .
+DICOM:0018_1261 ilxtr:hasIlxId ILX:0382989 .
 
-DICOM:0018_1271 ilxtr:hasIlxId ilx:0382984 .
+DICOM:0018_1271 ilxtr:hasIlxId ILX:0382984 .
 
-DICOM:0018_1272 ilxtr:hasIlxId ilx:0381842 .
+DICOM:0018_1272 ilxtr:hasIlxId ILX:0381842 .
 
-DICOM:0018_1300 ilxtr:hasIlxId ilx:0110365 .
+DICOM:0018_1300 ilxtr:hasIlxId ILX:0110365 .
 
-DICOM:0018_1301 ilxtr:hasIlxId ilx:0112634 .
+DICOM:0018_1301 ilxtr:hasIlxId ILX:0112634 .
 
-DICOM:0018_1302 ilxtr:hasIlxId ilx:0110364 .
+DICOM:0018_1302 ilxtr:hasIlxId ILX:0110364 .
 
-DICOM:0018_1310 ilxtr:hasIlxId ilx:0100260 .
+DICOM:0018_1310 ilxtr:hasIlxId ILX:0100260 .
 
-DICOM:0018_1312 ilxtr:hasIlxId ilx:0105312 .
+DICOM:0018_1312 ilxtr:hasIlxId ILX:0105312 .
 
-DICOM:0018_1314 ilxtr:hasIlxId ilx:0104285 .
+DICOM:0018_1314 ilxtr:hasIlxId ILX:0104285 .
 
-DICOM:0018_1315 ilxtr:hasIlxId ilx:0112256 .
+DICOM:0018_1315 ilxtr:hasIlxId ILX:0112256 .
 
-DICOM:0018_1316 ilxtr:hasIlxId ilx:0110339 .
+DICOM:0018_1316 ilxtr:hasIlxId ILX:0110339 .
 
-DICOM:0018_1318 ilxtr:hasIlxId ilx:0381825 .
+DICOM:0018_1318 ilxtr:hasIlxId ILX:0381825 .
 
-DICOM:0018_1320 ilxtr:hasIlxId ilx:0381879 .
+DICOM:0018_1320 ilxtr:hasIlxId ILX:0381879 .
 
-DICOM:0018_1400 ilxtr:hasIlxId ilx:0381663 .
+DICOM:0018_1400 ilxtr:hasIlxId ILX:0381663 .
 
-DICOM:0018_1401 ilxtr:hasIlxId ilx:0382096 .
+DICOM:0018_1401 ilxtr:hasIlxId ILX:0382096 .
 
-DICOM:0018_1402 ilxtr:hasIlxId ilx:0383110 .
+DICOM:0018_1402 ilxtr:hasIlxId ILX:0383110 .
 
-DICOM:0018_1403 ilxtr:hasIlxId ilx:0382735 .
+DICOM:0018_1403 ilxtr:hasIlxId ILX:0382735 .
 
-DICOM:0018_1404 ilxtr:hasIlxId ilx:0382196 .
+DICOM:0018_1404 ilxtr:hasIlxId ILX:0382196 .
 
-DICOM:0018_1405 ilxtr:hasIlxId ilx:0382886 .
+DICOM:0018_1405 ilxtr:hasIlxId ILX:0382886 .
 
-DICOM:0018_1411 ilxtr:hasIlxId ilx:0382673 .
+DICOM:0018_1411 ilxtr:hasIlxId ILX:0382673 .
 
-DICOM:0018_1412 ilxtr:hasIlxId ilx:0382680 .
+DICOM:0018_1412 ilxtr:hasIlxId ILX:0382680 .
 
-DICOM:0018_1413 ilxtr:hasIlxId ilx:0382690 .
+DICOM:0018_1413 ilxtr:hasIlxId ILX:0382690 .
 
-DICOM:0018_1450 ilxtr:hasIlxId ilx:0102391 .
+DICOM:0018_1450 ilxtr:hasIlxId ILX:0102391 .
 
-DICOM:0018_1460 ilxtr:hasIlxId ilx:0111805 .
+DICOM:0018_1460 ilxtr:hasIlxId ILX:0111805 .
 
-DICOM:0018_1470 ilxtr:hasIlxId ilx:0111803 .
+DICOM:0018_1470 ilxtr:hasIlxId ILX:0111803 .
 
-DICOM:0018_1480 ilxtr:hasIlxId ilx:0111806 .
+DICOM:0018_1480 ilxtr:hasIlxId ILX:0111806 .
 
-DICOM:0018_1490 ilxtr:hasIlxId ilx:0111807 .
+DICOM:0018_1490 ilxtr:hasIlxId ILX:0111807 .
 
-DICOM:0018_1491 ilxtr:hasIlxId ilx:0111804 .
+DICOM:0018_1491 ilxtr:hasIlxId ILX:0111804 .
 
-DICOM:0018_1495 ilxtr:hasIlxId ilx:0107847 .
+DICOM:0018_1495 ilxtr:hasIlxId ILX:0107847 .
 
-DICOM:0018_1500 ilxtr:hasIlxId ilx:0109052 .
+DICOM:0018_1500 ilxtr:hasIlxId ILX:0109052 .
 
-DICOM:0018_1508 ilxtr:hasIlxId ilx:0109057 .
+DICOM:0018_1508 ilxtr:hasIlxId ILX:0109057 .
 
-DICOM:0018_1510 ilxtr:hasIlxId ilx:0109053 .
+DICOM:0018_1510 ilxtr:hasIlxId ILX:0109053 .
 
-DICOM:0018_1511 ilxtr:hasIlxId ilx:0109055 .
+DICOM:0018_1511 ilxtr:hasIlxId ILX:0109055 .
 
-DICOM:0018_1520 ilxtr:hasIlxId ilx:0109054 .
+DICOM:0018_1520 ilxtr:hasIlxId ILX:0109054 .
 
-DICOM:0018_1521 ilxtr:hasIlxId ilx:0109056 .
+DICOM:0018_1521 ilxtr:hasIlxId ILX:0109056 .
 
-DICOM:0018_1530 ilxtr:hasIlxId ilx:0103151 .
+DICOM:0018_1530 ilxtr:hasIlxId ILX:0103151 .
 
-DICOM:0018_1531 ilxtr:hasIlxId ilx:0103153 .
+DICOM:0018_1531 ilxtr:hasIlxId ILX:0103153 .
 
-DICOM:0018_1600 ilxtr:hasIlxId ilx:0382997 .
+DICOM:0018_1600 ilxtr:hasIlxId ILX:0382997 .
 
-DICOM:0018_1602 ilxtr:hasIlxId ilx:0382708 .
+DICOM:0018_1602 ilxtr:hasIlxId ILX:0382708 .
 
-DICOM:0018_1604 ilxtr:hasIlxId ilx:0382745 .
+DICOM:0018_1604 ilxtr:hasIlxId ILX:0382745 .
 
-DICOM:0018_1606 ilxtr:hasIlxId ilx:0382331 .
+DICOM:0018_1606 ilxtr:hasIlxId ILX:0382331 .
 
-DICOM:0018_1608 ilxtr:hasIlxId ilx:0382487 .
+DICOM:0018_1608 ilxtr:hasIlxId ILX:0382487 .
 
-DICOM:0018_1610 ilxtr:hasIlxId ilx:0383007 .
+DICOM:0018_1610 ilxtr:hasIlxId ILX:0383007 .
 
-DICOM:0018_1612 ilxtr:hasIlxId ilx:0383171 .
+DICOM:0018_1612 ilxtr:hasIlxId ILX:0383171 .
 
-DICOM:0018_1620 ilxtr:hasIlxId ilx:0382927 .
+DICOM:0018_1620 ilxtr:hasIlxId ILX:0382927 .
 
-DICOM:0018_1622 ilxtr:hasIlxId ilx:0383054 .
+DICOM:0018_1622 ilxtr:hasIlxId ILX:0383054 .
 
-DICOM:0018_1623 ilxtr:hasIlxId ilx:0382390 .
+DICOM:0018_1623 ilxtr:hasIlxId ILX:0382390 .
 
-DICOM:0018_1624 ilxtr:hasIlxId ilx:0381708 .
+DICOM:0018_1624 ilxtr:hasIlxId ILX:0381708 .
 
-DICOM:0018_1700 ilxtr:hasIlxId ilx:0102378 .
+DICOM:0018_1700 ilxtr:hasIlxId ILX:0102378 .
 
-DICOM:0018_1702 ilxtr:hasIlxId ilx:0102375 .
+DICOM:0018_1702 ilxtr:hasIlxId ILX:0102375 .
 
-DICOM:0018_1704 ilxtr:hasIlxId ilx:0102377 .
+DICOM:0018_1704 ilxtr:hasIlxId ILX:0102377 .
 
-DICOM:0018_1706 ilxtr:hasIlxId ilx:0102380 .
+DICOM:0018_1706 ilxtr:hasIlxId ILX:0102380 .
 
-DICOM:0018_1708 ilxtr:hasIlxId ilx:0102376 .
+DICOM:0018_1708 ilxtr:hasIlxId ILX:0102376 .
 
-DICOM:0018_1710 ilxtr:hasIlxId ilx:0101879 .
+DICOM:0018_1710 ilxtr:hasIlxId ILX:0101879 .
 
-DICOM:0018_1712 ilxtr:hasIlxId ilx:0109634 .
+DICOM:0018_1712 ilxtr:hasIlxId ILX:0109634 .
 
-DICOM:0018_1720 ilxtr:hasIlxId ilx:0112426 .
+DICOM:0018_1720 ilxtr:hasIlxId ILX:0112426 .
 
-DICOM:0018_1800 ilxtr:hasIlxId ilx:0100267 .
+DICOM:0018_1800 ilxtr:hasIlxId ILX:0100267 .
 
-DICOM:0018_1801 ilxtr:hasIlxId ilx:0111758 .
+DICOM:0018_1801 ilxtr:hasIlxId ILX:0111758 .
 
-DICOM:0018_1802 ilxtr:hasIlxId ilx:0111747 .
+DICOM:0018_1802 ilxtr:hasIlxId ILX:0111747 .
 
-DICOM:0018_1803 ilxtr:hasIlxId ilx:0107709 .
+DICOM:0018_1803 ilxtr:hasIlxId ILX:0107709 .
 
-DICOM:0018_2001 ilxtr:hasIlxId ilx:0108360 .
+DICOM:0018_2001 ilxtr:hasIlxId ILX:0108360 .
 
-DICOM:0018_2002 ilxtr:hasIlxId ilx:0104409 .
+DICOM:0018_2002 ilxtr:hasIlxId ILX:0104409 .
 
-DICOM:0018_2003 ilxtr:hasIlxId ilx:0104419 .
+DICOM:0018_2003 ilxtr:hasIlxId ILX:0104419 .
 
-DICOM:0018_2004 ilxtr:hasIlxId ilx:0104422 .
+DICOM:0018_2004 ilxtr:hasIlxId ILX:0104422 .
 
-DICOM:0018_2005 ilxtr:hasIlxId ilx:0110669 .
+DICOM:0018_2005 ilxtr:hasIlxId ILX:0110669 .
 
-DICOM:0018_2006 ilxtr:hasIlxId ilx:0103325 .
+DICOM:0018_2006 ilxtr:hasIlxId ILX:0103325 .
 
-DICOM:0018_2010 ilxtr:hasIlxId ilx:0107648 .
+DICOM:0018_2010 ilxtr:hasIlxId ILX:0107648 .
 
-DICOM:0018_2020 ilxtr:hasIlxId ilx:0103258 .
+DICOM:0018_2020 ilxtr:hasIlxId ILX:0103258 .
 
-DICOM:0018_2030 ilxtr:hasIlxId ilx:0110232 .
+DICOM:0018_2030 ilxtr:hasIlxId ILX:0110232 .
 
-DICOM:0018_2041 ilxtr:hasIlxId ilx:0382930 .
+DICOM:0018_2041 ilxtr:hasIlxId ILX:0382930 .
 
-DICOM:0018_2042 ilxtr:hasIlxId ilx:0382055 .
+DICOM:0018_2042 ilxtr:hasIlxId ILX:0382055 .
 
-DICOM:0018_2043 ilxtr:hasIlxId ilx:0382276 .
+DICOM:0018_2043 ilxtr:hasIlxId ILX:0382276 .
 
-DICOM:0018_2044 ilxtr:hasIlxId ilx:0382064 .
+DICOM:0018_2044 ilxtr:hasIlxId ILX:0382064 .
 
-DICOM:0018_2045 ilxtr:hasIlxId ilx:0381876 .
+DICOM:0018_2045 ilxtr:hasIlxId ILX:0381876 .
 
-DICOM:0018_2046 ilxtr:hasIlxId ilx:0382287 .
+DICOM:0018_2046 ilxtr:hasIlxId ILX:0382287 .
 
-DICOM:0018_3100 ilxtr:hasIlxId ilx:0105764 .
+DICOM:0018_3100 ilxtr:hasIlxId ILX:0105764 .
 
-DICOM:0018_3101 ilxtr:hasIlxId ilx:0105766 .
+DICOM:0018_3101 ilxtr:hasIlxId ILX:0105766 .
 
-DICOM:0018_3102 ilxtr:hasIlxId ilx:0105765 .
+DICOM:0018_3102 ilxtr:hasIlxId ILX:0105765 .
 
-DICOM:0018_3103 ilxtr:hasIlxId ilx:0105767 .
+DICOM:0018_3103 ilxtr:hasIlxId ILX:0105767 .
 
-DICOM:0018_3104 ilxtr:hasIlxId ilx:0105768 .
+DICOM:0018_3104 ilxtr:hasIlxId ILX:0105768 .
 
-DICOM:0018_3105 ilxtr:hasIlxId ilx:0106186 .
+DICOM:0018_3105 ilxtr:hasIlxId ILX:0106186 .
 
-DICOM:0018_5000 ilxtr:hasIlxId ilx:0108286 .
+DICOM:0018_5000 ilxtr:hasIlxId ILX:0108286 .
 
-DICOM:0018_5010 ilxtr:hasIlxId ilx:0111865 .
+DICOM:0018_5010 ilxtr:hasIlxId ILX:0111865 .
 
-DICOM:0018_5012 ilxtr:hasIlxId ilx:0104341 .
+DICOM:0018_5012 ilxtr:hasIlxId ILX:0104341 .
 
-DICOM:0018_5020 ilxtr:hasIlxId ilx:0109386 .
+DICOM:0018_5020 ilxtr:hasIlxId ILX:0109386 .
 
-DICOM:0018_5022 ilxtr:hasIlxId ilx:0106604 .
+DICOM:0018_5022 ilxtr:hasIlxId ILX:0106604 .
 
-DICOM:0018_5024 ilxtr:hasIlxId ilx:0101388 .
+DICOM:0018_5024 ilxtr:hasIlxId ILX:0101388 .
 
-DICOM:0018_5026 ilxtr:hasIlxId ilx:0102611 .
+DICOM:0018_5026 ilxtr:hasIlxId ILX:0102611 .
 
-DICOM:0018_5027 ilxtr:hasIlxId ilx:0110715 .
+DICOM:0018_5027 ilxtr:hasIlxId ILX:0110715 .
 
-DICOM:0018_5028 ilxtr:hasIlxId ilx:0110716 .
+DICOM:0018_5028 ilxtr:hasIlxId ILX:0110716 .
 
-DICOM:0018_5029 ilxtr:hasIlxId ilx:0110717 .
+DICOM:0018_5029 ilxtr:hasIlxId ILX:0110717 .
 
-DICOM:0018_5050 ilxtr:hasIlxId ilx:0103096 .
+DICOM:0018_5050 ilxtr:hasIlxId ILX:0103096 .
 
-DICOM:0018_5100 ilxtr:hasIlxId ilx:0108593 .
+DICOM:0018_5100 ilxtr:hasIlxId ILX:0108593 .
 
-DICOM:0018_5101 ilxtr:hasIlxId ilx:0381963 .
+DICOM:0018_5101 ilxtr:hasIlxId ILX:0381963 .
 
-DICOM:0018_5104 ilxtr:hasIlxId ilx:0109410 .
+DICOM:0018_5104 ilxtr:hasIlxId ILX:0109410 .
 
-DICOM:0018_5210 ilxtr:hasIlxId ilx:0105253 .
+DICOM:0018_5210 ilxtr:hasIlxId ILX:0105253 .
 
-DICOM:0018_5212 ilxtr:hasIlxId ilx:0105254 .
+DICOM:0018_5212 ilxtr:hasIlxId ILX:0105254 .
 
-DICOM:0018_6000 ilxtr:hasIlxId ilx:0383028 .
+DICOM:0018_6000 ilxtr:hasIlxId ILX:0383028 .
 
-DICOM:0018_6011 ilxtr:hasIlxId ilx:0110524 .
+DICOM:0018_6011 ilxtr:hasIlxId ILX:0110524 .
 
-DICOM:0018_6012 ilxtr:hasIlxId ilx:0109828 .
+DICOM:0018_6012 ilxtr:hasIlxId ILX:0109828 .
 
-DICOM:0018_6014 ilxtr:hasIlxId ilx:0109820 .
+DICOM:0018_6014 ilxtr:hasIlxId ILX:0109820 .
 
-DICOM:0018_6016 ilxtr:hasIlxId ilx:0109821 .
+DICOM:0018_6016 ilxtr:hasIlxId ILX:0109821 .
 
-DICOM:0018_6018 ilxtr:hasIlxId ilx:0109824 .
+DICOM:0018_6018 ilxtr:hasIlxId ILX:0109824 .
 
-DICOM:0018_6020 ilxtr:hasIlxId ilx:0109734 .
+DICOM:0018_6020 ilxtr:hasIlxId ILX:0109734 .
 
-DICOM:0018_6022 ilxtr:hasIlxId ilx:0109735 .
+DICOM:0018_6022 ilxtr:hasIlxId ILX:0109735 .
 
-DICOM:0018_6024 ilxtr:hasIlxId ilx:0108860 .
+DICOM:0018_6024 ilxtr:hasIlxId ILX:0108860 .
 
-DICOM:0018_6026 ilxtr:hasIlxId ilx:0108861 .
+DICOM:0018_6026 ilxtr:hasIlxId ILX:0108861 .
 
-DICOM:0018_6028 ilxtr:hasIlxId ilx:0109732 .
+DICOM:0018_6028 ilxtr:hasIlxId ILX:0109732 .
 
-DICOM:0018_6030 ilxtr:hasIlxId ilx:0111858 .
+DICOM:0018_6030 ilxtr:hasIlxId ILX:0111858 .
 
-DICOM:0018_6031 ilxtr:hasIlxId ilx:0111870 .
+DICOM:0018_6031 ilxtr:hasIlxId ILX:0111870 .
 
-DICOM:0018_6032 ilxtr:hasIlxId ilx:0109513 .
+DICOM:0018_6032 ilxtr:hasIlxId ILX:0109513 .
 
-DICOM:0018_6034 ilxtr:hasIlxId ilx:0103405 .
+DICOM:0018_6034 ilxtr:hasIlxId ILX:0103405 .
 
-DICOM:0018_6036 ilxtr:hasIlxId ilx:0111035 .
+DICOM:0018_6036 ilxtr:hasIlxId ILX:0111035 .
 
-DICOM:0018_6039 ilxtr:hasIlxId ilx:0103406 .
+DICOM:0018_6039 ilxtr:hasIlxId ILX:0103406 .
 
-DICOM:0018_6041 ilxtr:hasIlxId ilx:0111783 .
+DICOM:0018_6041 ilxtr:hasIlxId ILX:0111783 .
 
-DICOM:0018_6043 ilxtr:hasIlxId ilx:0111785 .
+DICOM:0018_6043 ilxtr:hasIlxId ILX:0111785 .
 
-DICOM:0018_6044 ilxtr:hasIlxId ilx:0108946 .
+DICOM:0018_6044 ilxtr:hasIlxId ILX:0108946 .
 
-DICOM:0018_6046 ilxtr:hasIlxId ilx:0108945 .
+DICOM:0018_6046 ilxtr:hasIlxId ILX:0108945 .
 
-DICOM:0018_6048 ilxtr:hasIlxId ilx:0108948 .
+DICOM:0018_6048 ilxtr:hasIlxId ILX:0108948 .
 
-DICOM:0018_6050 ilxtr:hasIlxId ilx:0107842 .
+DICOM:0018_6050 ilxtr:hasIlxId ILX:0107842 .
 
-DICOM:0018_6052 ilxtr:hasIlxId ilx:0111462 .
+DICOM:0018_6052 ilxtr:hasIlxId ILX:0111462 .
 
-DICOM:0018_6054 ilxtr:hasIlxId ilx:0111463 .
+DICOM:0018_6054 ilxtr:hasIlxId ILX:0111463 .
 
-DICOM:0018_6056 ilxtr:hasIlxId ilx:0107843 .
+DICOM:0018_6056 ilxtr:hasIlxId ILX:0107843 .
 
-DICOM:0018_6058 ilxtr:hasIlxId ilx:0111461 .
+DICOM:0018_6058 ilxtr:hasIlxId ILX:0111461 .
 
-DICOM:0018_6060 ilxtr:hasIlxId ilx:0109589 .
+DICOM:0018_6060 ilxtr:hasIlxId ILX:0109589 .
 
-DICOM:0018_7000 ilxtr:hasIlxId ilx:0103139 .
+DICOM:0018_7000 ilxtr:hasIlxId ILX:0103139 .
 
-DICOM:0018_7001 ilxtr:hasIlxId ilx:0103154 .
+DICOM:0018_7001 ilxtr:hasIlxId ILX:0103154 .
 
-DICOM:0018_7004 ilxtr:hasIlxId ilx:0103156 .
+DICOM:0018_7004 ilxtr:hasIlxId ILX:0103156 .
 
-DICOM:0018_7005 ilxtr:hasIlxId ilx:0103140 .
+DICOM:0018_7005 ilxtr:hasIlxId ILX:0103140 .
 
-DICOM:0018_7006 ilxtr:hasIlxId ilx:0103141 .
+DICOM:0018_7006 ilxtr:hasIlxId ILX:0103141 .
 
-DICOM:0018_7008 ilxtr:hasIlxId ilx:0103150 .
+DICOM:0018_7008 ilxtr:hasIlxId ILX:0103150 .
 
-DICOM:0018_7010 ilxtr:hasIlxId ilx:0104032 .
+DICOM:0018_7010 ilxtr:hasIlxId ILX:0104032 .
 
-DICOM:0018_7011 ilxtr:hasIlxId ilx:0104033 .
+DICOM:0018_7011 ilxtr:hasIlxId ILX:0104033 .
 
-DICOM:0018_7012 ilxtr:hasIlxId ilx:0103155 .
+DICOM:0018_7012 ilxtr:hasIlxId ILX:0103155 .
 
-DICOM:0018_7014 ilxtr:hasIlxId ilx:0103137 .
+DICOM:0018_7014 ilxtr:hasIlxId ILX:0103137 .
 
-DICOM:0018_7016 ilxtr:hasIlxId ilx:0103133 .
+DICOM:0018_7016 ilxtr:hasIlxId ILX:0103133 .
 
-DICOM:0018_7020 ilxtr:hasIlxId ilx:0103142 .
+DICOM:0018_7020 ilxtr:hasIlxId ILX:0103142 .
 
-DICOM:0018_7022 ilxtr:hasIlxId ilx:0103144 .
+DICOM:0018_7022 ilxtr:hasIlxId ILX:0103144 .
 
-DICOM:0018_7024 ilxtr:hasIlxId ilx:0103136 .
+DICOM:0018_7024 ilxtr:hasIlxId ILX:0103136 .
 
-DICOM:0018_7026 ilxtr:hasIlxId ilx:0103134 .
+DICOM:0018_7026 ilxtr:hasIlxId ILX:0103134 .
 
-DICOM:0018_7028 ilxtr:hasIlxId ilx:0103135 .
+DICOM:0018_7028 ilxtr:hasIlxId ILX:0103135 .
 
-DICOM:0018_7030 ilxtr:hasIlxId ilx:0104211 .
+DICOM:0018_7030 ilxtr:hasIlxId ILX:0104211 .
 
-DICOM:0018_7032 ilxtr:hasIlxId ilx:0104212 .
+DICOM:0018_7032 ilxtr:hasIlxId ILX:0104212 .
 
-DICOM:0018_7034 ilxtr:hasIlxId ilx:0104210 .
+DICOM:0018_7034 ilxtr:hasIlxId ILX:0104210 .
 
-DICOM:0018_7036 ilxtr:hasIlxId ilx:0382656 .
+DICOM:0018_7036 ilxtr:hasIlxId ILX:0382656 .
 
-DICOM:0018_7038 ilxtr:hasIlxId ilx:0383133 .
+DICOM:0018_7038 ilxtr:hasIlxId ILX:0383133 .
 
-DICOM:0018_7040 ilxtr:hasIlxId ilx:0104783 .
+DICOM:0018_7040 ilxtr:hasIlxId ILX:0104783 .
 
-DICOM:0018_7041 ilxtr:hasIlxId ilx:0104792 .
+DICOM:0018_7041 ilxtr:hasIlxId ILX:0104792 .
 
-DICOM:0018_7042 ilxtr:hasIlxId ilx:0104793 .
+DICOM:0018_7042 ilxtr:hasIlxId ILX:0104793 .
 
-DICOM:0018_7044 ilxtr:hasIlxId ilx:0104791 .
+DICOM:0018_7044 ilxtr:hasIlxId ILX:0104791 .
 
-DICOM:0018_7046 ilxtr:hasIlxId ilx:0104784 .
+DICOM:0018_7046 ilxtr:hasIlxId ILX:0104784 .
 
-DICOM:0018_7048 ilxtr:hasIlxId ilx:0104790 .
+DICOM:0018_7048 ilxtr:hasIlxId ILX:0104790 .
 
-DICOM:0018_7050 ilxtr:hasIlxId ilx:0104235 .
+DICOM:0018_7050 ilxtr:hasIlxId ILX:0104235 .
 
-DICOM:0018_7052 ilxtr:hasIlxId ilx:0104239 .
+DICOM:0018_7052 ilxtr:hasIlxId ILX:0104239 .
 
-DICOM:0018_7054 ilxtr:hasIlxId ilx:0383176 .
+DICOM:0018_7054 ilxtr:hasIlxId ILX:0383176 .
 
-DICOM:0018_7056 ilxtr:hasIlxId ilx:0381617 .
+DICOM:0018_7056 ilxtr:hasIlxId ILX:0381617 .
 
-DICOM:0018_7058 ilxtr:hasIlxId ilx:0381719 .
+DICOM:0018_7058 ilxtr:hasIlxId ILX:0381719 .
 
-DICOM:0018_7060 ilxtr:hasIlxId ilx:0104025 .
+DICOM:0018_7060 ilxtr:hasIlxId ILX:0104025 .
 
-DICOM:0018_7062 ilxtr:hasIlxId ilx:0104026 .
+DICOM:0018_7062 ilxtr:hasIlxId ILX:0104026 .
 
-DICOM:0018_7064 ilxtr:hasIlxId ilx:0104029 .
+DICOM:0018_7064 ilxtr:hasIlxId ILX:0104029 .
 
-DICOM:0018_7065 ilxtr:hasIlxId ilx:0108842 .
+DICOM:0018_7065 ilxtr:hasIlxId ILX:0108842 .
 
-DICOM:0018_8150 ilxtr:hasIlxId ilx:0383180 .
+DICOM:0018_8150 ilxtr:hasIlxId ILX:0383180 .
 
-DICOM:0018_8151 ilxtr:hasIlxId ilx:0112685 .
+DICOM:0018_8151 ilxtr:hasIlxId ILX:0112685 .
 
-DICOM:0018_9004 ilxtr:hasIlxId ilx:0102510 .
+DICOM:0018_9004 ilxtr:hasIlxId ILX:0102510 .
 
-DICOM:0018_9005 ilxtr:hasIlxId ilx:0109515 .
+DICOM:0018_9005 ilxtr:hasIlxId ILX:0109515 .
 
-DICOM:0018_9006 ilxtr:hasIlxId ilx:0107150 .
+DICOM:0018_9006 ilxtr:hasIlxId ILX:0107150 .
 
-DICOM:0018_9008 ilxtr:hasIlxId ilx:0103660 .
+DICOM:0018_9008 ilxtr:hasIlxId ILX:0103660 .
 
-DICOM:0018_9009 ilxtr:hasIlxId ilx:0105677 .
+DICOM:0018_9009 ilxtr:hasIlxId ILX:0105677 .
 
-DICOM:0018_9010 ilxtr:hasIlxId ilx:0104290 .
+DICOM:0018_9010 ilxtr:hasIlxId ILX:0104290 .
 
-DICOM:0018_9011 ilxtr:hasIlxId ilx:0107191 .
+DICOM:0018_9011 ilxtr:hasIlxId ILX:0107191 .
 
-DICOM:0018_9012 ilxtr:hasIlxId ilx:0107179 .
+DICOM:0018_9012 ilxtr:hasIlxId ILX:0107179 .
 
-DICOM:0018_9014 ilxtr:hasIlxId ilx:0108786 .
+DICOM:0018_9014 ilxtr:hasIlxId ILX:0108786 .
 
-DICOM:0018_9015 ilxtr:hasIlxId ilx:0111749 .
+DICOM:0018_9015 ilxtr:hasIlxId ILX:0111749 .
 
-DICOM:0018_9016 ilxtr:hasIlxId ilx:0110989 .
+DICOM:0018_9016 ilxtr:hasIlxId ILX:0110989 .
 
-DICOM:0018_9017 ilxtr:hasIlxId ilx:0111033 .
+DICOM:0018_9017 ilxtr:hasIlxId ILX:0111033 .
 
-DICOM:0018_9018 ilxtr:hasIlxId ilx:0103659 .
+DICOM:0018_9018 ilxtr:hasIlxId ILX:0103659 .
 
-DICOM:0018_9019 ilxtr:hasIlxId ilx:0111504 .
+DICOM:0018_9019 ilxtr:hasIlxId ILX:0111504 .
 
-DICOM:0018_9020 ilxtr:hasIlxId ilx:0106467 .
+DICOM:0018_9020 ilxtr:hasIlxId ILX:0106467 .
 
-DICOM:0018_9021 ilxtr:hasIlxId ilx:0111445 .
+DICOM:0018_9021 ilxtr:hasIlxId ILX:0111445 .
 
-DICOM:0018_9022 ilxtr:hasIlxId ilx:0101358 .
+DICOM:0018_9022 ilxtr:hasIlxId ILX:0101358 .
 
-DICOM:0018_9024 ilxtr:hasIlxId ilx:0110354 .
+DICOM:0018_9024 ilxtr:hasIlxId ILX:0110354 .
 
-DICOM:0018_9025 ilxtr:hasIlxId ilx:0110876 .
+DICOM:0018_9025 ilxtr:hasIlxId ILX:0110876 .
 
-DICOM:0018_9026 ilxtr:hasIlxId ilx:0110875 .
+DICOM:0018_9026 ilxtr:hasIlxId ILX:0110875 .
 
-DICOM:0018_9027 ilxtr:hasIlxId ilx:0110829 .
+DICOM:0018_9027 ilxtr:hasIlxId ILX:0110829 .
 
-DICOM:0018_9028 ilxtr:hasIlxId ilx:0111509 .
+DICOM:0018_9028 ilxtr:hasIlxId ILX:0111509 .
 
-DICOM:0018_9029 ilxtr:hasIlxId ilx:0108308 .
+DICOM:0018_9029 ilxtr:hasIlxId ILX:0108308 .
 
-DICOM:0018_9030 ilxtr:hasIlxId ilx:0111506 .
+DICOM:0018_9030 ilxtr:hasIlxId ILX:0111506 .
 
-DICOM:0018_9032 ilxtr:hasIlxId ilx:0104609 .
+DICOM:0018_9032 ilxtr:hasIlxId ILX:0104609 .
 
-DICOM:0018_9033 ilxtr:hasIlxId ilx:0110459 .
+DICOM:0018_9033 ilxtr:hasIlxId ILX:0110459 .
 
-DICOM:0018_9034 ilxtr:hasIlxId ilx:0109715 .
+DICOM:0018_9034 ilxtr:hasIlxId ILX:0109715 .
 
-DICOM:0018_9035 ilxtr:hasIlxId ilx:0111508 .
+DICOM:0018_9035 ilxtr:hasIlxId ILX:0111508 .
 
-DICOM:0018_9036 ilxtr:hasIlxId ilx:0108549 .
+DICOM:0018_9036 ilxtr:hasIlxId ILX:0108549 .
 
-DICOM:0018_9037 ilxtr:hasIlxId ilx:0382405 .
+DICOM:0018_9037 ilxtr:hasIlxId ILX:0382405 .
 
-DICOM:0018_9041 ilxtr:hasIlxId ilx:0109685 .
+DICOM:0018_9041 ilxtr:hasIlxId ILX:0109685 .
 
-DICOM:0018_9042 ilxtr:hasIlxId ilx:0107153 .
+DICOM:0018_9042 ilxtr:hasIlxId ILX:0107153 .
 
-DICOM:0018_9043 ilxtr:hasIlxId ilx:0383186 .
+DICOM:0018_9043 ilxtr:hasIlxId ILX:0383186 .
 
-DICOM:0018_9044 ilxtr:hasIlxId ilx:0109571 .
+DICOM:0018_9044 ilxtr:hasIlxId ILX:0109571 .
 
-DICOM:0018_9045 ilxtr:hasIlxId ilx:0107174 .
+DICOM:0018_9045 ilxtr:hasIlxId ILX:0107174 .
 
-DICOM:0018_9046 ilxtr:hasIlxId ilx:0107173 .
+DICOM:0018_9046 ilxtr:hasIlxId ILX:0107173 .
 
-DICOM:0018_9047 ilxtr:hasIlxId ilx:0107175 .
+DICOM:0018_9047 ilxtr:hasIlxId ILX:0107175 .
 
-DICOM:0018_9048 ilxtr:hasIlxId ilx:0107176 .
+DICOM:0018_9048 ilxtr:hasIlxId ILX:0107176 .
 
-DICOM:0018_9049 ilxtr:hasIlxId ilx:0107158 .
+DICOM:0018_9049 ilxtr:hasIlxId ILX:0107158 .
 
-DICOM:0018_9050 ilxtr:hasIlxId ilx:0111891 .
+DICOM:0018_9050 ilxtr:hasIlxId ILX:0111891 .
 
-DICOM:0018_9051 ilxtr:hasIlxId ilx:0111893 .
+DICOM:0018_9051 ilxtr:hasIlxId ILX:0111893 .
 
-DICOM:0018_9052 ilxtr:hasIlxId ilx:0110874 .
+DICOM:0018_9052 ilxtr:hasIlxId ILX:0110874 .
 
-DICOM:0018_9053 ilxtr:hasIlxId ilx:0102060 .
+DICOM:0018_9053 ilxtr:hasIlxId ILX:0102060 .
 
-DICOM:0018_9054 ilxtr:hasIlxId ilx:0112562 .
+DICOM:0018_9054 ilxtr:hasIlxId ILX:0112562 .
 
-DICOM:0018_9058 ilxtr:hasIlxId ilx:0107142 .
+DICOM:0018_9058 ilxtr:hasIlxId ILX:0107142 .
 
-DICOM:0018_9059 ilxtr:hasIlxId ilx:0102855 .
+DICOM:0018_9059 ilxtr:hasIlxId ILX:0102855 .
 
-DICOM:0018_9060 ilxtr:hasIlxId ilx:0102854 .
+DICOM:0018_9060 ilxtr:hasIlxId ILX:0102854 .
 
-DICOM:0018_9061 ilxtr:hasIlxId ilx:0102857 .
+DICOM:0018_9061 ilxtr:hasIlxId ILX:0102857 .
 
-DICOM:0018_9062 ilxtr:hasIlxId ilx:0102858 .
+DICOM:0018_9062 ilxtr:hasIlxId ILX:0102858 .
 
-DICOM:0018_9063 ilxtr:hasIlxId ilx:0102856 .
+DICOM:0018_9063 ilxtr:hasIlxId ILX:0102856 .
 
-DICOM:0018_9064 ilxtr:hasIlxId ilx:0105805 .
+DICOM:0018_9064 ilxtr:hasIlxId ILX:0105805 .
 
-DICOM:0018_9065 ilxtr:hasIlxId ilx:0111748 .
+DICOM:0018_9065 ilxtr:hasIlxId ILX:0111748 .
 
-DICOM:0018_9066 ilxtr:hasIlxId ilx:0107853 .
+DICOM:0018_9066 ilxtr:hasIlxId ILX:0107853 .
 
-DICOM:0018_9067 ilxtr:hasIlxId ilx:0101116 .
+DICOM:0018_9067 ilxtr:hasIlxId ILX:0101116 .
 
-DICOM:0018_9069 ilxtr:hasIlxId ilx:0108448 .
+DICOM:0018_9069 ilxtr:hasIlxId ILX:0108448 .
 
-DICOM:0018_9070 ilxtr:hasIlxId ilx:0382893 .
+DICOM:0018_9070 ilxtr:hasIlxId ILX:0382893 .
 
-DICOM:0018_9073 ilxtr:hasIlxId ilx:0100259 .
+DICOM:0018_9073 ilxtr:hasIlxId ILX:0100259 .
 
-DICOM:0018_9074 ilxtr:hasIlxId ilx:0104401 .
+DICOM:0018_9074 ilxtr:hasIlxId ILX:0104401 .
 
-DICOM:0018_9075 ilxtr:hasIlxId ilx:0103235 .
+DICOM:0018_9075 ilxtr:hasIlxId ILX:0103235 .
 
-DICOM:0018_9076 ilxtr:hasIlxId ilx:0103236 .
+DICOM:0018_9076 ilxtr:hasIlxId ILX:0103236 .
 
-DICOM:0018_9077 ilxtr:hasIlxId ilx:0108444 .
+DICOM:0018_9077 ilxtr:hasIlxId ILX:0108444 .
 
-DICOM:0018_9078 ilxtr:hasIlxId ilx:0108445 .
+DICOM:0018_9078 ilxtr:hasIlxId ILX:0108445 .
 
-DICOM:0018_9079 ilxtr:hasIlxId ilx:0105679 .
+DICOM:0018_9079 ilxtr:hasIlxId ILX:0105679 .
 
-DICOM:0018_9080 ilxtr:hasIlxId ilx:0106827 .
+DICOM:0018_9080 ilxtr:hasIlxId ILX:0106827 .
 
-DICOM:0018_9081 ilxtr:hasIlxId ilx:0108548 .
+DICOM:0018_9081 ilxtr:hasIlxId ILX:0108548 .
 
-DICOM:0018_9082 ilxtr:hasIlxId ilx:0103680 .
+DICOM:0018_9082 ilxtr:hasIlxId ILX:0103680 .
 
-DICOM:0018_9083 ilxtr:hasIlxId ilx:0106826 .
+DICOM:0018_9083 ilxtr:hasIlxId ILX:0106826 .
 
-DICOM:0018_9084 ilxtr:hasIlxId ilx:0102061 .
+DICOM:0018_9084 ilxtr:hasIlxId ILX:0102061 .
 
-DICOM:0018_9085 ilxtr:hasIlxId ilx:0382483 .
+DICOM:0018_9085 ilxtr:hasIlxId ILX:0382483 .
 
-DICOM:0018_9087 ilxtr:hasIlxId ilx:0103233 .
+DICOM:0018_9087 ilxtr:hasIlxId ILX:0103233 .
 
-DICOM:0018_9089 ilxtr:hasIlxId ilx:0103237 .
+DICOM:0018_9089 ilxtr:hasIlxId ILX:0103237 .
 
-DICOM:0018_9090 ilxtr:hasIlxId ilx:0112276 .
+DICOM:0018_9090 ilxtr:hasIlxId ILX:0112276 .
 
-DICOM:0018_9091 ilxtr:hasIlxId ilx:0112278 .
+DICOM:0018_9091 ilxtr:hasIlxId ILX:0112278 .
 
-DICOM:0018_9092 ilxtr:hasIlxId ilx:0382289 .
+DICOM:0018_9092 ilxtr:hasIlxId ILX:0382289 .
 
-DICOM:0018_9093 ilxtr:hasIlxId ilx:0107828 .
+DICOM:0018_9093 ilxtr:hasIlxId ILX:0107828 .
 
-DICOM:0018_9094 ilxtr:hasIlxId ilx:0102605 .
+DICOM:0018_9094 ilxtr:hasIlxId ILX:0102605 .
 
-DICOM:0018_9095 ilxtr:hasIlxId ilx:0110883 .
+DICOM:0018_9095 ilxtr:hasIlxId ILX:0110883 .
 
-DICOM:0018_9098 ilxtr:hasIlxId ilx:0111894 .
+DICOM:0018_9098 ilxtr:hasIlxId ILX:0111894 .
 
-DICOM:0018_9100 ilxtr:hasIlxId ilx:0109961 .
+DICOM:0018_9100 ilxtr:hasIlxId ILX:0109961 .
 
-DICOM:0018_9101 ilxtr:hasIlxId ilx:0104444 .
+DICOM:0018_9101 ilxtr:hasIlxId ILX:0104444 .
 
-DICOM:0018_9103 ilxtr:hasIlxId ilx:0382083 .
+DICOM:0018_9103 ilxtr:hasIlxId ILX:0382083 .
 
-DICOM:0018_9104 ilxtr:hasIlxId ilx:0110665 .
+DICOM:0018_9104 ilxtr:hasIlxId ILX:0110665 .
 
-DICOM:0018_9105 ilxtr:hasIlxId ilx:0110664 .
+DICOM:0018_9105 ilxtr:hasIlxId ILX:0110664 .
 
-DICOM:0018_9106 ilxtr:hasIlxId ilx:0106933 .
+DICOM:0018_9106 ilxtr:hasIlxId ILX:0106933 .
 
-DICOM:0018_9107 ilxtr:hasIlxId ilx:0107154 .
+DICOM:0018_9107 ilxtr:hasIlxId ILX:0107154 .
 
-DICOM:0018_9112 ilxtr:hasIlxId ilx:0107157 .
+DICOM:0018_9112 ilxtr:hasIlxId ILX:0107157 .
 
-DICOM:0018_9114 ilxtr:hasIlxId ilx:0107148 .
+DICOM:0018_9114 ilxtr:hasIlxId ILX:0107148 .
 
-DICOM:0018_9115 ilxtr:hasIlxId ilx:0107152 .
+DICOM:0018_9115 ilxtr:hasIlxId ILX:0107152 .
 
-DICOM:0018_9117 ilxtr:hasIlxId ilx:0107147 .
+DICOM:0018_9117 ilxtr:hasIlxId ILX:0107147 .
 
-DICOM:0018_9118 ilxtr:hasIlxId ilx:0382135 .
+DICOM:0018_9118 ilxtr:hasIlxId ILX:0382135 .
 
-DICOM:0018_9119 ilxtr:hasIlxId ilx:0107146 .
+DICOM:0018_9119 ilxtr:hasIlxId ILX:0107146 .
 
-DICOM:0018_9125 ilxtr:hasIlxId ilx:0381892 .
+DICOM:0018_9125 ilxtr:hasIlxId ILX:0381892 .
 
-DICOM:0018_9126 ilxtr:hasIlxId ilx:0112561 .
+DICOM:0018_9126 ilxtr:hasIlxId ILX:0112561 .
 
-DICOM:0018_9127 ilxtr:hasIlxId ilx:0110880 .
+DICOM:0018_9127 ilxtr:hasIlxId ILX:0110880 .
 
-DICOM:0018_9147 ilxtr:hasIlxId ilx:0103232 .
+DICOM:0018_9147 ilxtr:hasIlxId ILX:0103232 .
 
-DICOM:0018_9151 ilxtr:hasIlxId ilx:0104420 .
+DICOM:0018_9151 ilxtr:hasIlxId ILX:0104420 .
 
-DICOM:0018_9152 ilxtr:hasIlxId ilx:0107151 .
+DICOM:0018_9152 ilxtr:hasIlxId ILX:0107151 .
 
-DICOM:0018_9155 ilxtr:hasIlxId ilx:0108449 .
+DICOM:0018_9155 ilxtr:hasIlxId ILX:0108449 .
 
-DICOM:0018_9159 ilxtr:hasIlxId ilx:0110881 .
+DICOM:0018_9159 ilxtr:hasIlxId ILX:0110881 .
 
-DICOM:0018_9168 ilxtr:hasIlxId ilx:0108450 .
+DICOM:0018_9168 ilxtr:hasIlxId ILX:0108450 .
 
-DICOM:0018_9169 ilxtr:hasIlxId ilx:0382864 .
+DICOM:0018_9169 ilxtr:hasIlxId ILX:0382864 .
 
-DICOM:0018_9170 ilxtr:hasIlxId ilx:0109967 .
+DICOM:0018_9170 ilxtr:hasIlxId ILX:0109967 .
 
-DICOM:0018_9171 ilxtr:hasIlxId ilx:0109968 .
+DICOM:0018_9171 ilxtr:hasIlxId ILX:0109968 .
 
-DICOM:0018_9172 ilxtr:hasIlxId ilx:0382072 .
+DICOM:0018_9172 ilxtr:hasIlxId ILX:0382072 .
 
-DICOM:0018_9173 ilxtr:hasIlxId ilx:0382698 .
+DICOM:0018_9173 ilxtr:hasIlxId ILX:0382698 .
 
-DICOM:0018_9174 ilxtr:hasIlxId ilx:0382461 .
+DICOM:0018_9174 ilxtr:hasIlxId ILX:0382461 .
 
-DICOM:0018_9175 ilxtr:hasIlxId ilx:0100853 .
+DICOM:0018_9175 ilxtr:hasIlxId ILX:0100853 .
 
-DICOM:0018_9176 ilxtr:hasIlxId ilx:0108052 .
+DICOM:0018_9176 ilxtr:hasIlxId ILX:0108052 .
 
-DICOM:0018_9177 ilxtr:hasIlxId ilx:0108053 .
+DICOM:0018_9177 ilxtr:hasIlxId ILX:0108053 .
 
-DICOM:0018_9178 ilxtr:hasIlxId ilx:0108051 .
+DICOM:0018_9178 ilxtr:hasIlxId ILX:0108051 .
 
-DICOM:0018_9179 ilxtr:hasIlxId ilx:0110849 .
+DICOM:0018_9179 ilxtr:hasIlxId ILX:0110849 .
 
-DICOM:0018_9180 ilxtr:hasIlxId ilx:0104735 .
+DICOM:0018_9180 ilxtr:hasIlxId ILX:0104735 .
 
-DICOM:0018_9181 ilxtr:hasIlxId ilx:0110851 .
+DICOM:0018_9181 ilxtr:hasIlxId ILX:0110851 .
 
-DICOM:0018_9182 ilxtr:hasIlxId ilx:0104734 .
+DICOM:0018_9182 ilxtr:hasIlxId ILX:0104734 .
 
-DICOM:0018_9183 ilxtr:hasIlxId ilx:0104291 .
+DICOM:0018_9183 ilxtr:hasIlxId ILX:0104291 .
 
-DICOM:0018_9184 ilxtr:hasIlxId ilx:0111510 .
+DICOM:0018_9184 ilxtr:hasIlxId ILX:0111510 .
 
-DICOM:0018_9185 ilxtr:hasIlxId ilx:0382482 .
+DICOM:0018_9185 ilxtr:hasIlxId ILX:0382482 .
 
-DICOM:0018_9186 ilxtr:hasIlxId ilx:0382253 .
+DICOM:0018_9186 ilxtr:hasIlxId ILX:0382253 .
 
-DICOM:0018_9197 ilxtr:hasIlxId ilx:0107159 .
+DICOM:0018_9197 ilxtr:hasIlxId ILX:0107159 .
 
-DICOM:0018_9198 ilxtr:hasIlxId ilx:0104255 .
+DICOM:0018_9198 ilxtr:hasIlxId ILX:0104255 .
 
-DICOM:0018_9199 ilxtr:hasIlxId ilx:0112581 .
+DICOM:0018_9199 ilxtr:hasIlxId ILX:0112581 .
 
-DICOM:0018_9200 ilxtr:hasIlxId ilx:0107155 .
+DICOM:0018_9200 ilxtr:hasIlxId ILX:0107155 .
 
-DICOM:0018_9214 ilxtr:hasIlxId ilx:0109966 .
+DICOM:0018_9214 ilxtr:hasIlxId ILX:0109966 .
 
-DICOM:0018_9217 ilxtr:hasIlxId ilx:0112277 .
+DICOM:0018_9217 ilxtr:hasIlxId ILX:0112277 .
 
-DICOM:0018_9218 ilxtr:hasIlxId ilx:0111507 .
+DICOM:0018_9218 ilxtr:hasIlxId ILX:0111507 .
 
-DICOM:0018_9219 ilxtr:hasIlxId ilx:0111505 .
+DICOM:0018_9219 ilxtr:hasIlxId ILX:0111505 .
 
-DICOM:0018_9220 ilxtr:hasIlxId ilx:0104402 .
+DICOM:0018_9220 ilxtr:hasIlxId ILX:0104402 .
 
-DICOM:0018_9226 ilxtr:hasIlxId ilx:0107149 .
+DICOM:0018_9226 ilxtr:hasIlxId ILX:0107149 .
 
-DICOM:0018_9227 ilxtr:hasIlxId ilx:0107156 .
+DICOM:0018_9227 ilxtr:hasIlxId ILX:0107156 .
 
-DICOM:0018_9231 ilxtr:hasIlxId ilx:0107143 .
+DICOM:0018_9231 ilxtr:hasIlxId ILX:0107143 .
 
-DICOM:0018_9232 ilxtr:hasIlxId ilx:0107144 .
+DICOM:0018_9232 ilxtr:hasIlxId ILX:0107144 .
 
-DICOM:0018_9234 ilxtr:hasIlxId ilx:0110882 .
+DICOM:0018_9234 ilxtr:hasIlxId ILX:0110882 .
 
-DICOM:0018_9236 ilxtr:hasIlxId ilx:0101663 .
+DICOM:0018_9236 ilxtr:hasIlxId ILX:0101663 .
 
-DICOM:0018_9239 ilxtr:hasIlxId ilx:0110850 .
+DICOM:0018_9239 ilxtr:hasIlxId ILX:0110850 .
 
-DICOM:0018_9240 ilxtr:hasIlxId ilx:0383175 .
+DICOM:0018_9240 ilxtr:hasIlxId ILX:0383175 .
 
-DICOM:0018_9241 ilxtr:hasIlxId ilx:0104733 .
+DICOM:0018_9241 ilxtr:hasIlxId ILX:0104733 .
 
-DICOM:0018_9250 ilxtr:hasIlxId ilx:0381499 .
+DICOM:0018_9250 ilxtr:hasIlxId ILX:0381499 .
 
-DICOM:0018_9251 ilxtr:hasIlxId ilx:0382344 .
+DICOM:0018_9251 ilxtr:hasIlxId ILX:0382344 .
 
-DICOM:0018_9252 ilxtr:hasIlxId ilx:0382831 .
+DICOM:0018_9252 ilxtr:hasIlxId ILX:0382831 .
 
-DICOM:0018_9253 ilxtr:hasIlxId ilx:0381516 .
+DICOM:0018_9253 ilxtr:hasIlxId ILX:0381516 .
 
-DICOM:0018_9254 ilxtr:hasIlxId ilx:0382224 .
+DICOM:0018_9254 ilxtr:hasIlxId ILX:0382224 .
 
-DICOM:0018_9255 ilxtr:hasIlxId ilx:0382215 .
+DICOM:0018_9255 ilxtr:hasIlxId ILX:0382215 .
 
-DICOM:0018_9256 ilxtr:hasIlxId ilx:0381615 .
+DICOM:0018_9256 ilxtr:hasIlxId ILX:0381615 .
 
-DICOM:0018_9257 ilxtr:hasIlxId ilx:0383035 .
+DICOM:0018_9257 ilxtr:hasIlxId ILX:0383035 .
 
-DICOM:0018_9258 ilxtr:hasIlxId ilx:0382704 .
+DICOM:0018_9258 ilxtr:hasIlxId ILX:0382704 .
 
-DICOM:0018_9259 ilxtr:hasIlxId ilx:0383065 .
+DICOM:0018_9259 ilxtr:hasIlxId ILX:0383065 .
 
-DICOM:0018_9260 ilxtr:hasIlxId ilx:0382372 .
+DICOM:0018_9260 ilxtr:hasIlxId ILX:0382372 .
 
-DICOM:0018_9295 ilxtr:hasIlxId ilx:0382659 .
+DICOM:0018_9295 ilxtr:hasIlxId ILX:0382659 .
 
-DICOM:0018_9296 ilxtr:hasIlxId ilx:0382302 .
+DICOM:0018_9296 ilxtr:hasIlxId ILX:0382302 .
 
-DICOM:0018_9297 ilxtr:hasIlxId ilx:0382789 .
+DICOM:0018_9297 ilxtr:hasIlxId ILX:0382789 .
 
-DICOM:0018_9298 ilxtr:hasIlxId ilx:0382825 .
+DICOM:0018_9298 ilxtr:hasIlxId ILX:0382825 .
 
-DICOM:0018_9301 ilxtr:hasIlxId ilx:0382923 .
+DICOM:0018_9301 ilxtr:hasIlxId ILX:0382923 .
 
-DICOM:0018_9302 ilxtr:hasIlxId ilx:0381525 .
+DICOM:0018_9302 ilxtr:hasIlxId ILX:0381525 .
 
-DICOM:0018_9303 ilxtr:hasIlxId ilx:0381521 .
+DICOM:0018_9303 ilxtr:hasIlxId ILX:0381521 .
 
-DICOM:0018_9304 ilxtr:hasIlxId ilx:0382175 .
+DICOM:0018_9304 ilxtr:hasIlxId ILX:0382175 .
 
-DICOM:0018_9305 ilxtr:hasIlxId ilx:0382484 .
+DICOM:0018_9305 ilxtr:hasIlxId ILX:0382484 .
 
-DICOM:0018_9306 ilxtr:hasIlxId ilx:0383153 .
+DICOM:0018_9306 ilxtr:hasIlxId ILX:0383153 .
 
-DICOM:0018_9307 ilxtr:hasIlxId ilx:0382079 .
+DICOM:0018_9307 ilxtr:hasIlxId ILX:0382079 .
 
-DICOM:0018_9308 ilxtr:hasIlxId ilx:0381534 .
+DICOM:0018_9308 ilxtr:hasIlxId ILX:0381534 .
 
-DICOM:0018_9309 ilxtr:hasIlxId ilx:0381649 .
+DICOM:0018_9309 ilxtr:hasIlxId ILX:0381649 .
 
-DICOM:0018_9310 ilxtr:hasIlxId ilx:0381561 .
+DICOM:0018_9310 ilxtr:hasIlxId ILX:0381561 .
 
-DICOM:0018_9311 ilxtr:hasIlxId ilx:0381732 .
+DICOM:0018_9311 ilxtr:hasIlxId ILX:0381732 .
 
-DICOM:0018_9312 ilxtr:hasIlxId ilx:0383076 .
+DICOM:0018_9312 ilxtr:hasIlxId ILX:0383076 .
 
-DICOM:0018_9313 ilxtr:hasIlxId ilx:0382530 .
+DICOM:0018_9313 ilxtr:hasIlxId ILX:0382530 .
 
-DICOM:0018_9314 ilxtr:hasIlxId ilx:0381771 .
+DICOM:0018_9314 ilxtr:hasIlxId ILX:0381771 .
 
-DICOM:0018_9315 ilxtr:hasIlxId ilx:0382829 .
+DICOM:0018_9315 ilxtr:hasIlxId ILX:0382829 .
 
-DICOM:0018_9316 ilxtr:hasIlxId ilx:0383068 .
+DICOM:0018_9316 ilxtr:hasIlxId ILX:0383068 .
 
-DICOM:0018_9317 ilxtr:hasIlxId ilx:0381523 .
+DICOM:0018_9317 ilxtr:hasIlxId ILX:0381523 .
 
-DICOM:0018_9318 ilxtr:hasIlxId ilx:0381655 .
+DICOM:0018_9318 ilxtr:hasIlxId ILX:0381655 .
 
-DICOM:0018_9319 ilxtr:hasIlxId ilx:0382060 .
+DICOM:0018_9319 ilxtr:hasIlxId ILX:0382060 .
 
-DICOM:0018_9320 ilxtr:hasIlxId ilx:0382188 .
+DICOM:0018_9320 ilxtr:hasIlxId ILX:0382188 .
 
-DICOM:0018_9321 ilxtr:hasIlxId ilx:0382600 .
+DICOM:0018_9321 ilxtr:hasIlxId ILX:0382600 .
 
-DICOM:0018_9322 ilxtr:hasIlxId ilx:0382456 .
+DICOM:0018_9322 ilxtr:hasIlxId ILX:0382456 .
 
-DICOM:0018_9323 ilxtr:hasIlxId ilx:0382887 .
+DICOM:0018_9323 ilxtr:hasIlxId ILX:0382887 .
 
-DICOM:0018_9324 ilxtr:hasIlxId ilx:0382437 .
+DICOM:0018_9324 ilxtr:hasIlxId ILX:0382437 .
 
-DICOM:0018_9325 ilxtr:hasIlxId ilx:0382251 .
+DICOM:0018_9325 ilxtr:hasIlxId ILX:0382251 .
 
-DICOM:0018_9326 ilxtr:hasIlxId ilx:0383098 .
+DICOM:0018_9326 ilxtr:hasIlxId ILX:0383098 .
 
-DICOM:0018_9327 ilxtr:hasIlxId ilx:0383017 .
+DICOM:0018_9327 ilxtr:hasIlxId ILX:0383017 .
 
-DICOM:0018_9328 ilxtr:hasIlxId ilx:0383189 .
+DICOM:0018_9328 ilxtr:hasIlxId ILX:0383189 .
 
-DICOM:0018_9329 ilxtr:hasIlxId ilx:0381471 .
+DICOM:0018_9329 ilxtr:hasIlxId ILX:0381471 .
 
-DICOM:0018_9330 ilxtr:hasIlxId ilx:0381589 .
+DICOM:0018_9330 ilxtr:hasIlxId ILX:0381589 .
 
-DICOM:0018_9332 ilxtr:hasIlxId ilx:0381765 .
+DICOM:0018_9332 ilxtr:hasIlxId ILX:0381765 .
 
-DICOM:0018_9333 ilxtr:hasIlxId ilx:0382233 .
+DICOM:0018_9333 ilxtr:hasIlxId ILX:0382233 .
 
-DICOM:0018_9334 ilxtr:hasIlxId ilx:0382246 .
+DICOM:0018_9334 ilxtr:hasIlxId ILX:0382246 .
 
-DICOM:0018_9335 ilxtr:hasIlxId ilx:0383023 .
+DICOM:0018_9335 ilxtr:hasIlxId ILX:0383023 .
 
-DICOM:0018_9337 ilxtr:hasIlxId ilx:0381915 .
+DICOM:0018_9337 ilxtr:hasIlxId ILX:0381915 .
 
-DICOM:0018_9338 ilxtr:hasIlxId ilx:0383040 .
+DICOM:0018_9338 ilxtr:hasIlxId ILX:0383040 .
 
-DICOM:0018_9340 ilxtr:hasIlxId ilx:0102530 .
+DICOM:0018_9340 ilxtr:hasIlxId ILX:0102530 .
 
-DICOM:0018_9341 ilxtr:hasIlxId ilx:0382514 .
+DICOM:0018_9341 ilxtr:hasIlxId ILX:0382514 .
 
-DICOM:0018_9342 ilxtr:hasIlxId ilx:0382465 .
+DICOM:0018_9342 ilxtr:hasIlxId ILX:0382465 .
 
-DICOM:0018_9343 ilxtr:hasIlxId ilx:0382384 .
+DICOM:0018_9343 ilxtr:hasIlxId ILX:0382384 .
 
-DICOM:0018_9344 ilxtr:hasIlxId ilx:0381669 .
+DICOM:0018_9344 ilxtr:hasIlxId ILX:0381669 .
 
-DICOM:0018_9345 ilxtr:hasIlxId ilx:0381910 .
+DICOM:0018_9345 ilxtr:hasIlxId ILX:0381910 .
 
-DICOM:0018_9346 ilxtr:hasIlxId ilx:0382155 .
+DICOM:0018_9346 ilxtr:hasIlxId ILX:0382155 .
 
-DICOM:0018_9351 ilxtr:hasIlxId ilx:0383079 .
+DICOM:0018_9351 ilxtr:hasIlxId ILX:0383079 .
 
-DICOM:0018_9352 ilxtr:hasIlxId ilx:0382006 .
+DICOM:0018_9352 ilxtr:hasIlxId ILX:0382006 .
 
-DICOM:0018_9353 ilxtr:hasIlxId ilx:0381909 .
+DICOM:0018_9353 ilxtr:hasIlxId ILX:0381909 .
 
-DICOM:0018_9360 ilxtr:hasIlxId ilx:0382697 .
+DICOM:0018_9360 ilxtr:hasIlxId ILX:0382697 .
 
-DICOM:0018_9401 ilxtr:hasIlxId ilx:0383156 .
+DICOM:0018_9401 ilxtr:hasIlxId ILX:0383156 .
 
-DICOM:0018_9402 ilxtr:hasIlxId ilx:0382577 .
+DICOM:0018_9402 ilxtr:hasIlxId ILX:0382577 .
 
-DICOM:0018_9403 ilxtr:hasIlxId ilx:0382506 .
+DICOM:0018_9403 ilxtr:hasIlxId ILX:0382506 .
 
-DICOM:0018_9404 ilxtr:hasIlxId ilx:0381840 .
+DICOM:0018_9404 ilxtr:hasIlxId ILX:0381840 .
 
-DICOM:0018_9405 ilxtr:hasIlxId ilx:0382430 .
+DICOM:0018_9405 ilxtr:hasIlxId ILX:0382430 .
 
-DICOM:0018_9406 ilxtr:hasIlxId ilx:0381991 .
+DICOM:0018_9406 ilxtr:hasIlxId ILX:0381991 .
 
-DICOM:0018_9407 ilxtr:hasIlxId ilx:0381813 .
+DICOM:0018_9407 ilxtr:hasIlxId ILX:0381813 .
 
-DICOM:0018_9412 ilxtr:hasIlxId ilx:0381594 .
+DICOM:0018_9412 ilxtr:hasIlxId ILX:0381594 .
 
-DICOM:0018_9417 ilxtr:hasIlxId ilx:0383036 .
+DICOM:0018_9417 ilxtr:hasIlxId ILX:0383036 .
 
-DICOM:0018_9420 ilxtr:hasIlxId ilx:0381463 .
+DICOM:0018_9420 ilxtr:hasIlxId ILX:0381463 .
 
-DICOM:0018_9423 ilxtr:hasIlxId ilx:0381707 .
+DICOM:0018_9423 ilxtr:hasIlxId ILX:0381707 .
 
-DICOM:0018_9425 ilxtr:hasIlxId ilx:0382723 .
+DICOM:0018_9425 ilxtr:hasIlxId ILX:0382723 .
 
-DICOM:0018_9426 ilxtr:hasIlxId ilx:0381650 .
+DICOM:0018_9426 ilxtr:hasIlxId ILX:0381650 .
 
-DICOM:0018_9427 ilxtr:hasIlxId ilx:0382526 .
+DICOM:0018_9427 ilxtr:hasIlxId ILX:0382526 .
 
-DICOM:0018_9428 ilxtr:hasIlxId ilx:0382458 .
+DICOM:0018_9428 ilxtr:hasIlxId ILX:0382458 .
 
-DICOM:0018_9429 ilxtr:hasIlxId ilx:0382507 .
+DICOM:0018_9429 ilxtr:hasIlxId ILX:0382507 .
 
-DICOM:0018_9430 ilxtr:hasIlxId ilx:0382936 .
+DICOM:0018_9430 ilxtr:hasIlxId ILX:0382936 .
 
-DICOM:0018_9432 ilxtr:hasIlxId ilx:0381536 .
+DICOM:0018_9432 ilxtr:hasIlxId ILX:0381536 .
 
-DICOM:0018_9433 ilxtr:hasIlxId ilx:0381626 .
+DICOM:0018_9433 ilxtr:hasIlxId ILX:0381626 .
 
-DICOM:0018_9434 ilxtr:hasIlxId ilx:0383002 .
+DICOM:0018_9434 ilxtr:hasIlxId ILX:0383002 .
 
-DICOM:0018_9435 ilxtr:hasIlxId ilx:0382263 .
+DICOM:0018_9435 ilxtr:hasIlxId ILX:0382263 .
 
-DICOM:0018_9436 ilxtr:hasIlxId ilx:0382819 .
+DICOM:0018_9436 ilxtr:hasIlxId ILX:0382819 .
 
-DICOM:0018_9437 ilxtr:hasIlxId ilx:0382780 .
+DICOM:0018_9437 ilxtr:hasIlxId ILX:0382780 .
 
-DICOM:0018_9438 ilxtr:hasIlxId ilx:0381677 .
+DICOM:0018_9438 ilxtr:hasIlxId ILX:0381677 .
 
-DICOM:0018_9439 ilxtr:hasIlxId ilx:0382046 .
+DICOM:0018_9439 ilxtr:hasIlxId ILX:0382046 .
 
-DICOM:0018_9440 ilxtr:hasIlxId ilx:0382869 .
+DICOM:0018_9440 ilxtr:hasIlxId ILX:0382869 .
 
-DICOM:0018_9441 ilxtr:hasIlxId ilx:0383089 .
+DICOM:0018_9441 ilxtr:hasIlxId ILX:0383089 .
 
-DICOM:0018_9442 ilxtr:hasIlxId ilx:0382945 .
+DICOM:0018_9442 ilxtr:hasIlxId ILX:0382945 .
 
-DICOM:0018_9447 ilxtr:hasIlxId ilx:0382398 .
+DICOM:0018_9447 ilxtr:hasIlxId ILX:0382398 .
 
-DICOM:0018_9449 ilxtr:hasIlxId ilx:0382919 .
+DICOM:0018_9449 ilxtr:hasIlxId ILX:0382919 .
 
-DICOM:0018_9451 ilxtr:hasIlxId ilx:0382113 .
+DICOM:0018_9451 ilxtr:hasIlxId ILX:0382113 .
 
-DICOM:0018_9452 ilxtr:hasIlxId ilx:0382486 .
+DICOM:0018_9452 ilxtr:hasIlxId ILX:0382486 .
 
-DICOM:0018_9455 ilxtr:hasIlxId ilx:0381613 .
+DICOM:0018_9455 ilxtr:hasIlxId ILX:0381613 .
 
-DICOM:0018_9456 ilxtr:hasIlxId ilx:0382065 .
+DICOM:0018_9456 ilxtr:hasIlxId ILX:0382065 .
 
-DICOM:0018_9457 ilxtr:hasIlxId ilx:0382554 .
+DICOM:0018_9457 ilxtr:hasIlxId ILX:0382554 .
 
-DICOM:0018_9461 ilxtr:hasIlxId ilx:0382859 .
+DICOM:0018_9461 ilxtr:hasIlxId ILX:0382859 .
 
-DICOM:0018_9462 ilxtr:hasIlxId ilx:0382668 .
+DICOM:0018_9462 ilxtr:hasIlxId ILX:0382668 .
 
-DICOM:0018_9463 ilxtr:hasIlxId ilx:0382445 .
+DICOM:0018_9463 ilxtr:hasIlxId ILX:0382445 .
 
-DICOM:0018_9464 ilxtr:hasIlxId ilx:0382198 .
+DICOM:0018_9464 ilxtr:hasIlxId ILX:0382198 .
 
-DICOM:0018_9465 ilxtr:hasIlxId ilx:0383073 .
+DICOM:0018_9465 ilxtr:hasIlxId ILX:0383073 .
 
-DICOM:0018_9466 ilxtr:hasIlxId ilx:0382292 .
+DICOM:0018_9466 ilxtr:hasIlxId ILX:0382292 .
 
-DICOM:0018_9467 ilxtr:hasIlxId ilx:0382491 .
+DICOM:0018_9467 ilxtr:hasIlxId ILX:0382491 .
 
-DICOM:0018_9468 ilxtr:hasIlxId ilx:0382970 .
+DICOM:0018_9468 ilxtr:hasIlxId ILX:0382970 .
 
-DICOM:0018_9469 ilxtr:hasIlxId ilx:0381949 .
+DICOM:0018_9469 ilxtr:hasIlxId ILX:0381949 .
 
-DICOM:0018_9470 ilxtr:hasIlxId ilx:0383057 .
+DICOM:0018_9470 ilxtr:hasIlxId ILX:0383057 .
 
-DICOM:0018_9471 ilxtr:hasIlxId ilx:0382983 .
+DICOM:0018_9471 ilxtr:hasIlxId ILX:0382983 .
 
-DICOM:0018_9472 ilxtr:hasIlxId ilx:0382037 .
+DICOM:0018_9472 ilxtr:hasIlxId ILX:0382037 .
 
-DICOM:0018_9473 ilxtr:hasIlxId ilx:0382427 .
+DICOM:0018_9473 ilxtr:hasIlxId ILX:0382427 .
 
-DICOM:0018_9474 ilxtr:hasIlxId ilx:0383158 .
+DICOM:0018_9474 ilxtr:hasIlxId ILX:0383158 .
 
-DICOM:0018_9476 ilxtr:hasIlxId ilx:0381637 .
+DICOM:0018_9476 ilxtr:hasIlxId ILX:0381637 .
 
-DICOM:0018_9477 ilxtr:hasIlxId ilx:0383025 .
+DICOM:0018_9477 ilxtr:hasIlxId ILX:0383025 .
 
-DICOM:0018_9504 ilxtr:hasIlxId ilx:0382334 .
+DICOM:0018_9504 ilxtr:hasIlxId ILX:0382334 .
 
-DICOM:0018_9506 ilxtr:hasIlxId ilx:0381698 .
+DICOM:0018_9506 ilxtr:hasIlxId ILX:0381698 .
 
-DICOM:0018_9507 ilxtr:hasIlxId ilx:0383155 .
+DICOM:0018_9507 ilxtr:hasIlxId ILX:0383155 .
 
-DICOM:0018_9508 ilxtr:hasIlxId ilx:0382763 .
+DICOM:0018_9508 ilxtr:hasIlxId ILX:0382763 .
 
-DICOM:0018_9509 ilxtr:hasIlxId ilx:0383122 .
+DICOM:0018_9509 ilxtr:hasIlxId ILX:0383122 .
 
-DICOM:0018_9510 ilxtr:hasIlxId ilx:0383024 .
+DICOM:0018_9510 ilxtr:hasIlxId ILX:0383024 .
 
-DICOM:0018_9511 ilxtr:hasIlxId ilx:0381811 .
+DICOM:0018_9511 ilxtr:hasIlxId ILX:0381811 .
 
-DICOM:0018_9514 ilxtr:hasIlxId ilx:0382411 .
+DICOM:0018_9514 ilxtr:hasIlxId ILX:0382411 .
 
-DICOM:0018_9515 ilxtr:hasIlxId ilx:0382438 .
+DICOM:0018_9515 ilxtr:hasIlxId ILX:0382438 .
 
-DICOM:0018_9516 ilxtr:hasIlxId ilx:0382256 .
+DICOM:0018_9516 ilxtr:hasIlxId ILX:0382256 .
 
-DICOM:0018_9517 ilxtr:hasIlxId ilx:0382226 .
+DICOM:0018_9517 ilxtr:hasIlxId ILX:0382226 .
 
-DICOM:0018_9518 ilxtr:hasIlxId ilx:0382041 .
+DICOM:0018_9518 ilxtr:hasIlxId ILX:0382041 .
 
-DICOM:0018_9519 ilxtr:hasIlxId ilx:0382189 .
+DICOM:0018_9519 ilxtr:hasIlxId ILX:0382189 .
 
-DICOM:0018_9524 ilxtr:hasIlxId ilx:0382977 .
+DICOM:0018_9524 ilxtr:hasIlxId ILX:0382977 .
 
-DICOM:0018_9525 ilxtr:hasIlxId ilx:0382167 .
+DICOM:0018_9525 ilxtr:hasIlxId ILX:0382167 .
 
-DICOM:0018_9526 ilxtr:hasIlxId ilx:0381961 .
+DICOM:0018_9526 ilxtr:hasIlxId ILX:0381961 .
 
-DICOM:0018_9527 ilxtr:hasIlxId ilx:0382027 .
+DICOM:0018_9527 ilxtr:hasIlxId ILX:0382027 .
 
-DICOM:0018_9528 ilxtr:hasIlxId ilx:0381770 .
+DICOM:0018_9528 ilxtr:hasIlxId ILX:0381770 .
 
-DICOM:0018_9530 ilxtr:hasIlxId ilx:0382032 .
+DICOM:0018_9530 ilxtr:hasIlxId ILX:0382032 .
 
-DICOM:0018_9531 ilxtr:hasIlxId ilx:0381537 .
+DICOM:0018_9531 ilxtr:hasIlxId ILX:0381537 .
 
-DICOM:0018_9538 ilxtr:hasIlxId ilx:0382376 .
+DICOM:0018_9538 ilxtr:hasIlxId ILX:0382376 .
 
-DICOM:0018_9541 ilxtr:hasIlxId ilx:0381821 .
+DICOM:0018_9541 ilxtr:hasIlxId ILX:0381821 .
 
-DICOM:0018_9542 ilxtr:hasIlxId ilx:0382131 .
+DICOM:0018_9542 ilxtr:hasIlxId ILX:0382131 .
 
-DICOM:0018_9543 ilxtr:hasIlxId ilx:0382021 .
+DICOM:0018_9543 ilxtr:hasIlxId ILX:0382021 .
 
-DICOM:0018_9544 ilxtr:hasIlxId ilx:0381673 .
+DICOM:0018_9544 ilxtr:hasIlxId ILX:0381673 .
 
-DICOM:0018_9545 ilxtr:hasIlxId ilx:0381994 .
+DICOM:0018_9545 ilxtr:hasIlxId ILX:0381994 .
 
-DICOM:0018_9546 ilxtr:hasIlxId ilx:0381904 .
+DICOM:0018_9546 ilxtr:hasIlxId ILX:0381904 .
 
-DICOM:0018_9547 ilxtr:hasIlxId ilx:0382309 .
+DICOM:0018_9547 ilxtr:hasIlxId ILX:0382309 .
 
-DICOM:0018_9548 ilxtr:hasIlxId ilx:0382813 .
+DICOM:0018_9548 ilxtr:hasIlxId ILX:0382813 .
 
-DICOM:0018_9549 ilxtr:hasIlxId ilx:0382694 .
+DICOM:0018_9549 ilxtr:hasIlxId ILX:0382694 .
 
-DICOM:0018_9550 ilxtr:hasIlxId ilx:0382529 .
+DICOM:0018_9550 ilxtr:hasIlxId ILX:0382529 .
 
-DICOM:0018_9551 ilxtr:hasIlxId ilx:0382848 .
+DICOM:0018_9551 ilxtr:hasIlxId ILX:0382848 .
 
-DICOM:0018_9552 ilxtr:hasIlxId ilx:0381588 .
+DICOM:0018_9552 ilxtr:hasIlxId ILX:0381588 .
 
-DICOM:0018_9553 ilxtr:hasIlxId ilx:0382109 .
+DICOM:0018_9553 ilxtr:hasIlxId ILX:0382109 .
 
-DICOM:0018_9554 ilxtr:hasIlxId ilx:0382101 .
+DICOM:0018_9554 ilxtr:hasIlxId ILX:0382101 .
 
-DICOM:0018_9555 ilxtr:hasIlxId ilx:0381999 .
+DICOM:0018_9555 ilxtr:hasIlxId ILX:0381999 .
 
-DICOM:0018_9556 ilxtr:hasIlxId ilx:0381728 .
+DICOM:0018_9556 ilxtr:hasIlxId ILX:0381728 .
 
-DICOM:0018_9557 ilxtr:hasIlxId ilx:0382909 .
+DICOM:0018_9557 ilxtr:hasIlxId ILX:0382909 .
 
-DICOM:0018_9558 ilxtr:hasIlxId ilx:0381526 .
+DICOM:0018_9558 ilxtr:hasIlxId ILX:0381526 .
 
-DICOM:0018_9559 ilxtr:hasIlxId ilx:0382336 .
+DICOM:0018_9559 ilxtr:hasIlxId ILX:0382336 .
 
-DICOM:0018_9601 ilxtr:hasIlxId ilx:0382301 .
+DICOM:0018_9601 ilxtr:hasIlxId ILX:0382301 .
 
-DICOM:0018_9602 ilxtr:hasIlxId ilx:0382228 .
+DICOM:0018_9602 ilxtr:hasIlxId ILX:0382228 .
 
-DICOM:0018_9603 ilxtr:hasIlxId ilx:0382996 .
+DICOM:0018_9603 ilxtr:hasIlxId ILX:0382996 .
 
-DICOM:0018_9604 ilxtr:hasIlxId ilx:0382324 .
+DICOM:0018_9604 ilxtr:hasIlxId ILX:0382324 .
 
-DICOM:0018_9605 ilxtr:hasIlxId ilx:0382779 .
+DICOM:0018_9605 ilxtr:hasIlxId ILX:0382779 .
 
-DICOM:0018_9606 ilxtr:hasIlxId ilx:0382913 .
+DICOM:0018_9606 ilxtr:hasIlxId ILX:0382913 .
 
-DICOM:0018_9607 ilxtr:hasIlxId ilx:0382949 .
+DICOM:0018_9607 ilxtr:hasIlxId ILX:0382949 .
 
-DICOM:0018_9621 ilxtr:hasIlxId ilx:0382290 .
+DICOM:0018_9621 ilxtr:hasIlxId ILX:0382290 .
 
-DICOM:0018_9622 ilxtr:hasIlxId ilx:0382720 .
+DICOM:0018_9622 ilxtr:hasIlxId ILX:0382720 .
 
-DICOM:0018_9623 ilxtr:hasIlxId ilx:0381760 .
+DICOM:0018_9623 ilxtr:hasIlxId ILX:0381760 .
 
-DICOM:0018_9624 ilxtr:hasIlxId ilx:0381596 .
+DICOM:0018_9624 ilxtr:hasIlxId ILX:0381596 .
 
-DICOM:0018_9701 ilxtr:hasIlxId ilx:0381694 .
+DICOM:0018_9701 ilxtr:hasIlxId ILX:0381694 .
 
-DICOM:0018_9715 ilxtr:hasIlxId ilx:0381806 .
+DICOM:0018_9715 ilxtr:hasIlxId ILX:0381806 .
 
-DICOM:0018_9716 ilxtr:hasIlxId ilx:0381685 .
+DICOM:0018_9716 ilxtr:hasIlxId ILX:0381685 .
 
-DICOM:0018_9717 ilxtr:hasIlxId ilx:0381982 .
+DICOM:0018_9717 ilxtr:hasIlxId ILX:0381982 .
 
-DICOM:0018_9718 ilxtr:hasIlxId ilx:0381983 .
+DICOM:0018_9718 ilxtr:hasIlxId ILX:0381983 .
 
-DICOM:0018_9719 ilxtr:hasIlxId ilx:0382559 .
+DICOM:0018_9719 ilxtr:hasIlxId ILX:0382559 .
 
-DICOM:0018_9720 ilxtr:hasIlxId ilx:0382850 .
+DICOM:0018_9720 ilxtr:hasIlxId ILX:0382850 .
 
-DICOM:0018_9721 ilxtr:hasIlxId ilx:0382801 .
+DICOM:0018_9721 ilxtr:hasIlxId ILX:0382801 .
 
-DICOM:0018_9722 ilxtr:hasIlxId ilx:0382349 .
+DICOM:0018_9722 ilxtr:hasIlxId ILX:0382349 .
 
-DICOM:0018_9723 ilxtr:hasIlxId ilx:0382093 .
+DICOM:0018_9723 ilxtr:hasIlxId ILX:0382093 .
 
-DICOM:0018_9724 ilxtr:hasIlxId ilx:0382418 .
+DICOM:0018_9724 ilxtr:hasIlxId ILX:0382418 .
 
-DICOM:0018_9725 ilxtr:hasIlxId ilx:0381576 .
+DICOM:0018_9725 ilxtr:hasIlxId ILX:0381576 .
 
-DICOM:0018_9726 ilxtr:hasIlxId ilx:0381554 .
+DICOM:0018_9726 ilxtr:hasIlxId ILX:0381554 .
 
-DICOM:0018_9727 ilxtr:hasIlxId ilx:0382640 .
+DICOM:0018_9727 ilxtr:hasIlxId ILX:0382640 .
 
-DICOM:0018_9729 ilxtr:hasIlxId ilx:0382459 .
+DICOM:0018_9729 ilxtr:hasIlxId ILX:0382459 .
 
-DICOM:0018_9732 ilxtr:hasIlxId ilx:0381467 .
+DICOM:0018_9732 ilxtr:hasIlxId ILX:0381467 .
 
-DICOM:0018_9733 ilxtr:hasIlxId ilx:0382327 .
+DICOM:0018_9733 ilxtr:hasIlxId ILX:0382327 .
 
-DICOM:0018_9734 ilxtr:hasIlxId ilx:0382951 .
+DICOM:0018_9734 ilxtr:hasIlxId ILX:0382951 .
 
-DICOM:0018_9735 ilxtr:hasIlxId ilx:0382687 .
+DICOM:0018_9735 ilxtr:hasIlxId ILX:0382687 .
 
-DICOM:0018_9736 ilxtr:hasIlxId ilx:0382007 .
+DICOM:0018_9736 ilxtr:hasIlxId ILX:0382007 .
 
-DICOM:0018_9737 ilxtr:hasIlxId ilx:0382107 .
+DICOM:0018_9737 ilxtr:hasIlxId ILX:0382107 .
 
-DICOM:0018_9738 ilxtr:hasIlxId ilx:0382205 .
+DICOM:0018_9738 ilxtr:hasIlxId ILX:0382205 .
 
-DICOM:0018_9739 ilxtr:hasIlxId ilx:0382192 .
+DICOM:0018_9739 ilxtr:hasIlxId ILX:0382192 .
 
-DICOM:0018_9740 ilxtr:hasIlxId ilx:0381597 .
+DICOM:0018_9740 ilxtr:hasIlxId ILX:0381597 .
 
-DICOM:0018_9749 ilxtr:hasIlxId ilx:0382218 .
+DICOM:0018_9749 ilxtr:hasIlxId ILX:0382218 .
 
-DICOM:0018_9751 ilxtr:hasIlxId ilx:0382912 .
+DICOM:0018_9751 ilxtr:hasIlxId ILX:0382912 .
 
-DICOM:0018_9755 ilxtr:hasIlxId ilx:0382136 .
+DICOM:0018_9755 ilxtr:hasIlxId ILX:0382136 .
 
-DICOM:0018_9756 ilxtr:hasIlxId ilx:0381775 .
+DICOM:0018_9756 ilxtr:hasIlxId ILX:0381775 .
 
-DICOM:0018_9758 ilxtr:hasIlxId ilx:0382056 .
+DICOM:0018_9758 ilxtr:hasIlxId ILX:0382056 .
 
-DICOM:0018_9759 ilxtr:hasIlxId ilx:0381565 .
+DICOM:0018_9759 ilxtr:hasIlxId ILX:0381565 .
 
-DICOM:0018_9760 ilxtr:hasIlxId ilx:0383093 .
+DICOM:0018_9760 ilxtr:hasIlxId ILX:0383093 .
 
-DICOM:0018_9761 ilxtr:hasIlxId ilx:0381718 .
+DICOM:0018_9761 ilxtr:hasIlxId ILX:0381718 .
 
-DICOM:0018_9762 ilxtr:hasIlxId ilx:0381582 .
+DICOM:0018_9762 ilxtr:hasIlxId ILX:0381582 .
 
-DICOM:0018_9763 ilxtr:hasIlxId ilx:0382452 .
+DICOM:0018_9763 ilxtr:hasIlxId ILX:0382452 .
 
-DICOM:0018_9764 ilxtr:hasIlxId ilx:0382249 .
+DICOM:0018_9764 ilxtr:hasIlxId ILX:0382249 .
 
-DICOM:0018_9765 ilxtr:hasIlxId ilx:0381942 .
+DICOM:0018_9765 ilxtr:hasIlxId ILX:0381942 .
 
-DICOM:0018_9766 ilxtr:hasIlxId ilx:0381505 .
+DICOM:0018_9766 ilxtr:hasIlxId ILX:0381505 .
 
-DICOM:0018_9767 ilxtr:hasIlxId ilx:0383055 .
+DICOM:0018_9767 ilxtr:hasIlxId ILX:0383055 .
 
-DICOM:0018_9768 ilxtr:hasIlxId ilx:0382558 .
+DICOM:0018_9768 ilxtr:hasIlxId ILX:0382558 .
 
-DICOM:0018_9769 ilxtr:hasIlxId ilx:0382296 .
+DICOM:0018_9769 ilxtr:hasIlxId ILX:0382296 .
 
-DICOM:0018_9770 ilxtr:hasIlxId ilx:0381524 .
+DICOM:0018_9770 ilxtr:hasIlxId ILX:0381524 .
 
-DICOM:0018_9771 ilxtr:hasIlxId ilx:0382896 .
+DICOM:0018_9771 ilxtr:hasIlxId ILX:0382896 .
 
-DICOM:0018_9772 ilxtr:hasIlxId ilx:0382005 .
+DICOM:0018_9772 ilxtr:hasIlxId ILX:0382005 .
 
-DICOM:0018_9801 ilxtr:hasIlxId ilx:0382265 .
+DICOM:0018_9801 ilxtr:hasIlxId ILX:0382265 .
 
-DICOM:0018_9803 ilxtr:hasIlxId ilx:0382544 .
+DICOM:0018_9803 ilxtr:hasIlxId ILX:0382544 .
 
-DICOM:0018_9804 ilxtr:hasIlxId ilx:0382203 .
+DICOM:0018_9804 ilxtr:hasIlxId ILX:0382203 .
 
-DICOM:0018_9805 ilxtr:hasIlxId ilx:0383006 .
+DICOM:0018_9805 ilxtr:hasIlxId ILX:0383006 .
 
-DICOM:0018_9806 ilxtr:hasIlxId ilx:0381574 .
+DICOM:0018_9806 ilxtr:hasIlxId ILX:0381574 .
 
-DICOM:0018_9808 ilxtr:hasIlxId ilx:0382162 .
+DICOM:0018_9808 ilxtr:hasIlxId ILX:0382162 .
 
-DICOM:0018_9809 ilxtr:hasIlxId ilx:0381661 .
+DICOM:0018_9809 ilxtr:hasIlxId ILX:0381661 .
 
-DICOM:0018_9900 ilxtr:hasIlxId ilx:0382310 .
+DICOM:0018_9900 ilxtr:hasIlxId ILX:0382310 .
 
-DICOM:0018_9901 ilxtr:hasIlxId ilx:0382531 .
+DICOM:0018_9901 ilxtr:hasIlxId ILX:0382531 .
 
-DICOM:0018_9902 ilxtr:hasIlxId ilx:0382674 .
+DICOM:0018_9902 ilxtr:hasIlxId ILX:0382674 .
 
-DICOM:0018_9903 ilxtr:hasIlxId ilx:0382573 .
+DICOM:0018_9903 ilxtr:hasIlxId ILX:0382573 .
 
-DICOM:0018_9904 ilxtr:hasIlxId ilx:0381688 .
+DICOM:0018_9904 ilxtr:hasIlxId ILX:0381688 .
 
-DICOM:0018_9905 ilxtr:hasIlxId ilx:0382865 .
+DICOM:0018_9905 ilxtr:hasIlxId ILX:0382865 .
 
-DICOM:0018_9906 ilxtr:hasIlxId ilx:0382008 .
+DICOM:0018_9906 ilxtr:hasIlxId ILX:0382008 .
 
-DICOM:0018_9907 ilxtr:hasIlxId ilx:0382178 .
+DICOM:0018_9907 ilxtr:hasIlxId ILX:0382178 .
 
-DICOM:0018_9908 ilxtr:hasIlxId ilx:0381927 .
+DICOM:0018_9908 ilxtr:hasIlxId ILX:0381927 .
 
-DICOM:0018_9909 ilxtr:hasIlxId ilx:0383125 .
+DICOM:0018_9909 ilxtr:hasIlxId ILX:0383125 .
 
-DICOM:0018_9910 ilxtr:hasIlxId ilx:0381547 .
+DICOM:0018_9910 ilxtr:hasIlxId ILX:0381547 .
 
-DICOM:0018_9911 ilxtr:hasIlxId ilx:0381590 .
+DICOM:0018_9911 ilxtr:hasIlxId ILX:0381590 .
 
-DICOM:0018_9912 ilxtr:hasIlxId ilx:0381618 .
+DICOM:0018_9912 ilxtr:hasIlxId ILX:0381618 .
 
-DICOM:0018_9913 ilxtr:hasIlxId ilx:0382591 .
+DICOM:0018_9913 ilxtr:hasIlxId ILX:0382591 .
 
-DICOM:0018_9914 ilxtr:hasIlxId ilx:0383043 .
+DICOM:0018_9914 ilxtr:hasIlxId ILX:0383043 .
 
-DICOM:0018_9915 ilxtr:hasIlxId ilx:0382548 .
+DICOM:0018_9915 ilxtr:hasIlxId ILX:0382548 .
 
-DICOM:0018_9916 ilxtr:hasIlxId ilx:0382123 .
+DICOM:0018_9916 ilxtr:hasIlxId ILX:0382123 .
 
-DICOM:0018_9917 ilxtr:hasIlxId ilx:0381671 .
+DICOM:0018_9917 ilxtr:hasIlxId ILX:0381671 .
 
-DICOM:0018_9918 ilxtr:hasIlxId ilx:0382472 .
+DICOM:0018_9918 ilxtr:hasIlxId ILX:0382472 .
 
-DICOM:0018_9919 ilxtr:hasIlxId ilx:0382605 .
+DICOM:0018_9919 ilxtr:hasIlxId ILX:0382605 .
 
-DICOM:0018_9920 ilxtr:hasIlxId ilx:0381735 .
+DICOM:0018_9920 ilxtr:hasIlxId ILX:0381735 .
 
-DICOM:0018_9921 ilxtr:hasIlxId ilx:0381528 .
+DICOM:0018_9921 ilxtr:hasIlxId ILX:0381528 .
 
-DICOM:0018_9922 ilxtr:hasIlxId ilx:0382204 .
+DICOM:0018_9922 ilxtr:hasIlxId ILX:0382204 .
 
-DICOM:0018_9923 ilxtr:hasIlxId ilx:0382961 .
+DICOM:0018_9923 ilxtr:hasIlxId ILX:0382961 .
 
-DICOM:0018_9924 ilxtr:hasIlxId ilx:0382366 .
+DICOM:0018_9924 ilxtr:hasIlxId ILX:0382366 .
 
-DICOM:0018_9930 ilxtr:hasIlxId ilx:0381810 .
+DICOM:0018_9930 ilxtr:hasIlxId ILX:0381810 .
 
-DICOM:0018_9931 ilxtr:hasIlxId ilx:0381634 .
+DICOM:0018_9931 ilxtr:hasIlxId ILX:0381634 .
 
-DICOM:0018_9932 ilxtr:hasIlxId ilx:0383128 .
+DICOM:0018_9932 ilxtr:hasIlxId ILX:0383128 .
 
-DICOM:0018_9933 ilxtr:hasIlxId ilx:0383173 .
+DICOM:0018_9933 ilxtr:hasIlxId ILX:0383173 .
 
-DICOM:0018_9934 ilxtr:hasIlxId ilx:0382603 .
+DICOM:0018_9934 ilxtr:hasIlxId ILX:0382603 .
 
-DICOM:0018_9935 ilxtr:hasIlxId ilx:0381651 .
+DICOM:0018_9935 ilxtr:hasIlxId ILX:0381651 .
 
-DICOM:0018_9936 ilxtr:hasIlxId ilx:0381846 .
+DICOM:0018_9936 ilxtr:hasIlxId ILX:0381846 .
 
-DICOM:0018_9937 ilxtr:hasIlxId ilx:0381863 .
+DICOM:0018_9937 ilxtr:hasIlxId ILX:0381863 .
 
-DICOM:0018_9938 ilxtr:hasIlxId ilx:0382222 .
+DICOM:0018_9938 ilxtr:hasIlxId ILX:0382222 .
 
-DICOM:0018_9939 ilxtr:hasIlxId ilx:0383114 .
+DICOM:0018_9939 ilxtr:hasIlxId ILX:0383114 .
 
-DICOM:0018_9941 ilxtr:hasIlxId ilx:0381987 .
+DICOM:0018_9941 ilxtr:hasIlxId ILX:0381987 .
 
-DICOM:0018_9942 ilxtr:hasIlxId ilx:0382106 .
+DICOM:0018_9942 ilxtr:hasIlxId ILX:0382106 .
 
-DICOM:0018_9943 ilxtr:hasIlxId ilx:0381807 .
+DICOM:0018_9943 ilxtr:hasIlxId ILX:0381807 .
 
-DICOM:0018_9944 ilxtr:hasIlxId ilx:0382634 .
+DICOM:0018_9944 ilxtr:hasIlxId ILX:0382634 .
 
-DICOM:0018_9945 ilxtr:hasIlxId ilx:0382025 .
+DICOM:0018_9945 ilxtr:hasIlxId ILX:0382025 .
 
-DICOM:0018_9946 ilxtr:hasIlxId ilx:0381953 .
+DICOM:0018_9946 ilxtr:hasIlxId ILX:0381953 .
 
-DICOM:0018_9947 ilxtr:hasIlxId ilx:0382568 .
+DICOM:0018_9947 ilxtr:hasIlxId ILX:0382568 .
 
-DICOM:0018_A001 ilxtr:hasIlxId ilx:0102535 .
+DICOM:0018_A001 ilxtr:hasIlxId ILX:0102535 .
 
-DICOM:0018_A002 ilxtr:hasIlxId ilx:0102536 .
+DICOM:0018_A002 ilxtr:hasIlxId ILX:0102536 .
 
-DICOM:0018_A003 ilxtr:hasIlxId ilx:0102537 .
+DICOM:0018_A003 ilxtr:hasIlxId ILX:0102537 .
 
-DICOM:0020_000D ilxtr:hasIlxId ilx:0111142 .
+DICOM:0020_000D ilxtr:hasIlxId ILX:0111142 .
 
-DICOM:0020_000E ilxtr:hasIlxId ilx:0110545 .
+DICOM:0020_000E ilxtr:hasIlxId ILX:0110545 .
 
-DICOM:0020_0010 ilxtr:hasIlxId ilx:0111140 .
+DICOM:0020_0010 ilxtr:hasIlxId ILX:0111140 .
 
-DICOM:0020_0011 ilxtr:hasIlxId ilx:0110546 .
+DICOM:0020_0011 ilxtr:hasIlxId ILX:0110546 .
 
-DICOM:0020_0012 ilxtr:hasIlxId ilx:0100261 .
+DICOM:0020_0012 ilxtr:hasIlxId ILX:0100261 .
 
-DICOM:0020_0013 ilxtr:hasIlxId ilx:0105509 .
+DICOM:0020_0013 ilxtr:hasIlxId ILX:0105509 .
 
-DICOM:0020_0020 ilxtr:hasIlxId ilx:0108590 .
+DICOM:0020_0020 ilxtr:hasIlxId ILX:0108590 .
 
-DICOM:0020_0022 ilxtr:hasIlxId ilx:0108298 .
+DICOM:0020_0022 ilxtr:hasIlxId ILX:0108298 .
 
-DICOM:0020_0032 ilxtr:hasIlxId ilx:0105246 .
+DICOM:0020_0032 ilxtr:hasIlxId ILX:0105246 .
 
-DICOM:0020_0037 ilxtr:hasIlxId ilx:0105240 .
+DICOM:0020_0037 ilxtr:hasIlxId ILX:0105240 .
 
-DICOM:0020_0052 ilxtr:hasIlxId ilx:0104418 .
+DICOM:0020_0052 ilxtr:hasIlxId ILX:0104418 .
 
-DICOM:0020_0060 ilxtr:hasIlxId ilx:0106135 .
+DICOM:0020_0060 ilxtr:hasIlxId ILX:0106135 .
 
-DICOM:0020_0062 ilxtr:hasIlxId ilx:0105239 .
+DICOM:0020_0062 ilxtr:hasIlxId ILX:0105239 .
 
-DICOM:0020_0100 ilxtr:hasIlxId ilx:0111596 .
+DICOM:0020_0100 ilxtr:hasIlxId ILX:0111596 .
 
-DICOM:0020_103F ilxtr:hasIlxId ilx:0382409 .
+DICOM:0020_103F ilxtr:hasIlxId ILX:0382409 .
 
-DICOM:0020_0105 ilxtr:hasIlxId ilx:0107844 .
+DICOM:0020_0105 ilxtr:hasIlxId ILX:0107844 .
 
-DICOM:0020_0110 ilxtr:hasIlxId ilx:0111600 .
+DICOM:0020_0110 ilxtr:hasIlxId ILX:0111600 .
 
-DICOM:0020_0200 ilxtr:hasIlxId ilx:0111418 .
+DICOM:0020_0200 ilxtr:hasIlxId ILX:0111418 .
 
-DICOM:0020_0242 ilxtr:hasIlxId ilx:0382497 .
+DICOM:0020_0242 ilxtr:hasIlxId ILX:0382497 .
 
-DICOM:0020_930D ilxtr:hasIlxId ilx:0382538 .
+DICOM:0020_930D ilxtr:hasIlxId ILX:0382538 .
 
-DICOM:0020_930E ilxtr:hasIlxId ilx:0382877 .
+DICOM:0020_930E ilxtr:hasIlxId ILX:0382877 .
 
-DICOM:0020_930F ilxtr:hasIlxId ilx:0382728 .
+DICOM:0020_930F ilxtr:hasIlxId ILX:0382728 .
 
-DICOM:0020_1000 ilxtr:hasIlxId ilx:0110544 .
+DICOM:0020_1000 ilxtr:hasIlxId ILX:0110544 .
 
-DICOM:0020_1002 ilxtr:hasIlxId ilx:0105257 .
+DICOM:0020_1002 ilxtr:hasIlxId ILX:0105257 .
 
-DICOM:0020_1004 ilxtr:hasIlxId ilx:0100268 .
+DICOM:0020_1004 ilxtr:hasIlxId ILX:0100268 .
 
-DICOM:0020_1040 ilxtr:hasIlxId ilx:0109051 .
+DICOM:0020_1040 ilxtr:hasIlxId ILX:0109051 .
 
-DICOM:0020_1041 ilxtr:hasIlxId ilx:0110668 .
+DICOM:0020_1041 ilxtr:hasIlxId ILX:0110668 .
 
-DICOM:0020_1200 ilxtr:hasIlxId ilx:0107831 .
+DICOM:0020_1200 ilxtr:hasIlxId ILX:0107831 .
 
-DICOM:0020_1202 ilxtr:hasIlxId ilx:0107830 .
+DICOM:0020_1202 ilxtr:hasIlxId ILX:0107830 .
 
-DICOM:0020_1204 ilxtr:hasIlxId ilx:0107829 .
+DICOM:0020_1204 ilxtr:hasIlxId ILX:0107829 .
 
-DICOM:0020_1208 ilxtr:hasIlxId ilx:0107840 .
+DICOM:0020_1208 ilxtr:hasIlxId ILX:0107840 .
 
-DICOM:0020_1209 ilxtr:hasIlxId ilx:0107837 .
+DICOM:0020_1209 ilxtr:hasIlxId ILX:0107837 .
 
-DICOM:0020_4000 ilxtr:hasIlxId ilx:0105232 .
+DICOM:0020_4000 ilxtr:hasIlxId ILX:0105232 .
 
-DICOM:0020_9056 ilxtr:hasIlxId ilx:0111009 .
+DICOM:0020_9056 ilxtr:hasIlxId ILX:0111009 .
 
-DICOM:0020_9057 ilxtr:hasIlxId ilx:0105315 .
+DICOM:0020_9057 ilxtr:hasIlxId ILX:0105315 .
 
-DICOM:0020_9071 ilxtr:hasIlxId ilx:0104404 .
+DICOM:0020_9071 ilxtr:hasIlxId ILX:0104404 .
 
-DICOM:0020_9072 ilxtr:hasIlxId ilx:0104410 .
+DICOM:0020_9072 ilxtr:hasIlxId ILX:0104410 .
 
-DICOM:0020_9111 ilxtr:hasIlxId ilx:0104406 .
+DICOM:0020_9111 ilxtr:hasIlxId ILX:0104406 .
 
-DICOM:0020_9113 ilxtr:hasIlxId ilx:0108970 .
+DICOM:0020_9113 ilxtr:hasIlxId ILX:0108970 .
 
-DICOM:0020_9116 ilxtr:hasIlxId ilx:0108969 .
+DICOM:0020_9116 ilxtr:hasIlxId ILX:0108969 .
 
-DICOM:0020_9128 ilxtr:hasIlxId ilx:0111597 .
+DICOM:0020_9128 ilxtr:hasIlxId ILX:0111597 .
 
-DICOM:0020_9153 ilxtr:hasIlxId ilx:0381782 .
+DICOM:0020_9153 ilxtr:hasIlxId ILX:0381782 .
 
-DICOM:0020_9154 ilxtr:hasIlxId ilx:0382776 .
+DICOM:0020_9154 ilxtr:hasIlxId ILX:0382776 .
 
-DICOM:0020_9155 ilxtr:hasIlxId ilx:0381539 .
+DICOM:0020_9155 ilxtr:hasIlxId ILX:0381539 .
 
-DICOM:0020_9156 ilxtr:hasIlxId ilx:0104403 .
+DICOM:0020_9156 ilxtr:hasIlxId ILX:0104403 .
 
-DICOM:0020_9157 ilxtr:hasIlxId ilx:0103273 .
+DICOM:0020_9157 ilxtr:hasIlxId ILX:0103273 .
 
-DICOM:0020_9158 ilxtr:hasIlxId ilx:0104405 .
+DICOM:0020_9158 ilxtr:hasIlxId ILX:0104405 .
 
-DICOM:0020_9161 ilxtr:hasIlxId ilx:0102450 .
+DICOM:0020_9161 ilxtr:hasIlxId ILX:0102450 .
 
-DICOM:0020_9162 ilxtr:hasIlxId ilx:0105310 .
+DICOM:0020_9162 ilxtr:hasIlxId ILX:0105310 .
 
-DICOM:0020_9163 ilxtr:hasIlxId ilx:0105311 .
+DICOM:0020_9163 ilxtr:hasIlxId ILX:0105311 .
 
-DICOM:0020_9164 ilxtr:hasIlxId ilx:0103275 .
+DICOM:0020_9164 ilxtr:hasIlxId ILX:0103275 .
 
-DICOM:0020_9165 ilxtr:hasIlxId ilx:0103270 .
+DICOM:0020_9165 ilxtr:hasIlxId ILX:0103270 .
 
-DICOM:0020_9167 ilxtr:hasIlxId ilx:0104468 .
+DICOM:0020_9167 ilxtr:hasIlxId ILX:0104468 .
 
-DICOM:0020_9172 ilxtr:hasIlxId ilx:0381923 .
+DICOM:0020_9172 ilxtr:hasIlxId ILX:0381923 .
 
-DICOM:0020_9213 ilxtr:hasIlxId ilx:0103271 .
+DICOM:0020_9213 ilxtr:hasIlxId ILX:0103271 .
 
-DICOM:0020_9221 ilxtr:hasIlxId ilx:0103274 .
+DICOM:0020_9221 ilxtr:hasIlxId ILX:0103274 .
 
-DICOM:0020_9222 ilxtr:hasIlxId ilx:0103272 .
+DICOM:0020_9222 ilxtr:hasIlxId ILX:0103272 .
 
-DICOM:0020_9228 ilxtr:hasIlxId ilx:0102449 .
+DICOM:0020_9228 ilxtr:hasIlxId ILX:0102449 .
 
-DICOM:0020_9238 ilxtr:hasIlxId ilx:0104469 .
+DICOM:0020_9238 ilxtr:hasIlxId ILX:0104469 .
 
-DICOM:0020_9241 ilxtr:hasIlxId ilx:0382480 .
+DICOM:0020_9241 ilxtr:hasIlxId ILX:0382480 .
 
-DICOM:0020_9245 ilxtr:hasIlxId ilx:0381500 .
+DICOM:0020_9245 ilxtr:hasIlxId ILX:0381500 .
 
-DICOM:0020_9246 ilxtr:hasIlxId ilx:0381874 .
+DICOM:0020_9246 ilxtr:hasIlxId ILX:0381874 .
 
-DICOM:0020_9247 ilxtr:hasIlxId ilx:0381491 .
+DICOM:0020_9247 ilxtr:hasIlxId ILX:0381491 .
 
-DICOM:0020_9248 ilxtr:hasIlxId ilx:0382754 .
+DICOM:0020_9248 ilxtr:hasIlxId ILX:0382754 .
 
-DICOM:0020_9249 ilxtr:hasIlxId ilx:0383164 .
+DICOM:0020_9249 ilxtr:hasIlxId ILX:0383164 .
 
-DICOM:0020_9250 ilxtr:hasIlxId ilx:0382520 .
+DICOM:0020_9250 ilxtr:hasIlxId ILX:0382520 .
 
-DICOM:0020_9251 ilxtr:hasIlxId ilx:0382729 .
+DICOM:0020_9251 ilxtr:hasIlxId ILX:0382729 .
 
-DICOM:0020_9252 ilxtr:hasIlxId ilx:0382242 .
+DICOM:0020_9252 ilxtr:hasIlxId ILX:0382242 .
 
-DICOM:0020_9253 ilxtr:hasIlxId ilx:0382844 .
+DICOM:0020_9253 ilxtr:hasIlxId ILX:0382844 .
 
-DICOM:0020_9254 ilxtr:hasIlxId ilx:0381885 .
+DICOM:0020_9254 ilxtr:hasIlxId ILX:0381885 .
 
-DICOM:0020_9255 ilxtr:hasIlxId ilx:0381675 .
+DICOM:0020_9255 ilxtr:hasIlxId ILX:0381675 .
 
-DICOM:0020_9256 ilxtr:hasIlxId ilx:0382319 .
+DICOM:0020_9256 ilxtr:hasIlxId ILX:0382319 .
 
-DICOM:0020_9257 ilxtr:hasIlxId ilx:0382229 .
+DICOM:0020_9257 ilxtr:hasIlxId ILX:0382229 .
 
-DICOM:0020_9301 ilxtr:hasIlxId ilx:0381538 .
+DICOM:0020_9301 ilxtr:hasIlxId ILX:0381538 .
 
-DICOM:0020_9302 ilxtr:hasIlxId ilx:0381599 .
+DICOM:0020_9302 ilxtr:hasIlxId ILX:0381599 .
 
-DICOM:0020_9310 ilxtr:hasIlxId ilx:0381461 .
+DICOM:0020_9310 ilxtr:hasIlxId ILX:0381461 .
 
-DICOM:0020_9311 ilxtr:hasIlxId ilx:0382306 .
+DICOM:0020_9311 ilxtr:hasIlxId ILX:0382306 .
 
-DICOM:0020_9421 ilxtr:hasIlxId ilx:0383117 .
+DICOM:0020_9421 ilxtr:hasIlxId ILX:0383117 .
 
-DICOM:0020_9450 ilxtr:hasIlxId ilx:0381889 .
+DICOM:0020_9450 ilxtr:hasIlxId ILX:0381889 .
 
-DICOM:0020_9453 ilxtr:hasIlxId ilx:0382105 .
+DICOM:0020_9453 ilxtr:hasIlxId ILX:0382105 .
 
-DICOM:0020_9518 ilxtr:hasIlxId ilx:0381689 .
+DICOM:0020_9518 ilxtr:hasIlxId ILX:0381689 .
 
-DICOM:0020_9529 ilxtr:hasIlxId ilx:0381570 .
+DICOM:0020_9529 ilxtr:hasIlxId ILX:0381570 .
 
-DICOM:0020_9536 ilxtr:hasIlxId ilx:0381903 .
+DICOM:0020_9536 ilxtr:hasIlxId ILX:0381903 .
 
-DICOM:0022_000A ilxtr:hasIlxId ilx:0103759 .
+DICOM:0022_000A ilxtr:hasIlxId ILX:0103759 .
 
-DICOM:0022_000B ilxtr:hasIlxId ilx:0105640 .
+DICOM:0022_000B ilxtr:hasIlxId ILX:0105640 .
 
-DICOM:0022_000C ilxtr:hasIlxId ilx:0105106 .
+DICOM:0022_000C ilxtr:hasIlxId ILX:0105106 .
 
-DICOM:0022_000D ilxtr:hasIlxId ilx:0109540 .
+DICOM:0022_000D ilxtr:hasIlxId ILX:0109540 .
 
-DICOM:0022_000E ilxtr:hasIlxId ilx:0102985 .
+DICOM:0022_000E ilxtr:hasIlxId ILX:0102985 .
 
-DICOM:0022_0001 ilxtr:hasIlxId ilx:0106243 .
+DICOM:0022_0001 ilxtr:hasIlxId ILX:0106243 .
 
-DICOM:0022_001A ilxtr:hasIlxId ilx:0102032 .
+DICOM:0022_001A ilxtr:hasIlxId ILX:0102032 .
 
-DICOM:0022_001B ilxtr:hasIlxId ilx:0109817 .
+DICOM:0022_001B ilxtr:hasIlxId ILX:0109817 .
 
-DICOM:0022_001C ilxtr:hasIlxId ilx:0107262 .
+DICOM:0022_001C ilxtr:hasIlxId ILX:0107262 .
 
-DICOM:0022_001D ilxtr:hasIlxId ilx:0109902 .
+DICOM:0022_001D ilxtr:hasIlxId ILX:0109902 .
 
-DICOM:0022_0002 ilxtr:hasIlxId ilx:0106242 .
+DICOM:0022_0002 ilxtr:hasIlxId ILX:0106242 .
 
-DICOM:0022_0003 ilxtr:hasIlxId ilx:0105243 .
+DICOM:0022_0003 ilxtr:hasIlxId ILX:0105243 .
 
-DICOM:0022_0004 ilxtr:hasIlxId ilx:0105242 .
+DICOM:0022_0004 ilxtr:hasIlxId ILX:0105242 .
 
-DICOM:0022_004E ilxtr:hasIlxId ilx:0382536 .
+DICOM:0022_004E ilxtr:hasIlxId ILX:0382536 .
 
-DICOM:0022_0005 ilxtr:hasIlxId ilx:0108587 .
+DICOM:0022_0005 ilxtr:hasIlxId ILX:0108587 .
 
-DICOM:0022_0006 ilxtr:hasIlxId ilx:0108586 .
+DICOM:0022_0006 ilxtr:hasIlxId ILX:0108586 .
 
-DICOM:0022_0007 ilxtr:hasIlxId ilx:0110889 .
+DICOM:0022_0007 ilxtr:hasIlxId ILX:0110889 .
 
-DICOM:0022_0008 ilxtr:hasIlxId ilx:0102742 .
+DICOM:0022_0008 ilxtr:hasIlxId ILX:0102742 .
 
-DICOM:0022_0009 ilxtr:hasIlxId ilx:0102741 .
+DICOM:0022_0009 ilxtr:hasIlxId ILX:0102741 .
 
-DICOM:0022_0010 ilxtr:hasIlxId ilx:0111043 .
+DICOM:0022_0010 ilxtr:hasIlxId ILX:0111043 .
 
-DICOM:0022_0011 ilxtr:hasIlxId ilx:0111044 .
+DICOM:0022_0011 ilxtr:hasIlxId ILX:0111044 .
 
-DICOM:0022_0012 ilxtr:hasIlxId ilx:0111045 .
+DICOM:0022_0012 ilxtr:hasIlxId ILX:0111045 .
 
-DICOM:0022_0013 ilxtr:hasIlxId ilx:0111048 .
+DICOM:0022_0013 ilxtr:hasIlxId ILX:0111048 .
 
-DICOM:0022_0014 ilxtr:hasIlxId ilx:0111047 .
+DICOM:0022_0014 ilxtr:hasIlxId ILX:0111047 .
 
-DICOM:0022_0015 ilxtr:hasIlxId ilx:0100258 .
+DICOM:0022_0015 ilxtr:hasIlxId ILX:0100258 .
 
-DICOM:0022_0016 ilxtr:hasIlxId ilx:0105223 .
+DICOM:0022_0016 ilxtr:hasIlxId ILX:0105223 .
 
-DICOM:0022_0017 ilxtr:hasIlxId ilx:0106244 .
+DICOM:0022_0017 ilxtr:hasIlxId ILX:0106244 .
 
-DICOM:0022_0018 ilxtr:hasIlxId ilx:0105244 .
+DICOM:0022_0018 ilxtr:hasIlxId ILX:0105244 .
 
-DICOM:0022_0019 ilxtr:hasIlxId ilx:0106169 .
+DICOM:0022_0019 ilxtr:hasIlxId ILX:0106169 .
 
-DICOM:0022_0020 ilxtr:hasIlxId ilx:0111046 .
+DICOM:0022_0020 ilxtr:hasIlxId ILX:0111046 .
 
-DICOM:0022_0021 ilxtr:hasIlxId ilx:0106157 .
+DICOM:0022_0021 ilxtr:hasIlxId ILX:0106157 .
 
-DICOM:0022_0022 ilxtr:hasIlxId ilx:0110146 .
+DICOM:0022_0022 ilxtr:hasIlxId ILX:0110146 .
 
-DICOM:0022_0028 ilxtr:hasIlxId ilx:0381862 .
+DICOM:0022_0028 ilxtr:hasIlxId ILX:0381862 .
 
-DICOM:0022_0030 ilxtr:hasIlxId ilx:0381969 .
+DICOM:0022_0030 ilxtr:hasIlxId ILX:0381969 .
 
-DICOM:0022_0031 ilxtr:hasIlxId ilx:0382576 .
+DICOM:0022_0031 ilxtr:hasIlxId ILX:0382576 .
 
-DICOM:0022_0032 ilxtr:hasIlxId ilx:0382874 .
+DICOM:0022_0032 ilxtr:hasIlxId ILX:0382874 .
 
-DICOM:0022_0035 ilxtr:hasIlxId ilx:0382069 .
+DICOM:0022_0035 ilxtr:hasIlxId ILX:0382069 .
 
-DICOM:0022_0036 ilxtr:hasIlxId ilx:0382498 .
+DICOM:0022_0036 ilxtr:hasIlxId ILX:0382498 .
 
-DICOM:0022_0037 ilxtr:hasIlxId ilx:0382904 .
+DICOM:0022_0037 ilxtr:hasIlxId ILX:0382904 .
 
-DICOM:0022_0038 ilxtr:hasIlxId ilx:0382490 .
+DICOM:0022_0038 ilxtr:hasIlxId ILX:0382490 .
 
-DICOM:0022_0039 ilxtr:hasIlxId ilx:0382369 .
+DICOM:0022_0039 ilxtr:hasIlxId ILX:0382369 .
 
-DICOM:0022_0041 ilxtr:hasIlxId ilx:0381826 .
+DICOM:0022_0041 ilxtr:hasIlxId ILX:0381826 .
 
-DICOM:0022_0042 ilxtr:hasIlxId ilx:0381472 .
+DICOM:0022_0042 ilxtr:hasIlxId ILX:0381472 .
 
-DICOM:0022_0048 ilxtr:hasIlxId ilx:0382626 .
+DICOM:0022_0048 ilxtr:hasIlxId ILX:0382626 .
 
-DICOM:0022_0049 ilxtr:hasIlxId ilx:0381488 .
+DICOM:0022_0049 ilxtr:hasIlxId ILX:0381488 .
 
-DICOM:0022_0055 ilxtr:hasIlxId ilx:0383100 .
+DICOM:0022_0055 ilxtr:hasIlxId ILX:0383100 .
 
-DICOM:0022_0056 ilxtr:hasIlxId ilx:0383019 .
+DICOM:0022_0056 ilxtr:hasIlxId ILX:0383019 .
 
-DICOM:0022_0057 ilxtr:hasIlxId ilx:0381450 .
+DICOM:0022_0057 ilxtr:hasIlxId ILX:0381450 .
 
-DICOM:0022_0058 ilxtr:hasIlxId ilx:0381864 .
+DICOM:0022_0058 ilxtr:hasIlxId ILX:0381864 .
 
-DICOM:0022_1007 ilxtr:hasIlxId ilx:0382146 .
+DICOM:0022_1007 ilxtr:hasIlxId ILX:0382146 .
 
-DICOM:0022_1008 ilxtr:hasIlxId ilx:0381482 .
+DICOM:0022_1008 ilxtr:hasIlxId ILX:0381482 .
 
-DICOM:0022_1009 ilxtr:hasIlxId ilx:0382661 .
+DICOM:0022_1009 ilxtr:hasIlxId ILX:0382661 .
 
-DICOM:0022_1010 ilxtr:hasIlxId ilx:0382082 .
+DICOM:0022_1010 ilxtr:hasIlxId ILX:0382082 .
 
-DICOM:0022_1012 ilxtr:hasIlxId ilx:0383012 .
+DICOM:0022_1012 ilxtr:hasIlxId ILX:0383012 .
 
-DICOM:0022_1019 ilxtr:hasIlxId ilx:0382521 .
+DICOM:0022_1019 ilxtr:hasIlxId ILX:0382521 .
 
-DICOM:0022_1024 ilxtr:hasIlxId ilx:0383108 .
+DICOM:0022_1024 ilxtr:hasIlxId ILX:0383108 .
 
-DICOM:0022_1025 ilxtr:hasIlxId ilx:0383022 .
+DICOM:0022_1025 ilxtr:hasIlxId ILX:0383022 .
 
-DICOM:0022_1028 ilxtr:hasIlxId ilx:0383070 .
+DICOM:0022_1028 ilxtr:hasIlxId ILX:0383070 .
 
-DICOM:0022_1029 ilxtr:hasIlxId ilx:0382581 .
+DICOM:0022_1029 ilxtr:hasIlxId ILX:0382581 .
 
-DICOM:0022_1033 ilxtr:hasIlxId ilx:0382479 .
+DICOM:0022_1033 ilxtr:hasIlxId ILX:0382479 .
 
-DICOM:0022_1035 ilxtr:hasIlxId ilx:0382546 .
+DICOM:0022_1035 ilxtr:hasIlxId ILX:0382546 .
 
-DICOM:0022_1037 ilxtr:hasIlxId ilx:0382201 .
+DICOM:0022_1037 ilxtr:hasIlxId ILX:0382201 .
 
-DICOM:0022_1039 ilxtr:hasIlxId ilx:0382891 .
+DICOM:0022_1039 ilxtr:hasIlxId ILX:0382891 .
 
-DICOM:0022_1040 ilxtr:hasIlxId ilx:0382031 .
+DICOM:0022_1040 ilxtr:hasIlxId ILX:0382031 .
 
-DICOM:0022_1044 ilxtr:hasIlxId ilx:0382254 .
+DICOM:0022_1044 ilxtr:hasIlxId ILX:0382254 .
 
-DICOM:0022_1050 ilxtr:hasIlxId ilx:0382944 .
+DICOM:0022_1050 ilxtr:hasIlxId ILX:0382944 .
 
-DICOM:0022_1053 ilxtr:hasIlxId ilx:0381888 .
+DICOM:0022_1053 ilxtr:hasIlxId ILX:0381888 .
 
-DICOM:0022_1054 ilxtr:hasIlxId ilx:0382726 .
+DICOM:0022_1054 ilxtr:hasIlxId ILX:0382726 .
 
-DICOM:0022_1059 ilxtr:hasIlxId ilx:0382504 .
+DICOM:0022_1059 ilxtr:hasIlxId ILX:0382504 .
 
-DICOM:0022_1065 ilxtr:hasIlxId ilx:0381823 .
+DICOM:0022_1065 ilxtr:hasIlxId ILX:0381823 .
 
-DICOM:0022_1066 ilxtr:hasIlxId ilx:0381867 .
+DICOM:0022_1066 ilxtr:hasIlxId ILX:0381867 .
 
-DICOM:0022_1090 ilxtr:hasIlxId ilx:0383096 .
+DICOM:0022_1090 ilxtr:hasIlxId ILX:0383096 .
 
-DICOM:0022_1092 ilxtr:hasIlxId ilx:0382303 .
+DICOM:0022_1092 ilxtr:hasIlxId ILX:0382303 .
 
-DICOM:0022_1093 ilxtr:hasIlxId ilx:0382675 .
+DICOM:0022_1093 ilxtr:hasIlxId ILX:0382675 .
 
-DICOM:0022_1095 ilxtr:hasIlxId ilx:0381453 .
+DICOM:0022_1095 ilxtr:hasIlxId ILX:0381453 .
 
-DICOM:0022_1096 ilxtr:hasIlxId ilx:0381865 .
+DICOM:0022_1096 ilxtr:hasIlxId ILX:0381865 .
 
-DICOM:0022_1097 ilxtr:hasIlxId ilx:0382176 .
+DICOM:0022_1097 ilxtr:hasIlxId ILX:0382176 .
 
-DICOM:0022_1101 ilxtr:hasIlxId ilx:0382481 .
+DICOM:0022_1101 ilxtr:hasIlxId ILX:0382481 .
 
-DICOM:0022_1103 ilxtr:hasIlxId ilx:0381858 .
+DICOM:0022_1103 ilxtr:hasIlxId ILX:0381858 .
 
-DICOM:0022_1121 ilxtr:hasIlxId ilx:0383170 .
+DICOM:0022_1121 ilxtr:hasIlxId ILX:0383170 .
 
-DICOM:0022_1122 ilxtr:hasIlxId ilx:0382686 .
+DICOM:0022_1122 ilxtr:hasIlxId ILX:0382686 .
 
-DICOM:0022_1125 ilxtr:hasIlxId ilx:0382941 .
+DICOM:0022_1125 ilxtr:hasIlxId ILX:0382941 .
 
-DICOM:0022_1127 ilxtr:hasIlxId ilx:0382457 .
+DICOM:0022_1127 ilxtr:hasIlxId ILX:0382457 .
 
-DICOM:0022_1128 ilxtr:hasIlxId ilx:0382644 .
+DICOM:0022_1128 ilxtr:hasIlxId ILX:0382644 .
 
-DICOM:0022_1130 ilxtr:hasIlxId ilx:0382286 .
+DICOM:0022_1130 ilxtr:hasIlxId ILX:0382286 .
 
-DICOM:0022_1131 ilxtr:hasIlxId ilx:0382851 .
+DICOM:0022_1131 ilxtr:hasIlxId ILX:0382851 .
 
-DICOM:0022_1132 ilxtr:hasIlxId ilx:0381670 .
+DICOM:0022_1132 ilxtr:hasIlxId ILX:0381670 .
 
-DICOM:0022_1133 ilxtr:hasIlxId ilx:0382489 .
+DICOM:0022_1133 ilxtr:hasIlxId ILX:0382489 .
 
-DICOM:0022_1134 ilxtr:hasIlxId ilx:0382898 .
+DICOM:0022_1134 ilxtr:hasIlxId ILX:0382898 .
 
-DICOM:0022_1135 ilxtr:hasIlxId ilx:0381886 .
+DICOM:0022_1135 ilxtr:hasIlxId ILX:0381886 .
 
-DICOM:0022_1140 ilxtr:hasIlxId ilx:0383113 .
+DICOM:0022_1140 ilxtr:hasIlxId ILX:0383113 .
 
-DICOM:0022_1150 ilxtr:hasIlxId ilx:0381457 .
+DICOM:0022_1150 ilxtr:hasIlxId ILX:0381457 .
 
-DICOM:0022_1155 ilxtr:hasIlxId ilx:0381787 .
+DICOM:0022_1155 ilxtr:hasIlxId ILX:0381787 .
 
-DICOM:0022_1159 ilxtr:hasIlxId ilx:0382853 .
+DICOM:0022_1159 ilxtr:hasIlxId ILX:0382853 .
 
-DICOM:0022_1210 ilxtr:hasIlxId ilx:0381577 .
+DICOM:0022_1210 ilxtr:hasIlxId ILX:0381577 .
 
-DICOM:0022_1211 ilxtr:hasIlxId ilx:0382528 .
+DICOM:0022_1211 ilxtr:hasIlxId ILX:0382528 .
 
-DICOM:0022_1212 ilxtr:hasIlxId ilx:0382145 .
+DICOM:0022_1212 ilxtr:hasIlxId ILX:0382145 .
 
-DICOM:0022_1220 ilxtr:hasIlxId ilx:0381916 .
+DICOM:0022_1220 ilxtr:hasIlxId ILX:0381916 .
 
-DICOM:0022_1225 ilxtr:hasIlxId ilx:0381587 .
+DICOM:0022_1225 ilxtr:hasIlxId ILX:0381587 .
 
-DICOM:0022_1230 ilxtr:hasIlxId ilx:0383069 .
+DICOM:0022_1230 ilxtr:hasIlxId ILX:0383069 .
 
-DICOM:0022_1250 ilxtr:hasIlxId ilx:0381967 .
+DICOM:0022_1250 ilxtr:hasIlxId ILX:0381967 .
 
-DICOM:0022_1255 ilxtr:hasIlxId ilx:0381697 .
+DICOM:0022_1255 ilxtr:hasIlxId ILX:0381697 .
 
-DICOM:0022_1257 ilxtr:hasIlxId ilx:0382571 .
+DICOM:0022_1257 ilxtr:hasIlxId ILX:0382571 .
 
-DICOM:0022_1262 ilxtr:hasIlxId ilx:0381640 .
+DICOM:0022_1262 ilxtr:hasIlxId ILX:0381640 .
 
-DICOM:0022_1300 ilxtr:hasIlxId ilx:0383167 .
+DICOM:0022_1300 ilxtr:hasIlxId ILX:0383167 .
 
-DICOM:0022_1310 ilxtr:hasIlxId ilx:0382084 .
+DICOM:0022_1310 ilxtr:hasIlxId ILX:0382084 .
 
-DICOM:0022_1330 ilxtr:hasIlxId ilx:0382034 .
+DICOM:0022_1330 ilxtr:hasIlxId ILX:0382034 .
 
-DICOM:0022_1415 ilxtr:hasIlxId ilx:0382769 .
+DICOM:0022_1415 ilxtr:hasIlxId ILX:0382769 .
 
-DICOM:0022_1420 ilxtr:hasIlxId ilx:0382193 .
+DICOM:0022_1420 ilxtr:hasIlxId ILX:0382193 .
 
-DICOM:0022_1423 ilxtr:hasIlxId ilx:0381699 .
+DICOM:0022_1423 ilxtr:hasIlxId ILX:0381699 .
 
-DICOM:0022_1436 ilxtr:hasIlxId ilx:0382711 .
+DICOM:0022_1436 ilxtr:hasIlxId ILX:0382711 .
 
-DICOM:0022_1443 ilxtr:hasIlxId ilx:0381530 .
+DICOM:0022_1443 ilxtr:hasIlxId ILX:0381530 .
 
-DICOM:0022_1445 ilxtr:hasIlxId ilx:0382650 .
+DICOM:0022_1445 ilxtr:hasIlxId ILX:0382650 .
 
-DICOM:0022_1450 ilxtr:hasIlxId ilx:0382768 .
+DICOM:0022_1450 ilxtr:hasIlxId ILX:0382768 .
 
-DICOM:0022_1452 ilxtr:hasIlxId ilx:0382786 .
+DICOM:0022_1452 ilxtr:hasIlxId ILX:0382786 .
 
-DICOM:0022_1454 ilxtr:hasIlxId ilx:0381580 .
+DICOM:0022_1454 ilxtr:hasIlxId ILX:0381580 .
 
-DICOM:0022_1458 ilxtr:hasIlxId ilx:0381827 .
+DICOM:0022_1458 ilxtr:hasIlxId ILX:0381827 .
 
-DICOM:0022_1460 ilxtr:hasIlxId ilx:0382171 .
+DICOM:0022_1460 ilxtr:hasIlxId ILX:0382171 .
 
-DICOM:0022_1463 ilxtr:hasIlxId ilx:0381573 .
+DICOM:0022_1463 ilxtr:hasIlxId ILX:0381573 .
 
-DICOM:0022_1465 ilxtr:hasIlxId ilx:0382873 .
+DICOM:0022_1465 ilxtr:hasIlxId ILX:0382873 .
 
-DICOM:0022_1466 ilxtr:hasIlxId ilx:0382816 .
+DICOM:0022_1466 ilxtr:hasIlxId ILX:0382816 .
 
-DICOM:0022_1467 ilxtr:hasIlxId ilx:0382740 .
+DICOM:0022_1467 ilxtr:hasIlxId ILX:0382740 .
 
-DICOM:0022_1468 ilxtr:hasIlxId ilx:0382159 .
+DICOM:0022_1468 ilxtr:hasIlxId ILX:0382159 .
 
-DICOM:0022_1470 ilxtr:hasIlxId ilx:0381759 .
+DICOM:0022_1470 ilxtr:hasIlxId ILX:0381759 .
 
-DICOM:0022_1472 ilxtr:hasIlxId ilx:0382446 .
+DICOM:0022_1472 ilxtr:hasIlxId ILX:0382446 .
 
-DICOM:0022_1512 ilxtr:hasIlxId ilx:0381641 .
+DICOM:0022_1512 ilxtr:hasIlxId ILX:0381641 .
 
-DICOM:0022_1513 ilxtr:hasIlxId ilx:0383086 .
+DICOM:0022_1513 ilxtr:hasIlxId ILX:0383086 .
 
-DICOM:0022_1515 ilxtr:hasIlxId ilx:0382985 .
+DICOM:0022_1515 ilxtr:hasIlxId ILX:0382985 .
 
-DICOM:0022_1517 ilxtr:hasIlxId ilx:0382849 .
+DICOM:0022_1517 ilxtr:hasIlxId ILX:0382849 .
 
-DICOM:0022_1518 ilxtr:hasIlxId ilx:0381971 .
+DICOM:0022_1518 ilxtr:hasIlxId ILX:0381971 .
 
-DICOM:0022_1525 ilxtr:hasIlxId ilx:0383119 .
+DICOM:0022_1525 ilxtr:hasIlxId ILX:0383119 .
 
-DICOM:0022_1526 ilxtr:hasIlxId ilx:0381645 .
+DICOM:0022_1526 ilxtr:hasIlxId ILX:0381645 .
 
-DICOM:0022_1527 ilxtr:hasIlxId ilx:0381850 .
+DICOM:0022_1527 ilxtr:hasIlxId ILX:0381850 .
 
-DICOM:0022_1528 ilxtr:hasIlxId ilx:0381998 .
+DICOM:0022_1528 ilxtr:hasIlxId ILX:0381998 .
 
-DICOM:0022_1529 ilxtr:hasIlxId ilx:0382350 .
+DICOM:0022_1529 ilxtr:hasIlxId ILX:0382350 .
 
-DICOM:0022_1530 ilxtr:hasIlxId ilx:0382664 .
+DICOM:0022_1530 ilxtr:hasIlxId ILX:0382664 .
 
-DICOM:0024_0010 ilxtr:hasIlxId ilx:0381710 .
+DICOM:0024_0010 ilxtr:hasIlxId ILX:0381710 .
 
-DICOM:0024_0011 ilxtr:hasIlxId ilx:0381489 .
+DICOM:0024_0011 ilxtr:hasIlxId ILX:0381489 .
 
-DICOM:0024_0012 ilxtr:hasIlxId ilx:0382342 .
+DICOM:0024_0012 ilxtr:hasIlxId ILX:0382342 .
 
-DICOM:0024_0016 ilxtr:hasIlxId ilx:0382519 .
+DICOM:0024_0016 ilxtr:hasIlxId ILX:0382519 .
 
-DICOM:0024_0018 ilxtr:hasIlxId ilx:0381543 .
+DICOM:0024_0018 ilxtr:hasIlxId ILX:0381543 .
 
-DICOM:0024_0020 ilxtr:hasIlxId ilx:0382833 .
+DICOM:0024_0020 ilxtr:hasIlxId ILX:0382833 .
 
-DICOM:0024_0021 ilxtr:hasIlxId ilx:0381959 .
+DICOM:0024_0021 ilxtr:hasIlxId ILX:0381959 .
 
-DICOM:0024_0024 ilxtr:hasIlxId ilx:0382701 .
+DICOM:0024_0024 ilxtr:hasIlxId ILX:0382701 .
 
-DICOM:0024_0025 ilxtr:hasIlxId ilx:0383011 .
+DICOM:0024_0025 ilxtr:hasIlxId ILX:0383011 .
 
-DICOM:0024_0028 ilxtr:hasIlxId ilx:0382183 .
+DICOM:0024_0028 ilxtr:hasIlxId ILX:0382183 .
 
-DICOM:0024_0032 ilxtr:hasIlxId ilx:0382022 .
+DICOM:0024_0032 ilxtr:hasIlxId ILX:0382022 .
 
-DICOM:0024_0033 ilxtr:hasIlxId ilx:0382225 .
+DICOM:0024_0033 ilxtr:hasIlxId ILX:0382225 .
 
-DICOM:0024_0034 ilxtr:hasIlxId ilx:0381723 .
+DICOM:0024_0034 ilxtr:hasIlxId ILX:0381723 .
 
-DICOM:0024_0035 ilxtr:hasIlxId ilx:0382321 .
+DICOM:0024_0035 ilxtr:hasIlxId ILX:0382321 .
 
-DICOM:0024_0036 ilxtr:hasIlxId ilx:0382015 .
+DICOM:0024_0036 ilxtr:hasIlxId ILX:0382015 .
 
-DICOM:0024_0037 ilxtr:hasIlxId ilx:0381531 .
+DICOM:0024_0037 ilxtr:hasIlxId ILX:0381531 .
 
-DICOM:0024_0038 ilxtr:hasIlxId ilx:0382214 .
+DICOM:0024_0038 ilxtr:hasIlxId ILX:0382214 .
 
-DICOM:0024_0039 ilxtr:hasIlxId ilx:0381857 .
+DICOM:0024_0039 ilxtr:hasIlxId ILX:0381857 .
 
-DICOM:0024_0040 ilxtr:hasIlxId ilx:0382404 .
+DICOM:0024_0040 ilxtr:hasIlxId ILX:0382404 .
 
-DICOM:0024_0042 ilxtr:hasIlxId ilx:0381977 .
+DICOM:0024_0042 ilxtr:hasIlxId ILX:0381977 .
 
-DICOM:0024_0044 ilxtr:hasIlxId ilx:0382918 .
+DICOM:0024_0044 ilxtr:hasIlxId ILX:0382918 .
 
-DICOM:0024_0045 ilxtr:hasIlxId ilx:0382010 .
+DICOM:0024_0045 ilxtr:hasIlxId ILX:0382010 .
 
-DICOM:0024_0046 ilxtr:hasIlxId ilx:0382062 .
+DICOM:0024_0046 ilxtr:hasIlxId ILX:0382062 .
 
-DICOM:0024_0048 ilxtr:hasIlxId ilx:0381800 .
+DICOM:0024_0048 ilxtr:hasIlxId ILX:0381800 .
 
-DICOM:0024_0050 ilxtr:hasIlxId ilx:0381830 .
+DICOM:0024_0050 ilxtr:hasIlxId ILX:0381830 .
 
-DICOM:0024_0051 ilxtr:hasIlxId ilx:0381992 .
+DICOM:0024_0051 ilxtr:hasIlxId ILX:0381992 .
 
-DICOM:0024_0052 ilxtr:hasIlxId ilx:0381619 .
+DICOM:0024_0052 ilxtr:hasIlxId ILX:0381619 .
 
-DICOM:0024_0053 ilxtr:hasIlxId ilx:0382038 .
+DICOM:0024_0053 ilxtr:hasIlxId ILX:0382038 .
 
-DICOM:0024_0054 ilxtr:hasIlxId ilx:0382884 .
+DICOM:0024_0054 ilxtr:hasIlxId ILX:0382884 .
 
-DICOM:0024_0055 ilxtr:hasIlxId ilx:0382341 .
+DICOM:0024_0055 ilxtr:hasIlxId ILX:0382341 .
 
-DICOM:0024_0056 ilxtr:hasIlxId ilx:0382933 .
+DICOM:0024_0056 ilxtr:hasIlxId ILX:0382933 .
 
-DICOM:0024_0057 ilxtr:hasIlxId ilx:0381936 .
+DICOM:0024_0057 ilxtr:hasIlxId ILX:0381936 .
 
-DICOM:0024_0058 ilxtr:hasIlxId ilx:0383166 .
+DICOM:0024_0058 ilxtr:hasIlxId ILX:0383166 .
 
-DICOM:0024_0059 ilxtr:hasIlxId ilx:0381643 .
+DICOM:0024_0059 ilxtr:hasIlxId ILX:0381643 .
 
-DICOM:0024_0060 ilxtr:hasIlxId ilx:0382294 .
+DICOM:0024_0060 ilxtr:hasIlxId ILX:0382294 .
 
-DICOM:0024_0061 ilxtr:hasIlxId ilx:0382211 .
+DICOM:0024_0061 ilxtr:hasIlxId ILX:0382211 .
 
-DICOM:0024_0062 ilxtr:hasIlxId ilx:0381772 .
+DICOM:0024_0062 ilxtr:hasIlxId ILX:0381772 .
 
-DICOM:0024_0063 ilxtr:hasIlxId ilx:0383105 .
+DICOM:0024_0063 ilxtr:hasIlxId ILX:0383105 .
 
-DICOM:0024_0064 ilxtr:hasIlxId ilx:0382401 .
+DICOM:0024_0064 ilxtr:hasIlxId ILX:0382401 .
 
-DICOM:0024_0065 ilxtr:hasIlxId ilx:0381882 .
+DICOM:0024_0065 ilxtr:hasIlxId ILX:0381882 .
 
-DICOM:0024_0066 ilxtr:hasIlxId ilx:0382330 .
+DICOM:0024_0066 ilxtr:hasIlxId ILX:0382330 .
 
-DICOM:0024_0067 ilxtr:hasIlxId ilx:0382667 .
+DICOM:0024_0067 ilxtr:hasIlxId ILX:0382667 .
 
-DICOM:0024_0068 ilxtr:hasIlxId ilx:0382239 .
+DICOM:0024_0068 ilxtr:hasIlxId ILX:0382239 .
 
-DICOM:0024_0069 ilxtr:hasIlxId ilx:0382737 .
+DICOM:0024_0069 ilxtr:hasIlxId ILX:0382737 .
 
-DICOM:0024_0070 ilxtr:hasIlxId ilx:0381847 .
+DICOM:0024_0070 ilxtr:hasIlxId ILX:0381847 .
 
-DICOM:0024_0071 ilxtr:hasIlxId ilx:0382953 .
+DICOM:0024_0071 ilxtr:hasIlxId ILX:0382953 .
 
-DICOM:0024_0072 ilxtr:hasIlxId ilx:0382556 .
+DICOM:0024_0072 ilxtr:hasIlxId ILX:0382556 .
 
-DICOM:0024_0073 ilxtr:hasIlxId ilx:0382304 .
+DICOM:0024_0073 ilxtr:hasIlxId ILX:0382304 .
 
-DICOM:0024_0074 ilxtr:hasIlxId ilx:0383051 .
+DICOM:0024_0074 ilxtr:hasIlxId ILX:0383051 .
 
-DICOM:0024_0075 ilxtr:hasIlxId ilx:0381749 .
+DICOM:0024_0075 ilxtr:hasIlxId ILX:0381749 .
 
-DICOM:0024_0076 ilxtr:hasIlxId ilx:0381995 .
+DICOM:0024_0076 ilxtr:hasIlxId ILX:0381995 .
 
-DICOM:0024_0077 ilxtr:hasIlxId ilx:0382493 .
+DICOM:0024_0077 ilxtr:hasIlxId ILX:0382493 .
 
-DICOM:0024_0078 ilxtr:hasIlxId ilx:0381660 .
+DICOM:0024_0078 ilxtr:hasIlxId ILX:0381660 .
 
-DICOM:0024_0079 ilxtr:hasIlxId ilx:0381542 .
+DICOM:0024_0079 ilxtr:hasIlxId ILX:0381542 .
 
-DICOM:0024_0080 ilxtr:hasIlxId ilx:0382172 .
+DICOM:0024_0080 ilxtr:hasIlxId ILX:0382172 .
 
-DICOM:0024_0081 ilxtr:hasIlxId ilx:0381988 .
+DICOM:0024_0081 ilxtr:hasIlxId ILX:0381988 .
 
-DICOM:0024_0083 ilxtr:hasIlxId ilx:0382830 .
+DICOM:0024_0083 ilxtr:hasIlxId ILX:0382830 .
 
-DICOM:0024_0085 ilxtr:hasIlxId ilx:0382999 .
+DICOM:0024_0085 ilxtr:hasIlxId ILX:0382999 .
 
-DICOM:0024_0086 ilxtr:hasIlxId ilx:0382307 .
+DICOM:0024_0086 ilxtr:hasIlxId ILX:0382307 .
 
-DICOM:0024_0087 ilxtr:hasIlxId ilx:0381861 .
+DICOM:0024_0087 ilxtr:hasIlxId ILX:0381861 .
 
-DICOM:0024_0088 ilxtr:hasIlxId ilx:0382158 .
+DICOM:0024_0088 ilxtr:hasIlxId ILX:0382158 .
 
-DICOM:0024_0089 ilxtr:hasIlxId ilx:0382920 .
+DICOM:0024_0089 ilxtr:hasIlxId ILX:0382920 .
 
-DICOM:0024_0090 ilxtr:hasIlxId ilx:0381611 .
+DICOM:0024_0090 ilxtr:hasIlxId ILX:0381611 .
 
-DICOM:0024_0091 ilxtr:hasIlxId ilx:0381532 .
+DICOM:0024_0091 ilxtr:hasIlxId ILX:0381532 .
 
-DICOM:0024_0092 ilxtr:hasIlxId ilx:0381628 .
+DICOM:0024_0092 ilxtr:hasIlxId ILX:0381628 .
 
-DICOM:0024_0093 ilxtr:hasIlxId ilx:0381603 .
+DICOM:0024_0093 ilxtr:hasIlxId ILX:0381603 .
 
-DICOM:0024_0094 ilxtr:hasIlxId ilx:0381901 .
+DICOM:0024_0094 ilxtr:hasIlxId ILX:0381901 .
 
-DICOM:0024_0095 ilxtr:hasIlxId ilx:0382382 .
+DICOM:0024_0095 ilxtr:hasIlxId ILX:0382382 .
 
-DICOM:0024_0096 ilxtr:hasIlxId ilx:0382009 .
+DICOM:0024_0096 ilxtr:hasIlxId ILX:0382009 .
 
-DICOM:0024_0097 ilxtr:hasIlxId ilx:0382076 .
+DICOM:0024_0097 ilxtr:hasIlxId ILX:0382076 .
 
-DICOM:0024_0098 ilxtr:hasIlxId ilx:0381902 .
+DICOM:0024_0098 ilxtr:hasIlxId ILX:0381902 .
 
-DICOM:0024_0100 ilxtr:hasIlxId ilx:0382197 .
+DICOM:0024_0100 ilxtr:hasIlxId ILX:0382197 .
 
-DICOM:0024_0102 ilxtr:hasIlxId ilx:0381873 .
+DICOM:0024_0102 ilxtr:hasIlxId ILX:0381873 .
 
-DICOM:0024_0103 ilxtr:hasIlxId ilx:0382549 .
+DICOM:0024_0103 ilxtr:hasIlxId ILX:0382549 .
 
-DICOM:0024_0104 ilxtr:hasIlxId ilx:0382807 .
+DICOM:0024_0104 ilxtr:hasIlxId ILX:0382807 .
 
-DICOM:0024_0105 ilxtr:hasIlxId ilx:0381693 .
+DICOM:0024_0105 ilxtr:hasIlxId ILX:0381693 .
 
-DICOM:0024_0106 ilxtr:hasIlxId ilx:0382206 .
+DICOM:0024_0106 ilxtr:hasIlxId ILX:0382206 .
 
-DICOM:0024_0107 ilxtr:hasIlxId ilx:0381509 .
+DICOM:0024_0107 ilxtr:hasIlxId ILX:0381509 .
 
-DICOM:0024_0108 ilxtr:hasIlxId ilx:0381674 .
+DICOM:0024_0108 ilxtr:hasIlxId ILX:0381674 .
 
-DICOM:0024_0110 ilxtr:hasIlxId ilx:0382693 .
+DICOM:0024_0110 ilxtr:hasIlxId ILX:0382693 .
 
-DICOM:0024_0112 ilxtr:hasIlxId ilx:0382149 .
+DICOM:0024_0112 ilxtr:hasIlxId ILX:0382149 .
 
-DICOM:0024_0113 ilxtr:hasIlxId ilx:0381819 .
+DICOM:0024_0113 ilxtr:hasIlxId ILX:0381819 .
 
-DICOM:0024_0114 ilxtr:hasIlxId ilx:0382272 .
+DICOM:0024_0114 ilxtr:hasIlxId ILX:0382272 .
 
-DICOM:0024_0115 ilxtr:hasIlxId ilx:0382094 .
+DICOM:0024_0115 ilxtr:hasIlxId ILX:0382094 .
 
-DICOM:0024_0117 ilxtr:hasIlxId ilx:0382270 .
+DICOM:0024_0117 ilxtr:hasIlxId ILX:0382270 .
 
-DICOM:0024_0118 ilxtr:hasIlxId ilx:0382104 .
+DICOM:0024_0118 ilxtr:hasIlxId ILX:0382104 .
 
-DICOM:0024_0120 ilxtr:hasIlxId ilx:0382998 .
+DICOM:0024_0120 ilxtr:hasIlxId ILX:0382998 .
 
-DICOM:0024_0122 ilxtr:hasIlxId ilx:0382822 .
+DICOM:0024_0122 ilxtr:hasIlxId ILX:0382822 .
 
-DICOM:0024_0124 ilxtr:hasIlxId ilx:0382423 .
+DICOM:0024_0124 ilxtr:hasIlxId ILX:0382423 .
 
-DICOM:0024_0126 ilxtr:hasIlxId ilx:0383077 .
+DICOM:0024_0126 ilxtr:hasIlxId ILX:0383077 .
 
-DICOM:0024_0202 ilxtr:hasIlxId ilx:0383059 .
+DICOM:0024_0202 ilxtr:hasIlxId ILX:0383059 .
 
-DICOM:0024_0306 ilxtr:hasIlxId ilx:0382646 .
+DICOM:0024_0306 ilxtr:hasIlxId ILX:0382646 .
 
-DICOM:0024_0307 ilxtr:hasIlxId ilx:0381502 .
+DICOM:0024_0307 ilxtr:hasIlxId ILX:0381502 .
 
-DICOM:0024_0308 ilxtr:hasIlxId ilx:0382555 .
+DICOM:0024_0308 ilxtr:hasIlxId ILX:0382555 .
 
-DICOM:0024_0309 ilxtr:hasIlxId ilx:0383018 .
+DICOM:0024_0309 ilxtr:hasIlxId ILX:0383018 .
 
-DICOM:0024_0317 ilxtr:hasIlxId ilx:0382052 .
+DICOM:0024_0317 ilxtr:hasIlxId ILX:0382052 .
 
-DICOM:0024_0320 ilxtr:hasIlxId ilx:0381462 .
+DICOM:0024_0320 ilxtr:hasIlxId ILX:0381462 .
 
-DICOM:0024_0325 ilxtr:hasIlxId ilx:0382190 .
+DICOM:0024_0325 ilxtr:hasIlxId ILX:0382190 .
 
-DICOM:0024_0338 ilxtr:hasIlxId ilx:0381754 .
+DICOM:0024_0338 ilxtr:hasIlxId ILX:0381754 .
 
-DICOM:0024_0341 ilxtr:hasIlxId ilx:0382030 .
+DICOM:0024_0341 ilxtr:hasIlxId ILX:0382030 .
 
-DICOM:0024_0344 ilxtr:hasIlxId ilx:0382744 .
+DICOM:0024_0344 ilxtr:hasIlxId ILX:0382744 .
 
-DICOM:0028_000A ilxtr:hasIlxId ilx:0104407 .
+DICOM:0028_000A ilxtr:hasIlxId ILX:0104407 .
 
-DICOM:0028_0A02 ilxtr:hasIlxId ilx:0381839 .
+DICOM:0028_0A02 ilxtr:hasIlxId ILX:0381839 .
 
-DICOM:0028_0A04 ilxtr:hasIlxId ilx:0382389 .
+DICOM:0028_0A04 ilxtr:hasIlxId ILX:0382389 .
 
-DICOM:0028_0002 ilxtr:hasIlxId ilx:0110331 .
+DICOM:0028_0002 ilxtr:hasIlxId ILX:0110331 .
 
-DICOM:0028_0003 ilxtr:hasIlxId ilx:0383177 .
+DICOM:0028_0003 ilxtr:hasIlxId ILX:0383177 .
 
-DICOM:0028_0004 ilxtr:hasIlxId ilx:0108836 .
+DICOM:0028_0004 ilxtr:hasIlxId ILX:0108836 .
 
-DICOM:0028_0006 ilxtr:hasIlxId ilx:0108965 .
+DICOM:0028_0006 ilxtr:hasIlxId ILX:0108965 .
 
-DICOM:0028_7FE0 ilxtr:hasIlxId ilx:0382053 .
+DICOM:0028_7FE0 ilxtr:hasIlxId ILX:0382053 .
 
-DICOM:0028_0008 ilxtr:hasIlxId ilx:0107823 .
+DICOM:0028_0008 ilxtr:hasIlxId ILX:0107823 .
 
-DICOM:0028_0009 ilxtr:hasIlxId ilx:0104408 .
+DICOM:0028_0009 ilxtr:hasIlxId ILX:0104408 .
 
-DICOM:0028_0010 ilxtr:hasIlxId ilx:0110238 .
+DICOM:0028_0010 ilxtr:hasIlxId ILX:0110238 .
 
-DICOM:0028_0011 ilxtr:hasIlxId ilx:0102393 .
+DICOM:0028_0011 ilxtr:hasIlxId ILX:0102393 .
 
-DICOM:0028_0014 ilxtr:hasIlxId ilx:0112151 .
+DICOM:0028_0014 ilxtr:hasIlxId ILX:0112151 .
 
-DICOM:0028_0030 ilxtr:hasIlxId ilx:0108956 .
+DICOM:0028_0030 ilxtr:hasIlxId ILX:0108956 .
 
-DICOM:0028_0031 ilxtr:hasIlxId ilx:0112751 .
+DICOM:0028_0031 ilxtr:hasIlxId ILX:0112751 .
 
-DICOM:0028_0032 ilxtr:hasIlxId ilx:0112750 .
+DICOM:0028_0032 ilxtr:hasIlxId ILX:0112750 .
 
-DICOM:0028_0034 ilxtr:hasIlxId ilx:0108942 .
+DICOM:0028_0034 ilxtr:hasIlxId ILX:0108942 .
 
-DICOM:0028_0051 ilxtr:hasIlxId ilx:0102564 .
+DICOM:0028_0051 ilxtr:hasIlxId ILX:0102564 .
 
-DICOM:0028_0100 ilxtr:hasIlxId ilx:0101321 .
+DICOM:0028_0100 ilxtr:hasIlxId ILX:0101321 .
 
-DICOM:0028_0101 ilxtr:hasIlxId ilx:0101322 .
+DICOM:0028_0101 ilxtr:hasIlxId ILX:0101322 .
 
-DICOM:0028_0102 ilxtr:hasIlxId ilx:0104992 .
+DICOM:0028_0102 ilxtr:hasIlxId ILX:0104992 .
 
-DICOM:0028_0103 ilxtr:hasIlxId ilx:0108955 .
+DICOM:0028_0103 ilxtr:hasIlxId ILX:0108955 .
 
-DICOM:0028_0106 ilxtr:hasIlxId ilx:0110690 .
+DICOM:0028_0106 ilxtr:hasIlxId ILX:0110690 .
 
-DICOM:0028_0107 ilxtr:hasIlxId ilx:0105995 .
+DICOM:0028_0107 ilxtr:hasIlxId ILX:0105995 .
 
-DICOM:0028_0108 ilxtr:hasIlxId ilx:0110691 .
+DICOM:0028_0108 ilxtr:hasIlxId ILX:0110691 .
 
-DICOM:0028_0109 ilxtr:hasIlxId ilx:0105997 .
+DICOM:0028_0109 ilxtr:hasIlxId ILX:0105997 .
 
-DICOM:0028_0120 ilxtr:hasIlxId ilx:0108954 .
+DICOM:0028_0120 ilxtr:hasIlxId ILX:0108954 .
 
-DICOM:0028_0121 ilxtr:hasIlxId ilx:0381722 .
+DICOM:0028_0121 ilxtr:hasIlxId ILX:0381722 .
 
-DICOM:0028_0122 ilxtr:hasIlxId ilx:0382823 .
+DICOM:0028_0122 ilxtr:hasIlxId ILX:0382823 .
 
-DICOM:0028_0123 ilxtr:hasIlxId ilx:0382126 .
+DICOM:0028_0123 ilxtr:hasIlxId ILX:0382126 .
 
-DICOM:0028_0124 ilxtr:hasIlxId ilx:0381695 .
+DICOM:0028_0124 ilxtr:hasIlxId ILX:0381695 .
 
-DICOM:0028_0125 ilxtr:hasIlxId ilx:0381875 .
+DICOM:0028_0125 ilxtr:hasIlxId ILX:0381875 .
 
-DICOM:0028_135A ilxtr:hasIlxId ilx:0381716 .
+DICOM:0028_135A ilxtr:hasIlxId ILX:0381716 .
 
-DICOM:0028_140B ilxtr:hasIlxId ilx:0383061 .
+DICOM:0028_140B ilxtr:hasIlxId ILX:0383061 .
 
-DICOM:0028_140C ilxtr:hasIlxId ilx:0382967 .
+DICOM:0028_140C ilxtr:hasIlxId ILX:0382967 .
 
-DICOM:0028_140D ilxtr:hasIlxId ilx:0382799 .
+DICOM:0028_140D ilxtr:hasIlxId ILX:0382799 .
 
-DICOM:0028_140E ilxtr:hasIlxId ilx:0382473 .
+DICOM:0028_140E ilxtr:hasIlxId ILX:0382473 .
 
-DICOM:0028_140F ilxtr:hasIlxId ilx:0382407 .
+DICOM:0028_140F ilxtr:hasIlxId ILX:0382407 .
 
-DICOM:0028_0300 ilxtr:hasIlxId ilx:0109575 .
+DICOM:0028_0300 ilxtr:hasIlxId ILX:0109575 .
 
-DICOM:0028_0301 ilxtr:hasIlxId ilx:0101500 .
+DICOM:0028_0301 ilxtr:hasIlxId ILX:0101500 .
 
-DICOM:0028_0302 ilxtr:hasIlxId ilx:0382377 .
+DICOM:0028_0302 ilxtr:hasIlxId ILX:0382377 .
 
-DICOM:0028_0303 ilxtr:hasIlxId ilx:0382154 .
+DICOM:0028_0303 ilxtr:hasIlxId ILX:0382154 .
 
-DICOM:0028_0304 ilxtr:hasIlxId ilx:0382665 .
+DICOM:0028_0304 ilxtr:hasIlxId ILX:0382665 .
 
-DICOM:0028_1040 ilxtr:hasIlxId ilx:0108951 .
+DICOM:0028_1040 ilxtr:hasIlxId ILX:0108951 .
 
-DICOM:0028_1041 ilxtr:hasIlxId ilx:0108952 .
+DICOM:0028_1041 ilxtr:hasIlxId ILX:0108952 .
 
-DICOM:0028_1050 ilxtr:hasIlxId ilx:0112646 .
+DICOM:0028_1050 ilxtr:hasIlxId ILX:0112646 .
 
-DICOM:0028_1051 ilxtr:hasIlxId ilx:0112648 .
+DICOM:0028_1051 ilxtr:hasIlxId ILX:0112648 .
 
-DICOM:0028_1052 ilxtr:hasIlxId ilx:0109949 .
+DICOM:0028_1052 ilxtr:hasIlxId ILX:0109949 .
 
-DICOM:0028_1053 ilxtr:hasIlxId ilx:0109950 .
+DICOM:0028_1053 ilxtr:hasIlxId ILX:0109950 .
 
-DICOM:0028_1054 ilxtr:hasIlxId ilx:0109951 .
+DICOM:0028_1054 ilxtr:hasIlxId ILX:0109951 .
 
-DICOM:0028_1055 ilxtr:hasIlxId ilx:0112647 .
+DICOM:0028_1055 ilxtr:hasIlxId ILX:0112647 .
 
-DICOM:0028_1056 ilxtr:hasIlxId ilx:0382809 .
+DICOM:0028_1056 ilxtr:hasIlxId ILX:0382809 .
 
-DICOM:0028_1090 ilxtr:hasIlxId ilx:0109699 .
+DICOM:0028_1090 ilxtr:hasIlxId ILX:0109699 .
 
-DICOM:0028_1101 ilxtr:hasIlxId ilx:0109725 .
+DICOM:0028_1101 ilxtr:hasIlxId ILX:0109725 .
 
-DICOM:0028_1102 ilxtr:hasIlxId ilx:0104778 .
+DICOM:0028_1102 ilxtr:hasIlxId ILX:0104778 .
 
-DICOM:0028_1103 ilxtr:hasIlxId ilx:0101366 .
+DICOM:0028_1103 ilxtr:hasIlxId ILX:0101366 .
 
-DICOM:0028_1104 ilxtr:hasIlxId ilx:0382608 .
+DICOM:0028_1104 ilxtr:hasIlxId ILX:0382608 .
 
-DICOM:0028_1199 ilxtr:hasIlxId ilx:0108374 .
+DICOM:0028_1199 ilxtr:hasIlxId ILX:0108374 .
 
-DICOM:0028_1201 ilxtr:hasIlxId ilx:0109724 .
+DICOM:0028_1201 ilxtr:hasIlxId ILX:0109724 .
 
-DICOM:0028_1202 ilxtr:hasIlxId ilx:0104777 .
+DICOM:0028_1202 ilxtr:hasIlxId ILX:0104777 .
 
-DICOM:0028_1203 ilxtr:hasIlxId ilx:0101365 .
+DICOM:0028_1203 ilxtr:hasIlxId ILX:0101365 .
 
-DICOM:0028_1204 ilxtr:hasIlxId ilx:0381646 .
+DICOM:0028_1204 ilxtr:hasIlxId ILX:0381646 .
 
-DICOM:0028_1221 ilxtr:hasIlxId ilx:0110460 .
+DICOM:0028_1221 ilxtr:hasIlxId ILX:0110460 .
 
-DICOM:0028_1222 ilxtr:hasIlxId ilx:0110458 .
+DICOM:0028_1222 ilxtr:hasIlxId ILX:0110458 .
 
-DICOM:0028_1223 ilxtr:hasIlxId ilx:0110457 .
+DICOM:0028_1223 ilxtr:hasIlxId ILX:0110457 .
 
-DICOM:0028_1224 ilxtr:hasIlxId ilx:0381506 .
+DICOM:0028_1224 ilxtr:hasIlxId ILX:0381506 .
 
-DICOM:0028_1300 ilxtr:hasIlxId ilx:0105302 .
+DICOM:0028_1300 ilxtr:hasIlxId ILX:0105302 .
 
-DICOM:0028_1350 ilxtr:hasIlxId ilx:0108551 .
+DICOM:0028_1350 ilxtr:hasIlxId ILX:0108551 .
 
-DICOM:0028_1351 ilxtr:hasIlxId ilx:0108552 .
+DICOM:0028_1351 ilxtr:hasIlxId ILX:0108552 .
 
-DICOM:0028_1352 ilxtr:hasIlxId ilx:0381933 .
+DICOM:0028_1352 ilxtr:hasIlxId ILX:0381933 .
 
-DICOM:0028_1401 ilxtr:hasIlxId ilx:0382762 .
+DICOM:0028_1401 ilxtr:hasIlxId ILX:0382762 .
 
-DICOM:0028_1402 ilxtr:hasIlxId ilx:0381498 .
+DICOM:0028_1402 ilxtr:hasIlxId ILX:0381498 .
 
-DICOM:0028_1403 ilxtr:hasIlxId ilx:0382429 .
+DICOM:0028_1403 ilxtr:hasIlxId ILX:0382429 .
 
-DICOM:0028_1404 ilxtr:hasIlxId ilx:0381598 .
+DICOM:0028_1404 ilxtr:hasIlxId ILX:0381598 .
 
-DICOM:0028_1405 ilxtr:hasIlxId ilx:0382942 .
+DICOM:0028_1405 ilxtr:hasIlxId ILX:0382942 .
 
-DICOM:0028_1406 ilxtr:hasIlxId ilx:0383071 .
+DICOM:0028_1406 ilxtr:hasIlxId ILX:0383071 .
 
-DICOM:0028_1407 ilxtr:hasIlxId ilx:0382391 .
+DICOM:0028_1407 ilxtr:hasIlxId ILX:0382391 .
 
-DICOM:0028_1408 ilxtr:hasIlxId ilx:0382383 .
+DICOM:0028_1408 ilxtr:hasIlxId ILX:0382383 .
 
-DICOM:0028_1410 ilxtr:hasIlxId ilx:0381470 .
+DICOM:0028_1410 ilxtr:hasIlxId ILX:0381470 .
 
-DICOM:0028_2000 ilxtr:hasIlxId ilx:0381592 .
+DICOM:0028_2000 ilxtr:hasIlxId ILX:0381592 .
 
-DICOM:0028_2002 ilxtr:hasIlxId ilx:0382102 .
+DICOM:0028_2002 ilxtr:hasIlxId ILX:0382102 .
 
-DICOM:0028_2110 ilxtr:hasIlxId ilx:0106369 .
+DICOM:0028_2110 ilxtr:hasIlxId ILX:0106369 .
 
-DICOM:0028_2112 ilxtr:hasIlxId ilx:0106371 .
+DICOM:0028_2112 ilxtr:hasIlxId ILX:0106371 .
 
-DICOM:0028_2114 ilxtr:hasIlxId ilx:0106370 .
+DICOM:0028_2114 ilxtr:hasIlxId ILX:0106370 .
 
-DICOM:0028_3000 ilxtr:hasIlxId ilx:0107046 .
+DICOM:0028_3000 ilxtr:hasIlxId ILX:0107046 .
 
-DICOM:0028_3002 ilxtr:hasIlxId ilx:0106412 .
+DICOM:0028_3002 ilxtr:hasIlxId ILX:0106412 .
 
-DICOM:0028_3003 ilxtr:hasIlxId ilx:0106413 .
+DICOM:0028_3003 ilxtr:hasIlxId ILX:0106413 .
 
-DICOM:0028_3004 ilxtr:hasIlxId ilx:0107047 .
+DICOM:0028_3004 ilxtr:hasIlxId ILX:0107047 .
 
-DICOM:0028_3006 ilxtr:hasIlxId ilx:0106411 .
+DICOM:0028_3006 ilxtr:hasIlxId ILX:0106411 .
 
-DICOM:0028_3010 ilxtr:hasIlxId ilx:0112537 .
+DICOM:0028_3010 ilxtr:hasIlxId ILX:0112537 .
 
-DICOM:0028_3110 ilxtr:hasIlxId ilx:0110718 .
+DICOM:0028_3110 ilxtr:hasIlxId ILX:0110718 .
 
-DICOM:0028_6010 ilxtr:hasIlxId ilx:0109926 .
+DICOM:0028_6010 ilxtr:hasIlxId ILX:0109926 .
 
-DICOM:0028_6020 ilxtr:hasIlxId ilx:0104411 .
+DICOM:0028_6020 ilxtr:hasIlxId ILX:0104411 .
 
-DICOM:0028_6022 ilxtr:hasIlxId ilx:0104412 .
+DICOM:0028_6022 ilxtr:hasIlxId ILX:0104412 .
 
-DICOM:0028_6023 ilxtr:hasIlxId ilx:0104413 .
+DICOM:0028_6023 ilxtr:hasIlxId ILX:0104413 .
 
-DICOM:0028_6040 ilxtr:hasIlxId ilx:0109588 .
+DICOM:0028_6040 ilxtr:hasIlxId ILX:0109588 .
 
-DICOM:0028_6100 ilxtr:hasIlxId ilx:0106542 .
+DICOM:0028_6100 ilxtr:hasIlxId ILX:0106542 .
 
-DICOM:0028_6101 ilxtr:hasIlxId ilx:0106540 .
+DICOM:0028_6101 ilxtr:hasIlxId ILX:0106540 .
 
-DICOM:0028_6102 ilxtr:hasIlxId ilx:0100852 .
+DICOM:0028_6102 ilxtr:hasIlxId ILX:0100852 .
 
-DICOM:0028_6110 ilxtr:hasIlxId ilx:0106539 .
+DICOM:0028_6110 ilxtr:hasIlxId ILX:0106539 .
 
-DICOM:0028_6112 ilxtr:hasIlxId ilx:0102534 .
+DICOM:0028_6112 ilxtr:hasIlxId ILX:0102534 .
 
-DICOM:0028_6114 ilxtr:hasIlxId ilx:0382075 .
+DICOM:0028_6114 ilxtr:hasIlxId ILX:0382075 .
 
-DICOM:0028_6120 ilxtr:hasIlxId ilx:0111740 .
+DICOM:0028_6120 ilxtr:hasIlxId ILX:0111740 .
 
-DICOM:0028_6190 ilxtr:hasIlxId ilx:0106541 .
+DICOM:0028_6190 ilxtr:hasIlxId ILX:0106541 .
 
-DICOM:0028_9001 ilxtr:hasIlxId ilx:0102828 .
+DICOM:0028_9001 ilxtr:hasIlxId ILX:0102828 .
 
-DICOM:0028_9002 ilxtr:hasIlxId ilx:0102827 .
+DICOM:0028_9002 ilxtr:hasIlxId ILX:0102827 .
 
-DICOM:0028_9003 ilxtr:hasIlxId ilx:0383185 .
+DICOM:0028_9003 ilxtr:hasIlxId ILX:0383185 .
 
-DICOM:0028_9099 ilxtr:hasIlxId ilx:0105996 .
+DICOM:0028_9099 ilxtr:hasIlxId ILX:0105996 .
 
-DICOM:0028_9108 ilxtr:hasIlxId ilx:0110620 .
+DICOM:0028_9108 ilxtr:hasIlxId ILX:0110620 .
 
-DICOM:0028_9110 ilxtr:hasIlxId ilx:0108953 .
+DICOM:0028_9110 ilxtr:hasIlxId ILX:0108953 .
 
-DICOM:0028_9132 ilxtr:hasIlxId ilx:0104424 .
+DICOM:0028_9132 ilxtr:hasIlxId ILX:0104424 .
 
-DICOM:0028_9145 ilxtr:hasIlxId ilx:0108958 .
+DICOM:0028_9145 ilxtr:hasIlxId ILX:0108958 .
 
-DICOM:0028_9235 ilxtr:hasIlxId ilx:0110621 .
+DICOM:0028_9235 ilxtr:hasIlxId ILX:0110621 .
 
-DICOM:0028_9411 ilxtr:hasIlxId ilx:0382166 .
+DICOM:0028_9411 ilxtr:hasIlxId ILX:0382166 .
 
-DICOM:0028_9415 ilxtr:hasIlxId ilx:0382202 .
+DICOM:0028_9415 ilxtr:hasIlxId ILX:0382202 .
 
-DICOM:0028_9416 ilxtr:hasIlxId ilx:0383143 .
+DICOM:0028_9416 ilxtr:hasIlxId ILX:0383143 .
 
-DICOM:0028_9422 ilxtr:hasIlxId ilx:0381562 .
+DICOM:0028_9422 ilxtr:hasIlxId ILX:0381562 .
 
-DICOM:0028_9443 ilxtr:hasIlxId ilx:0382001 .
+DICOM:0028_9443 ilxtr:hasIlxId ILX:0382001 .
 
-DICOM:0028_9444 ilxtr:hasIlxId ilx:0381843 .
+DICOM:0028_9444 ilxtr:hasIlxId ILX:0381843 .
 
-DICOM:0028_9445 ilxtr:hasIlxId ilx:0382375 .
+DICOM:0028_9445 ilxtr:hasIlxId ILX:0382375 .
 
-DICOM:0028_9446 ilxtr:hasIlxId ilx:0382639 .
+DICOM:0028_9446 ilxtr:hasIlxId ILX:0382639 .
 
-DICOM:0028_9454 ilxtr:hasIlxId ilx:0382604 .
+DICOM:0028_9454 ilxtr:hasIlxId ILX:0382604 .
 
-DICOM:0028_9474 ilxtr:hasIlxId ilx:0381934 .
+DICOM:0028_9474 ilxtr:hasIlxId ILX:0381934 .
 
-DICOM:0028_9478 ilxtr:hasIlxId ilx:0382133 .
+DICOM:0028_9478 ilxtr:hasIlxId ILX:0382133 .
 
-DICOM:0028_9501 ilxtr:hasIlxId ilx:0382273 .
+DICOM:0028_9501 ilxtr:hasIlxId ILX:0382273 .
 
-DICOM:0028_9502 ilxtr:hasIlxId ilx:0382862 .
+DICOM:0028_9502 ilxtr:hasIlxId ILX:0382862 .
 
-DICOM:0028_9503 ilxtr:hasIlxId ilx:0381550 .
+DICOM:0028_9503 ilxtr:hasIlxId ILX:0381550 .
 
-DICOM:0028_9505 ilxtr:hasIlxId ilx:0382059 .
+DICOM:0028_9505 ilxtr:hasIlxId ILX:0382059 .
 
-DICOM:0028_9506 ilxtr:hasIlxId ilx:0382194 .
+DICOM:0028_9506 ilxtr:hasIlxId ILX:0382194 .
 
-DICOM:0028_9507 ilxtr:hasIlxId ilx:0383124 .
+DICOM:0028_9507 ilxtr:hasIlxId ILX:0383124 .
 
-DICOM:0028_9520 ilxtr:hasIlxId ilx:0382778 .
+DICOM:0028_9520 ilxtr:hasIlxId ILX:0382778 .
 
-DICOM:0028_9537 ilxtr:hasIlxId ilx:0382262 .
+DICOM:0028_9537 ilxtr:hasIlxId ILX:0382262 .
 
-DICOM:0032_0032 ilxtr:hasIlxId ilx:0111146 .
+DICOM:0032_0032 ilxtr:hasIlxId ILX:0111146 .
 
-DICOM:0032_0033 ilxtr:hasIlxId ilx:0111147 .
+DICOM:0032_0033 ilxtr:hasIlxId ILX:0111147 .
 
-DICOM:0032_0034 ilxtr:hasIlxId ilx:0111143 .
+DICOM:0032_0034 ilxtr:hasIlxId ILX:0111143 .
 
-DICOM:0032_0035 ilxtr:hasIlxId ilx:0111144 .
+DICOM:0032_0035 ilxtr:hasIlxId ILX:0111144 .
 
-DICOM:0032_1000 ilxtr:hasIlxId ilx:0110401 .
+DICOM:0032_1000 ilxtr:hasIlxId ILX:0110401 .
 
-DICOM:0032_1001 ilxtr:hasIlxId ilx:0110402 .
+DICOM:0032_1001 ilxtr:hasIlxId ILX:0110402 .
 
-DICOM:0032_1010 ilxtr:hasIlxId ilx:0110403 .
+DICOM:0032_1010 ilxtr:hasIlxId ILX:0110403 .
 
-DICOM:0032_1011 ilxtr:hasIlxId ilx:0110404 .
+DICOM:0032_1011 ilxtr:hasIlxId ILX:0110404 .
 
-DICOM:0032_1020 ilxtr:hasIlxId ilx:0110400 .
+DICOM:0032_1020 ilxtr:hasIlxId ILX:0110400 .
 
-DICOM:0032_1021 ilxtr:hasIlxId ilx:0110399 .
+DICOM:0032_1021 ilxtr:hasIlxId ILX:0110399 .
 
-DICOM:0032_1030 ilxtr:hasIlxId ilx:0109679 .
+DICOM:0032_1030 ilxtr:hasIlxId ILX:0109679 .
 
-DICOM:0032_1031 ilxtr:hasIlxId ilx:0109945 .
+DICOM:0032_1031 ilxtr:hasIlxId ILX:0109945 .
 
-DICOM:0032_1032 ilxtr:hasIlxId ilx:0109944 .
+DICOM:0032_1032 ilxtr:hasIlxId ILX:0109944 .
 
-DICOM:0032_1033 ilxtr:hasIlxId ilx:0109946 .
+DICOM:0032_1033 ilxtr:hasIlxId ILX:0109946 .
 
-DICOM:0032_1034 ilxtr:hasIlxId ilx:0381563 .
+DICOM:0032_1034 ilxtr:hasIlxId ILX:0381563 .
 
-DICOM:0032_1040 ilxtr:hasIlxId ilx:0111133 .
+DICOM:0032_1040 ilxtr:hasIlxId ILX:0111133 .
 
-DICOM:0032_1041 ilxtr:hasIlxId ilx:0111134 .
+DICOM:0032_1041 ilxtr:hasIlxId ILX:0111134 .
 
-DICOM:0032_1050 ilxtr:hasIlxId ilx:0111135 .
+DICOM:0032_1050 ilxtr:hasIlxId ILX:0111135 .
 
-DICOM:0032_1051 ilxtr:hasIlxId ilx:0111136 .
+DICOM:0032_1051 ilxtr:hasIlxId ILX:0111136 .
 
-DICOM:0032_1055 ilxtr:hasIlxId ilx:0111137 .
+DICOM:0032_1055 ilxtr:hasIlxId ILX:0111137 .
 
-DICOM:0032_1060 ilxtr:hasIlxId ilx:0109937 .
+DICOM:0032_1060 ilxtr:hasIlxId ILX:0109937 .
 
-DICOM:0032_1064 ilxtr:hasIlxId ilx:0111141 .
+DICOM:0032_1064 ilxtr:hasIlxId ILX:0111141 .
 
-DICOM:0032_1070 ilxtr:hasIlxId ilx:0109932 .
+DICOM:0032_1070 ilxtr:hasIlxId ILX:0109932 .
 
-DICOM:0038_0004 ilxtr:hasIlxId ilx:0109774 .
+DICOM:0038_0004 ilxtr:hasIlxId ILX:0109774 .
 
-DICOM:0038_0008 ilxtr:hasIlxId ilx:0112504 .
+DICOM:0038_0008 ilxtr:hasIlxId ILX:0112504 .
 
-DICOM:0038_0010 ilxtr:hasIlxId ilx:0100333 .
+DICOM:0038_0010 ilxtr:hasIlxId ILX:0100333 .
 
-DICOM:0038_0011 ilxtr:hasIlxId ilx:0105755 .
+DICOM:0038_0011 ilxtr:hasIlxId ILX:0105755 .
 
-DICOM:0038_0014 ilxtr:hasIlxId ilx:0382966 .
+DICOM:0038_0014 ilxtr:hasIlxId ILX:0382966 .
 
-DICOM:0038_0020 ilxtr:hasIlxId ilx:0100334 .
+DICOM:0038_0020 ilxtr:hasIlxId ILX:0100334 .
 
-DICOM:0038_0021 ilxtr:hasIlxId ilx:0100337 .
+DICOM:0038_0021 ilxtr:hasIlxId ILX:0100337 .
 
-DICOM:0038_0030 ilxtr:hasIlxId ilx:0103300 .
+DICOM:0038_0030 ilxtr:hasIlxId ILX:0103300 .
 
-DICOM:0038_0032 ilxtr:hasIlxId ilx:0103303 .
+DICOM:0038_0032 ilxtr:hasIlxId ILX:0103303 .
 
-DICOM:0038_0040 ilxtr:hasIlxId ilx:0103302 .
+DICOM:0038_0040 ilxtr:hasIlxId ILX:0103302 .
 
-DICOM:0038_0044 ilxtr:hasIlxId ilx:0103301 .
+DICOM:0038_0044 ilxtr:hasIlxId ILX:0103301 .
 
-DICOM:0038_0050 ilxtr:hasIlxId ilx:0110846 .
+DICOM:0038_0050 ilxtr:hasIlxId ILX:0110846 .
 
-DICOM:0038_0060 ilxtr:hasIlxId ilx:0382595 .
+DICOM:0038_0060 ilxtr:hasIlxId ILX:0382595 .
 
-DICOM:0038_0062 ilxtr:hasIlxId ilx:0381686 .
+DICOM:0038_0062 ilxtr:hasIlxId ILX:0381686 .
 
-DICOM:0038_0064 ilxtr:hasIlxId ilx:0381468 .
+DICOM:0038_0064 ilxtr:hasIlxId ILX:0381468 .
 
-DICOM:0038_0101 ilxtr:hasIlxId ilx:0382750 .
+DICOM:0038_0101 ilxtr:hasIlxId ILX:0382750 .
 
-DICOM:0038_0102 ilxtr:hasIlxId ilx:0381966 .
+DICOM:0038_0102 ilxtr:hasIlxId ILX:0381966 .
 
-DICOM:0038_0300 ilxtr:hasIlxId ilx:0102681 .
+DICOM:0038_0300 ilxtr:hasIlxId ILX:0102681 .
 
-DICOM:0038_0400 ilxtr:hasIlxId ilx:0108609 .
+DICOM:0038_0400 ilxtr:hasIlxId ILX:0108609 .
 
-DICOM:0038_0500 ilxtr:hasIlxId ilx:0108598 .
+DICOM:0038_0500 ilxtr:hasIlxId ILX:0108598 .
 
-DICOM:0038_4000 ilxtr:hasIlxId ilx:0112503 .
+DICOM:0038_4000 ilxtr:hasIlxId ILX:0112503 .
 
-DICOM:0040_000A ilxtr:hasIlxId ilx:0111012 .
+DICOM:0040_000A ilxtr:hasIlxId ILX:0111012 .
 
-DICOM:0040_000B ilxtr:hasIlxId ilx:0110378 .
+DICOM:0040_000B ilxtr:hasIlxId ILX:0110378 .
 
-DICOM:0040_0001 ilxtr:hasIlxId ilx:0110393 .
+DICOM:0040_0001 ilxtr:hasIlxId ILX:0110393 .
 
-DICOM:0040_0002 ilxtr:hasIlxId ilx:0110387 .
+DICOM:0040_0002 ilxtr:hasIlxId ILX:0110387 .
 
-DICOM:0040_0003 ilxtr:hasIlxId ilx:0110389 .
+DICOM:0040_0003 ilxtr:hasIlxId ILX:0110389 .
 
-DICOM:0040_003A ilxtr:hasIlxId ilx:0383115 .
+DICOM:0040_003A ilxtr:hasIlxId ILX:0383115 .
 
-DICOM:0040_0004 ilxtr:hasIlxId ilx:0110381 .
+DICOM:0040_0004 ilxtr:hasIlxId ILX:0110381 .
 
-DICOM:0040_0005 ilxtr:hasIlxId ilx:0110382 .
+DICOM:0040_0005 ilxtr:hasIlxId ILX:0110382 .
 
-DICOM:0040_0006 ilxtr:hasIlxId ilx:0110379 .
+DICOM:0040_0006 ilxtr:hasIlxId ILX:0110379 .
 
-DICOM:0040_06FA ilxtr:hasIlxId ilx:0110676 .
+DICOM:0040_06FA ilxtr:hasIlxId ILX:0110676 .
 
-DICOM:0040_0007 ilxtr:hasIlxId ilx:0110380 .
+DICOM:0040_0007 ilxtr:hasIlxId ILX:0110380 .
 
-DICOM:0040_0008 ilxtr:hasIlxId ilx:0110392 .
+DICOM:0040_0008 ilxtr:hasIlxId ILX:0110392 .
 
-DICOM:0040_08D8 ilxtr:hasIlxId ilx:0108957 .
+DICOM:0040_08D8 ilxtr:hasIlxId ILX:0108957 .
 
-DICOM:0040_08DA ilxtr:hasIlxId ilx:0102552 .
+DICOM:0040_08DA ilxtr:hasIlxId ILX:0102552 .
 
-DICOM:0040_08EA ilxtr:hasIlxId ilx:0382291 .
+DICOM:0040_08EA ilxtr:hasIlxId ILX:0382291 .
 
-DICOM:0040_0009 ilxtr:hasIlxId ilx:0110383 .
+DICOM:0040_0009 ilxtr:hasIlxId ILX:0110383 .
 
-DICOM:0040_0010 ilxtr:hasIlxId ilx:0110396 .
+DICOM:0040_0010 ilxtr:hasIlxId ILX:0110396 .
 
-DICOM:0040_0011 ilxtr:hasIlxId ilx:0110384 .
+DICOM:0040_0011 ilxtr:hasIlxId ILX:0110384 .
 
-DICOM:0040_0012 ilxtr:hasIlxId ilx:0109182 .
+DICOM:0040_0012 ilxtr:hasIlxId ILX:0109182 .
 
-DICOM:0040_0020 ilxtr:hasIlxId ilx:0110390 .
+DICOM:0040_0020 ilxtr:hasIlxId ILX:0110390 .
 
-DICOM:0040_0026 ilxtr:hasIlxId ilx:0382597 .
+DICOM:0040_0026 ilxtr:hasIlxId ILX:0382597 .
 
-DICOM:0040_0027 ilxtr:hasIlxId ilx:0382587 .
+DICOM:0040_0027 ilxtr:hasIlxId ILX:0382587 .
 
-DICOM:0040_030E ilxtr:hasIlxId ilx:0104027 .
+DICOM:0040_030E ilxtr:hasIlxId ILX:0104027 .
 
-DICOM:0040_0031 ilxtr:hasIlxId ilx:0381920 .
+DICOM:0040_0031 ilxtr:hasIlxId ILX:0381920 .
 
-DICOM:0040_0032 ilxtr:hasIlxId ilx:0382048 .
+DICOM:0040_0032 ilxtr:hasIlxId ILX:0382048 .
 
-DICOM:0040_0033 ilxtr:hasIlxId ilx:0382663 .
+DICOM:0040_0033 ilxtr:hasIlxId ILX:0382663 .
 
-DICOM:0040_0035 ilxtr:hasIlxId ilx:0382557 .
+DICOM:0040_0035 ilxtr:hasIlxId ILX:0382557 .
 
-DICOM:0040_0036 ilxtr:hasIlxId ilx:0381515 .
+DICOM:0040_0036 ilxtr:hasIlxId ILX:0381515 .
 
-DICOM:0040_0039 ilxtr:hasIlxId ilx:0382706 .
+DICOM:0040_0039 ilxtr:hasIlxId ILX:0382706 .
 
-DICOM:0040_050A ilxtr:hasIlxId ilx:0110865 .
+DICOM:0040_050A ilxtr:hasIlxId ILX:0110865 .
 
-DICOM:0040_051A ilxtr:hasIlxId ilx:0381737 .
+DICOM:0040_051A ilxtr:hasIlxId ILX:0381737 .
 
-DICOM:0040_059A ilxtr:hasIlxId ilx:0110871 .
+DICOM:0040_059A ilxtr:hasIlxId ILX:0110871 .
 
-DICOM:0040_071A ilxtr:hasIlxId ilx:0105230 .
+DICOM:0040_071A ilxtr:hasIlxId ILX:0105230 .
 
-DICOM:0040_072A ilxtr:hasIlxId ilx:0112676 .
+DICOM:0040_072A ilxtr:hasIlxId ILX:0112676 .
 
-DICOM:0040_073A ilxtr:hasIlxId ilx:0112698 .
+DICOM:0040_073A ilxtr:hasIlxId ILX:0112698 .
 
-DICOM:0040_074A ilxtr:hasIlxId ilx:0112720 .
+DICOM:0040_074A ilxtr:hasIlxId ILX:0112720 .
 
-DICOM:0040_0100 ilxtr:hasIlxId ilx:0110386 .
+DICOM:0040_0100 ilxtr:hasIlxId ILX:0110386 .
 
-DICOM:0040_100A ilxtr:hasIlxId ilx:0109678 .
+DICOM:0040_100A ilxtr:hasIlxId ILX:0109678 .
 
-DICOM:0040_0220 ilxtr:hasIlxId ilx:0109772 .
+DICOM:0040_0220 ilxtr:hasIlxId ILX:0109772 .
 
-DICOM:0040_0241 ilxtr:hasIlxId ilx:0108702 .
+DICOM:0040_0241 ilxtr:hasIlxId ILX:0108702 .
 
-DICOM:0040_0242 ilxtr:hasIlxId ilx:0108705 .
+DICOM:0040_0242 ilxtr:hasIlxId ILX:0108705 .
 
-DICOM:0040_0243 ilxtr:hasIlxId ilx:0108688 .
+DICOM:0040_0243 ilxtr:hasIlxId ILX:0108688 .
 
-DICOM:0040_0244 ilxtr:hasIlxId ilx:0108695 .
+DICOM:0040_0244 ilxtr:hasIlxId ILX:0108695 .
 
-DICOM:0040_0245 ilxtr:hasIlxId ilx:0108696 .
+DICOM:0040_0245 ilxtr:hasIlxId ILX:0108696 .
 
-DICOM:0040_0250 ilxtr:hasIlxId ilx:0108692 .
+DICOM:0040_0250 ilxtr:hasIlxId ILX:0108692 .
 
-DICOM:0040_0251 ilxtr:hasIlxId ilx:0108693 .
+DICOM:0040_0251 ilxtr:hasIlxId ILX:0108693 .
 
-DICOM:0040_0252 ilxtr:hasIlxId ilx:0108697 .
+DICOM:0040_0252 ilxtr:hasIlxId ILX:0108697 .
 
-DICOM:0040_0253 ilxtr:hasIlxId ilx:0108694 .
+DICOM:0040_0253 ilxtr:hasIlxId ILX:0108694 .
 
-DICOM:0040_0254 ilxtr:hasIlxId ilx:0108690 .
+DICOM:0040_0254 ilxtr:hasIlxId ILX:0108690 .
 
-DICOM:0040_0255 ilxtr:hasIlxId ilx:0108698 .
+DICOM:0040_0255 ilxtr:hasIlxId ILX:0108698 .
 
-DICOM:0040_0260 ilxtr:hasIlxId ilx:0383184 .
+DICOM:0040_0260 ilxtr:hasIlxId ILX:0383184 .
 
-DICOM:0040_0261 ilxtr:hasIlxId ilx:0383137 .
+DICOM:0040_0261 ilxtr:hasIlxId ILX:0383137 .
 
-DICOM:0040_0270 ilxtr:hasIlxId ilx:0110398 .
+DICOM:0040_0270 ilxtr:hasIlxId ILX:0110398 .
 
-DICOM:0040_0275 ilxtr:hasIlxId ilx:0109930 .
+DICOM:0040_0275 ilxtr:hasIlxId ILX:0109930 .
 
-DICOM:0040_0280 ilxtr:hasIlxId ilx:0102399 .
+DICOM:0040_0280 ilxtr:hasIlxId ILX:0102399 .
 
-DICOM:0040_0281 ilxtr:hasIlxId ilx:0108691 .
+DICOM:0040_0281 ilxtr:hasIlxId ILX:0108691 .
 
-DICOM:0040_0300 ilxtr:hasIlxId ilx:0111831 .
+DICOM:0040_0300 ilxtr:hasIlxId ILX:0111831 .
 
-DICOM:0040_0301 ilxtr:hasIlxId ilx:0111828 .
+DICOM:0040_0301 ilxtr:hasIlxId ILX:0111828 .
 
-DICOM:0040_0302 ilxtr:hasIlxId ilx:0103871 .
+DICOM:0040_0302 ilxtr:hasIlxId ILX:0103871 .
 
-DICOM:0040_0303 ilxtr:hasIlxId ilx:0104024 .
+DICOM:0040_0303 ilxtr:hasIlxId ILX:0104024 .
 
-DICOM:0040_0306 ilxtr:hasIlxId ilx:0103340 .
+DICOM:0040_0306 ilxtr:hasIlxId ILX:0103340 .
 
-DICOM:0040_0310 ilxtr:hasIlxId ilx:0102398 .
+DICOM:0040_0310 ilxtr:hasIlxId ILX:0102398 .
 
-DICOM:0040_0312 ilxtr:hasIlxId ilx:0112684 .
+DICOM:0040_0312 ilxtr:hasIlxId ILX:0112684 .
 
-DICOM:0040_0314 ilxtr:hasIlxId ilx:0104876 .
+DICOM:0040_0314 ilxtr:hasIlxId ILX:0104876 .
 
-DICOM:0040_0316 ilxtr:hasIlxId ilx:0108130 .
+DICOM:0040_0316 ilxtr:hasIlxId ILX:0108130 .
 
-DICOM:0040_0318 ilxtr:hasIlxId ilx:0108131 .
+DICOM:0040_0318 ilxtr:hasIlxId ILX:0108131 .
 
-DICOM:0040_0340 ilxtr:hasIlxId ilx:0108701 .
+DICOM:0040_0340 ilxtr:hasIlxId ILX:0108701 .
 
-DICOM:0040_0400 ilxtr:hasIlxId ilx:0102400 .
+DICOM:0040_0400 ilxtr:hasIlxId ILX:0102400 .
 
-DICOM:0040_0440 ilxtr:hasIlxId ilx:0109466 .
+DICOM:0040_0440 ilxtr:hasIlxId ILX:0109466 .
 
-DICOM:0040_0441 ilxtr:hasIlxId ilx:0102508 .
+DICOM:0040_0441 ilxtr:hasIlxId ILX:0102508 .
 
-DICOM:0040_0512 ilxtr:hasIlxId ilx:0382191 .
+DICOM:0040_0512 ilxtr:hasIlxId ILX:0382191 .
 
-DICOM:0040_0513 ilxtr:hasIlxId ilx:0382513 .
+DICOM:0040_0513 ilxtr:hasIlxId ILX:0382513 .
 
-DICOM:0040_0515 ilxtr:hasIlxId ilx:0381490 .
+DICOM:0040_0515 ilxtr:hasIlxId ILX:0381490 .
 
-DICOM:0040_0518 ilxtr:hasIlxId ilx:0381717 .
+DICOM:0040_0518 ilxtr:hasIlxId ILX:0381717 .
 
-DICOM:0040_0520 ilxtr:hasIlxId ilx:0382903 .
+DICOM:0040_0520 ilxtr:hasIlxId ILX:0382903 .
 
-DICOM:0040_0550 ilxtr:hasIlxId ilx:0110870 .
+DICOM:0040_0550 ilxtr:hasIlxId ILX:0110870 .
 
-DICOM:0040_0551 ilxtr:hasIlxId ilx:0110867 .
+DICOM:0040_0551 ilxtr:hasIlxId ILX:0110867 .
 
-DICOM:0040_0554 ilxtr:hasIlxId ilx:0382839 .
+DICOM:0040_0554 ilxtr:hasIlxId ILX:0382839 .
 
-DICOM:0040_0555 ilxtr:hasIlxId ilx:0381667 .
+DICOM:0040_0555 ilxtr:hasIlxId ILX:0381667 .
 
-DICOM:0040_0556 ilxtr:hasIlxId ilx:0382794 .
+DICOM:0040_0556 ilxtr:hasIlxId ILX:0382794 .
 
-DICOM:0040_0560 ilxtr:hasIlxId ilx:0382808 .
+DICOM:0040_0560 ilxtr:hasIlxId ILX:0382808 .
 
-DICOM:0040_0562 ilxtr:hasIlxId ilx:0381741 .
+DICOM:0040_0562 ilxtr:hasIlxId ILX:0381741 .
 
-DICOM:0040_0600 ilxtr:hasIlxId ilx:0382322 .
+DICOM:0040_0600 ilxtr:hasIlxId ILX:0382322 .
 
-DICOM:0040_0602 ilxtr:hasIlxId ilx:0382308 .
+DICOM:0040_0602 ilxtr:hasIlxId ILX:0382308 .
 
-DICOM:0040_0610 ilxtr:hasIlxId ilx:0382562 .
+DICOM:0040_0610 ilxtr:hasIlxId ILX:0382562 .
 
-DICOM:0040_0612 ilxtr:hasIlxId ilx:0381492 .
+DICOM:0040_0612 ilxtr:hasIlxId ILX:0381492 .
 
-DICOM:0040_0620 ilxtr:hasIlxId ilx:0382068 .
+DICOM:0040_0620 ilxtr:hasIlxId ILX:0382068 .
 
-DICOM:0040_1001 ilxtr:hasIlxId ilx:0109938 .
+DICOM:0040_1001 ilxtr:hasIlxId ILX:0109938 .
 
-DICOM:0040_1002 ilxtr:hasIlxId ilx:0109680 .
+DICOM:0040_1002 ilxtr:hasIlxId ILX:0109680 .
 
-DICOM:0040_1003 ilxtr:hasIlxId ilx:0109940 .
+DICOM:0040_1003 ilxtr:hasIlxId ILX:0109940 .
 
-DICOM:0040_1004 ilxtr:hasIlxId ilx:0108602 .
+DICOM:0040_1004 ilxtr:hasIlxId ILX:0108602 .
 
-DICOM:0040_1005 ilxtr:hasIlxId ilx:0109939 .
+DICOM:0040_1005 ilxtr:hasIlxId ILX:0109939 .
 
-DICOM:0040_1008 ilxtr:hasIlxId ilx:0102469 .
+DICOM:0040_1008 ilxtr:hasIlxId ILX:0102469 .
 
-DICOM:0040_1009 ilxtr:hasIlxId ilx:0109925 .
+DICOM:0040_1009 ilxtr:hasIlxId ILX:0109925 .
 
-DICOM:0040_1010 ilxtr:hasIlxId ilx:0107296 .
+DICOM:0040_1010 ilxtr:hasIlxId ILX:0107296 .
 
-DICOM:0040_1011 ilxtr:hasIlxId ilx:0105534 .
+DICOM:0040_1011 ilxtr:hasIlxId ILX:0105534 .
 
-DICOM:0040_1012 ilxtr:hasIlxId ilx:0382152 .
+DICOM:0040_1012 ilxtr:hasIlxId ILX:0382152 .
 
-DICOM:0040_1101 ilxtr:hasIlxId ilx:0108769 .
+DICOM:0040_1101 ilxtr:hasIlxId ILX:0108769 .
 
-DICOM:0040_1102 ilxtr:hasIlxId ilx:0108770 .
+DICOM:0040_1102 ilxtr:hasIlxId ILX:0108770 .
 
-DICOM:0040_1103 ilxtr:hasIlxId ilx:0108771 .
+DICOM:0040_1103 ilxtr:hasIlxId ILX:0108771 .
 
-DICOM:0040_1104 ilxtr:hasIlxId ilx:0381996 .
+DICOM:0040_1104 ilxtr:hasIlxId ILX:0381996 .
 
-DICOM:0040_1400 ilxtr:hasIlxId ilx:0109936 .
+DICOM:0040_1400 ilxtr:hasIlxId ILX:0109936 .
 
-DICOM:0040_2004 ilxtr:hasIlxId ilx:0105753 .
+DICOM:0040_2004 ilxtr:hasIlxId ILX:0105753 .
 
-DICOM:0040_2005 ilxtr:hasIlxId ilx:0105754 .
+DICOM:0040_2005 ilxtr:hasIlxId ILX:0105754 .
 
-DICOM:0040_2008 ilxtr:hasIlxId ilx:0108118 .
+DICOM:0040_2008 ilxtr:hasIlxId ILX:0108118 .
 
-DICOM:0040_2009 ilxtr:hasIlxId ilx:0108119 .
+DICOM:0040_2009 ilxtr:hasIlxId ILX:0108119 .
 
-DICOM:0040_2010 ilxtr:hasIlxId ilx:0108117 .
+DICOM:0040_2010 ilxtr:hasIlxId ILX:0108117 .
 
-DICOM:0040_2016 ilxtr:hasIlxId ilx:0382248 .
+DICOM:0040_2016 ilxtr:hasIlxId ILX:0382248 .
 
-DICOM:0040_2017 ilxtr:hasIlxId ilx:0382843 .
+DICOM:0040_2017 ilxtr:hasIlxId ILX:0382843 .
 
-DICOM:0040_2400 ilxtr:hasIlxId ilx:0105269 .
+DICOM:0040_2400 ilxtr:hasIlxId ILX:0105269 .
 
-DICOM:0040_3001 ilxtr:hasIlxId ilx:0102470 .
+DICOM:0040_3001 ilxtr:hasIlxId ILX:0102470 .
 
-DICOM:0040_4001 ilxtr:hasIlxId ilx:0104587 .
+DICOM:0040_4001 ilxtr:hasIlxId ILX:0104587 .
 
-DICOM:0040_4002 ilxtr:hasIlxId ilx:0104585 .
+DICOM:0040_4002 ilxtr:hasIlxId ILX:0104585 .
 
-DICOM:0040_4003 ilxtr:hasIlxId ilx:0104586 .
+DICOM:0040_4003 ilxtr:hasIlxId ILX:0104586 .
 
-DICOM:0040_4004 ilxtr:hasIlxId ilx:0110391 .
+DICOM:0040_4004 ilxtr:hasIlxId ILX:0110391 .
 
-DICOM:0040_4005 ilxtr:hasIlxId ilx:0110388 .
+DICOM:0040_4005 ilxtr:hasIlxId ILX:0110388 .
 
-DICOM:0040_4006 ilxtr:hasIlxId ilx:0107188 .
+DICOM:0040_4006 ilxtr:hasIlxId ILX:0107188 .
 
-DICOM:0040_4007 ilxtr:hasIlxId ilx:0108699 .
+DICOM:0040_4007 ilxtr:hasIlxId ILX:0108699 .
 
-DICOM:0040_4009 ilxtr:hasIlxId ilx:0105116 .
+DICOM:0040_4009 ilxtr:hasIlxId ILX:0105116 .
 
-DICOM:0040_4010 ilxtr:hasIlxId ilx:0110385 .
+DICOM:0040_4010 ilxtr:hasIlxId ILX:0110385 .
 
-DICOM:0040_4011 ilxtr:hasIlxId ilx:0104016 .
+DICOM:0040_4011 ilxtr:hasIlxId ILX:0104016 .
 
-DICOM:0040_4015 ilxtr:hasIlxId ilx:0109979 .
+DICOM:0040_4015 ilxtr:hasIlxId ILX:0109979 .
 
-DICOM:0040_4016 ilxtr:hasIlxId ilx:0109762 .
+DICOM:0040_4016 ilxtr:hasIlxId ILX:0109762 .
 
-DICOM:0040_4018 ilxtr:hasIlxId ilx:0110405 .
+DICOM:0040_4018 ilxtr:hasIlxId ILX:0110405 .
 
-DICOM:0040_4019 ilxtr:hasIlxId ilx:0108707 .
+DICOM:0040_4019 ilxtr:hasIlxId ILX:0108707 .
 
-DICOM:0040_4020 ilxtr:hasIlxId ilx:0105496 .
+DICOM:0040_4020 ilxtr:hasIlxId ILX:0105496 .
 
-DICOM:0040_4021 ilxtr:hasIlxId ilx:0105497 .
+DICOM:0040_4021 ilxtr:hasIlxId ILX:0105497 .
 
-DICOM:0040_4022 ilxtr:hasIlxId ilx:0109909 .
+DICOM:0040_4022 ilxtr:hasIlxId ILX:0109909 .
 
-DICOM:0040_4023 ilxtr:hasIlxId ilx:0109763 .
+DICOM:0040_4023 ilxtr:hasIlxId ILX:0109763 .
 
-DICOM:0040_4025 ilxtr:hasIlxId ilx:0110397 .
+DICOM:0040_4025 ilxtr:hasIlxId ILX:0110397 .
 
-DICOM:0040_4026 ilxtr:hasIlxId ilx:0110394 .
+DICOM:0040_4026 ilxtr:hasIlxId ILX:0110394 .
 
-DICOM:0040_4027 ilxtr:hasIlxId ilx:0110395 .
+DICOM:0040_4027 ilxtr:hasIlxId ILX:0110395 .
 
-DICOM:0040_4028 ilxtr:hasIlxId ilx:0108706 .
+DICOM:0040_4028 ilxtr:hasIlxId ILX:0108706 .
 
-DICOM:0040_4029 ilxtr:hasIlxId ilx:0108703 .
+DICOM:0040_4029 ilxtr:hasIlxId ILX:0108703 .
 
-DICOM:0040_4030 ilxtr:hasIlxId ilx:0108704 .
+DICOM:0040_4030 ilxtr:hasIlxId ILX:0108704 .
 
-DICOM:0040_4031 ilxtr:hasIlxId ilx:0109943 .
+DICOM:0040_4031 ilxtr:hasIlxId ILX:0109943 .
 
-DICOM:0040_4032 ilxtr:hasIlxId ilx:0107654 .
+DICOM:0040_4032 ilxtr:hasIlxId ILX:0107654 .
 
-DICOM:0040_4033 ilxtr:hasIlxId ilx:0108285 .
+DICOM:0040_4033 ilxtr:hasIlxId ILX:0108285 .
 
-DICOM:0040_4034 ilxtr:hasIlxId ilx:0110377 .
+DICOM:0040_4034 ilxtr:hasIlxId ILX:0110377 .
 
-DICOM:0040_4035 ilxtr:hasIlxId ilx:0100295 .
+DICOM:0040_4035 ilxtr:hasIlxId ILX:0100295 .
 
-DICOM:0040_4036 ilxtr:hasIlxId ilx:0105118 .
+DICOM:0040_4036 ilxtr:hasIlxId ILX:0105118 .
 
-DICOM:0040_4037 ilxtr:hasIlxId ilx:0105117 .
+DICOM:0040_4037 ilxtr:hasIlxId ILX:0105117 .
 
-DICOM:0040_4071 ilxtr:hasIlxId ilx:0383116 .
+DICOM:0040_4071 ilxtr:hasIlxId ILX:0383116 .
 
-DICOM:0040_4072 ilxtr:hasIlxId ilx:0381774 .
+DICOM:0040_4072 ilxtr:hasIlxId ILX:0381774 .
 
-DICOM:0040_4073 ilxtr:hasIlxId ilx:0382652 .
+DICOM:0040_4073 ilxtr:hasIlxId ILX:0382652 .
 
-DICOM:0040_4074 ilxtr:hasIlxId ilx:0382593 .
+DICOM:0040_4074 ilxtr:hasIlxId ILX:0382593 .
 
-DICOM:0040_8302 ilxtr:hasIlxId ilx:0103872 .
+DICOM:0040_8302 ilxtr:hasIlxId ILX:0103872 .
 
-DICOM:0040_9092 ilxtr:hasIlxId ilx:0381818 .
+DICOM:0040_9092 ilxtr:hasIlxId ILX:0381818 .
 
-DICOM:0040_9094 ilxtr:hasIlxId ilx:0382545 .
+DICOM:0040_9094 ilxtr:hasIlxId ILX:0382545 .
 
-DICOM:0040_9096 ilxtr:hasIlxId ilx:0109675 .
+DICOM:0040_9096 ilxtr:hasIlxId ILX:0109675 .
 
-DICOM:0040_9098 ilxtr:hasIlxId ilx:0382653 .
+DICOM:0040_9098 ilxtr:hasIlxId ILX:0382653 .
 
-DICOM:0040_9210 ilxtr:hasIlxId ilx:0106414 .
+DICOM:0040_9210 ilxtr:hasIlxId ILX:0106414 .
 
-DICOM:0040_9211 ilxtr:hasIlxId ilx:0109673 .
+DICOM:0040_9211 ilxtr:hasIlxId ILX:0109673 .
 
-DICOM:0040_9212 ilxtr:hasIlxId ilx:0109674 .
+DICOM:0040_9212 ilxtr:hasIlxId ILX:0109674 .
 
-DICOM:0040_9213 ilxtr:hasIlxId ilx:0381627 .
+DICOM:0040_9213 ilxtr:hasIlxId ILX:0381627 .
 
-DICOM:0040_9214 ilxtr:hasIlxId ilx:0382810 .
+DICOM:0040_9214 ilxtr:hasIlxId ILX:0382810 .
 
-DICOM:0040_9216 ilxtr:hasIlxId ilx:0109671 .
+DICOM:0040_9216 ilxtr:hasIlxId ILX:0109671 .
 
-DICOM:0040_9220 ilxtr:hasIlxId ilx:0383104 .
+DICOM:0040_9220 ilxtr:hasIlxId ILX:0383104 .
 
-DICOM:0040_9224 ilxtr:hasIlxId ilx:0109672 .
+DICOM:0040_9224 ilxtr:hasIlxId ILX:0109672 .
 
-DICOM:0040_9225 ilxtr:hasIlxId ilx:0109676 .
+DICOM:0040_9225 ilxtr:hasIlxId ILX:0109676 .
 
-DICOM:0040_A0B0 ilxtr:hasIlxId ilx:0109803 .
+DICOM:0040_A0B0 ilxtr:hasIlxId ILX:0109803 .
 
-DICOM:0040_A07A ilxtr:hasIlxId ilx:0382250 .
+DICOM:0040_A07A ilxtr:hasIlxId ILX:0382250 .
 
-DICOM:0040_A07C ilxtr:hasIlxId ilx:0382791 .
+DICOM:0040_A07C ilxtr:hasIlxId ILX:0382791 .
 
-DICOM:0040_A010 ilxtr:hasIlxId ilx:0109900 .
+DICOM:0040_A010 ilxtr:hasIlxId ILX:0109900 .
 
-DICOM:0040_A13A ilxtr:hasIlxId ilx:0109751 .
+DICOM:0040_A13A ilxtr:hasIlxId ILX:0109751 .
 
-DICOM:0040_A027 ilxtr:hasIlxId ilx:0112391 .
+DICOM:0040_A027 ilxtr:hasIlxId ILX:0112391 .
 
-DICOM:0040_A030 ilxtr:hasIlxId ilx:0112386 .
+DICOM:0040_A030 ilxtr:hasIlxId ILX:0112386 .
 
-DICOM:0040_A30A ilxtr:hasIlxId ilx:0382619 .
+DICOM:0040_A30A ilxtr:hasIlxId ILX:0382619 .
 
-DICOM:0040_A032 ilxtr:hasIlxId ilx:0107873 .
+DICOM:0040_A032 ilxtr:hasIlxId ILX:0107873 .
 
-DICOM:0040_A040 ilxtr:hasIlxId ilx:0382583 .
+DICOM:0040_A040 ilxtr:hasIlxId ILX:0382583 .
 
-DICOM:0040_A043 ilxtr:hasIlxId ilx:0381632 .
+DICOM:0040_A043 ilxtr:hasIlxId ILX:0381632 .
 
-DICOM:0040_A050 ilxtr:hasIlxId ilx:0102516 .
+DICOM:0040_A050 ilxtr:hasIlxId ILX:0102516 .
 
-DICOM:0040_A073 ilxtr:hasIlxId ilx:0112390 .
+DICOM:0040_A073 ilxtr:hasIlxId ILX:0112390 .
 
-DICOM:0040_A075 ilxtr:hasIlxId ilx:0112389 .
+DICOM:0040_A075 ilxtr:hasIlxId ILX:0112389 .
 
-DICOM:0040_A078 ilxtr:hasIlxId ilx:0382688 .
+DICOM:0040_A078 ilxtr:hasIlxId ILX:0382688 .
 
-DICOM:0040_A080 ilxtr:hasIlxId ilx:0382875 .
+DICOM:0040_A080 ilxtr:hasIlxId ILX:0382875 .
 
-DICOM:0040_A082 ilxtr:hasIlxId ilx:0382144 .
+DICOM:0040_A082 ilxtr:hasIlxId ILX:0382144 .
 
-DICOM:0040_A084 ilxtr:hasIlxId ilx:0382755 .
+DICOM:0040_A084 ilxtr:hasIlxId ILX:0382755 .
 
-DICOM:0040_A088 ilxtr:hasIlxId ilx:0112388 .
+DICOM:0040_A088 ilxtr:hasIlxId ILX:0112388 .
 
-DICOM:0040_A120 ilxtr:hasIlxId ilx:0102844 .
+DICOM:0040_A120 ilxtr:hasIlxId ILX:0102844 .
 
-DICOM:0040_A121 ilxtr:hasIlxId ilx:0383109 .
+DICOM:0040_A121 ilxtr:hasIlxId ILX:0383109 .
 
-DICOM:0040_A123 ilxtr:hasIlxId ilx:0382955 .
+DICOM:0040_A123 ilxtr:hasIlxId ILX:0382955 .
 
-DICOM:0040_A124 ilxtr:hasIlxId ilx:0112146 .
+DICOM:0040_A124 ilxtr:hasIlxId ILX:0112146 .
 
-DICOM:0040_A130 ilxtr:hasIlxId ilx:0111598 .
+DICOM:0040_A130 ilxtr:hasIlxId ILX:0111598 .
 
-DICOM:0040_A132 ilxtr:hasIlxId ilx:0109787 .
+DICOM:0040_A132 ilxtr:hasIlxId ILX:0109787 .
 
-DICOM:0040_A136 ilxtr:hasIlxId ilx:0383179 .
+DICOM:0040_A136 ilxtr:hasIlxId ILX:0383179 .
 
-DICOM:0040_A138 ilxtr:hasIlxId ilx:0109798 .
+DICOM:0040_A138 ilxtr:hasIlxId ILX:0109798 .
 
-DICOM:0040_A160 ilxtr:hasIlxId ilx:0382340 .
+DICOM:0040_A160 ilxtr:hasIlxId ILX:0382340 .
 
-DICOM:0040_A161 ilxtr:hasIlxId ilx:0382213 .
+DICOM:0040_A161 ilxtr:hasIlxId ILX:0382213 .
 
-DICOM:0040_A162 ilxtr:hasIlxId ilx:0382181 .
+DICOM:0040_A162 ilxtr:hasIlxId ILX:0382181 .
 
-DICOM:0040_A163 ilxtr:hasIlxId ilx:0381912 .
+DICOM:0040_A163 ilxtr:hasIlxId ILX:0381912 .
 
-DICOM:0040_A168 ilxtr:hasIlxId ilx:0381519 .
+DICOM:0040_A168 ilxtr:hasIlxId ILX:0381519 .
 
-DICOM:0040_A170 ilxtr:hasIlxId ilx:0109547 .
+DICOM:0040_A170 ilxtr:hasIlxId ILX:0109547 .
 
-DICOM:0040_A171 ilxtr:hasIlxId ilx:0382567 .
+DICOM:0040_A171 ilxtr:hasIlxId ILX:0382567 .
 
-DICOM:0040_A180 ilxtr:hasIlxId ilx:0100649 .
+DICOM:0040_A180 ilxtr:hasIlxId ILX:0100649 .
 
-DICOM:0040_A195 ilxtr:hasIlxId ilx:0107058 .
+DICOM:0040_A195 ilxtr:hasIlxId ILX:0107058 .
 
-DICOM:0040_A300 ilxtr:hasIlxId ilx:0106598 .
+DICOM:0040_A300 ilxtr:hasIlxId ILX:0106598 .
 
-DICOM:0040_A301 ilxtr:hasIlxId ilx:0107855 .
+DICOM:0040_A301 ilxtr:hasIlxId ILX:0107855 .
 
-DICOM:0040_A360 ilxtr:hasIlxId ilx:0109202 .
+DICOM:0040_A360 ilxtr:hasIlxId ILX:0109202 .
 
-DICOM:0040_A370 ilxtr:hasIlxId ilx:0109783 .
+DICOM:0040_A370 ilxtr:hasIlxId ILX:0109783 .
 
-DICOM:0040_A372 ilxtr:hasIlxId ilx:0108689 .
+DICOM:0040_A372 ilxtr:hasIlxId ILX:0108689 .
 
-DICOM:0040_A375 ilxtr:hasIlxId ilx:0102682 .
+DICOM:0040_A375 ilxtr:hasIlxId ILX:0102682 .
 
-DICOM:0040_A385 ilxtr:hasIlxId ilx:0108773 .
+DICOM:0040_A385 ilxtr:hasIlxId ILX:0108773 .
 
-DICOM:0040_A390 ilxtr:hasIlxId ilx:0382470 .
+DICOM:0040_A390 ilxtr:hasIlxId ILX:0382470 .
 
-DICOM:0040_A491 ilxtr:hasIlxId ilx:0102429 .
+DICOM:0040_A491 ilxtr:hasIlxId ILX:0102429 .
 
-DICOM:0040_A492 ilxtr:hasIlxId ilx:0102430 .
+DICOM:0040_A492 ilxtr:hasIlxId ILX:0102430 .
 
-DICOM:0040_A493 ilxtr:hasIlxId ilx:0112387 .
+DICOM:0040_A493 ilxtr:hasIlxId ILX:0112387 .
 
-DICOM:0040_A496 ilxtr:hasIlxId ilx:0383112 .
+DICOM:0040_A496 ilxtr:hasIlxId ILX:0383112 .
 
-DICOM:0040_A504 ilxtr:hasIlxId ilx:0102512 .
+DICOM:0040_A504 ilxtr:hasIlxId ILX:0102512 .
 
-DICOM:0040_A525 ilxtr:hasIlxId ilx:0105211 .
+DICOM:0040_A525 ilxtr:hasIlxId ILX:0105211 .
 
-DICOM:0040_A730 ilxtr:hasIlxId ilx:0102511 .
+DICOM:0040_A730 ilxtr:hasIlxId ILX:0102511 .
 
-DICOM:0040_B020 ilxtr:hasIlxId ilx:0382362 .
+DICOM:0040_B020 ilxtr:hasIlxId ILX:0382362 .
 
-DICOM:0040_DB00 ilxtr:hasIlxId ilx:0111575 .
+DICOM:0040_DB00 ilxtr:hasIlxId ILX:0111575 .
 
-DICOM:0040_DB73 ilxtr:hasIlxId ilx:0109748 .
+DICOM:0040_DB73 ilxtr:hasIlxId ILX:0109748 .
 
-DICOM:0040_E001 ilxtr:hasIlxId ilx:0382802 .
+DICOM:0040_E001 ilxtr:hasIlxId ILX:0382802 .
 
-DICOM:0040_E008 ilxtr:hasIlxId ilx:0382885 .
+DICOM:0040_E008 ilxtr:hasIlxId ILX:0382885 .
 
-DICOM:0040_E010 ilxtr:hasIlxId ilx:0383154 .
+DICOM:0040_E010 ilxtr:hasIlxId ILX:0383154 .
 
-DICOM:0040_E011 ilxtr:hasIlxId ilx:0382601 .
+DICOM:0040_E011 ilxtr:hasIlxId ILX:0382601 .
 
-DICOM:0040_E020 ilxtr:hasIlxId ilx:0382908 .
+DICOM:0040_E020 ilxtr:hasIlxId ILX:0382908 .
 
-DICOM:0040_E021 ilxtr:hasIlxId ilx:0382164 .
+DICOM:0040_E021 ilxtr:hasIlxId ILX:0382164 .
 
-DICOM:0040_E022 ilxtr:hasIlxId ilx:0382946 .
+DICOM:0040_E022 ilxtr:hasIlxId ILX:0382946 .
 
-DICOM:0040_E023 ilxtr:hasIlxId ilx:0382798 .
+DICOM:0040_E023 ilxtr:hasIlxId ILX:0382798 .
 
-DICOM:0040_E024 ilxtr:hasIlxId ilx:0382360 .
+DICOM:0040_E024 ilxtr:hasIlxId ILX:0382360 .
 
-DICOM:0040_E025 ilxtr:hasIlxId ilx:0382588 .
+DICOM:0040_E025 ilxtr:hasIlxId ILX:0382588 .
 
-DICOM:0040_E030 ilxtr:hasIlxId ilx:0382173 .
+DICOM:0040_E030 ilxtr:hasIlxId ILX:0382173 .
 
-DICOM:0040_E031 ilxtr:hasIlxId ilx:0383157 .
+DICOM:0040_E031 ilxtr:hasIlxId ILX:0383157 .
 
-DICOM:0042_0010 ilxtr:hasIlxId ilx:0381878 .
+DICOM:0042_0010 ilxtr:hasIlxId ILX:0381878 .
 
-DICOM:0042_0011 ilxtr:hasIlxId ilx:0381899 .
+DICOM:0042_0011 ilxtr:hasIlxId ILX:0381899 .
 
-DICOM:0042_0012 ilxtr:hasIlxId ilx:0382269 .
+DICOM:0042_0012 ilxtr:hasIlxId ILX:0382269 .
 
-DICOM:0042_0013 ilxtr:hasIlxId ilx:0382216 .
+DICOM:0042_0013 ilxtr:hasIlxId ILX:0382216 .
 
-DICOM:0042_0014 ilxtr:hasIlxId ilx:0382718 .
+DICOM:0042_0014 ilxtr:hasIlxId ILX:0382718 .
 
-DICOM:0046_0012 ilxtr:hasIlxId ilx:0382478 .
+DICOM:0046_0012 ilxtr:hasIlxId ILX:0382478 .
 
-DICOM:0046_0014 ilxtr:hasIlxId ilx:0381824 .
+DICOM:0046_0014 ilxtr:hasIlxId ILX:0381824 .
 
-DICOM:0046_0015 ilxtr:hasIlxId ilx:0382950 .
+DICOM:0046_0015 ilxtr:hasIlxId ILX:0382950 .
 
-DICOM:0046_0016 ilxtr:hasIlxId ilx:0381834 .
+DICOM:0046_0016 ilxtr:hasIlxId ILX:0381834 .
 
-DICOM:0046_0018 ilxtr:hasIlxId ilx:0383010 .
+DICOM:0046_0018 ilxtr:hasIlxId ILX:0383010 .
 
-DICOM:0046_0028 ilxtr:hasIlxId ilx:0381783 .
+DICOM:0046_0028 ilxtr:hasIlxId ILX:0381783 .
 
-DICOM:0046_0030 ilxtr:hasIlxId ilx:0381972 .
+DICOM:0046_0030 ilxtr:hasIlxId ILX:0381972 .
 
-DICOM:0046_0032 ilxtr:hasIlxId ilx:0381721 .
+DICOM:0046_0032 ilxtr:hasIlxId ILX:0381721 .
 
-DICOM:0046_0034 ilxtr:hasIlxId ilx:0382730 .
+DICOM:0046_0034 ilxtr:hasIlxId ILX:0382730 .
 
-DICOM:0046_0036 ilxtr:hasIlxId ilx:0382890 .
+DICOM:0046_0036 ilxtr:hasIlxId ILX:0382890 .
 
-DICOM:0046_0038 ilxtr:hasIlxId ilx:0382050 .
+DICOM:0046_0038 ilxtr:hasIlxId ILX:0382050 .
 
-DICOM:0046_0040 ilxtr:hasIlxId ilx:0381529 .
+DICOM:0046_0040 ilxtr:hasIlxId ILX:0381529 .
 
-DICOM:0046_0042 ilxtr:hasIlxId ilx:0381517 .
+DICOM:0046_0042 ilxtr:hasIlxId ILX:0381517 .
 
-DICOM:0046_0044 ilxtr:hasIlxId ilx:0383142 .
+DICOM:0046_0044 ilxtr:hasIlxId ILX:0383142 .
 
-DICOM:0046_0046 ilxtr:hasIlxId ilx:0381997 .
+DICOM:0046_0046 ilxtr:hasIlxId ILX:0381997 .
 
-DICOM:0046_0050 ilxtr:hasIlxId ilx:0383064 .
+DICOM:0046_0050 ilxtr:hasIlxId ILX:0383064 .
 
-DICOM:0046_0052 ilxtr:hasIlxId ilx:0382414 .
+DICOM:0046_0052 ilxtr:hasIlxId ILX:0382414 .
 
-DICOM:0046_0060 ilxtr:hasIlxId ilx:0381564 .
+DICOM:0046_0060 ilxtr:hasIlxId ILX:0381564 .
 
-DICOM:0046_0062 ilxtr:hasIlxId ilx:0382969 .
+DICOM:0046_0062 ilxtr:hasIlxId ILX:0382969 .
 
-DICOM:0046_0063 ilxtr:hasIlxId ilx:0382471 .
+DICOM:0046_0063 ilxtr:hasIlxId ILX:0382471 .
 
-DICOM:0046_0064 ilxtr:hasIlxId ilx:0382293 .
+DICOM:0046_0064 ilxtr:hasIlxId ILX:0382293 .
 
-DICOM:0046_0070 ilxtr:hasIlxId ilx:0382187 .
+DICOM:0046_0070 ilxtr:hasIlxId ILX:0382187 .
 
-DICOM:0046_0071 ilxtr:hasIlxId ilx:0382742 .
+DICOM:0046_0071 ilxtr:hasIlxId ILX:0382742 .
 
-DICOM:0046_0074 ilxtr:hasIlxId ilx:0382761 .
+DICOM:0046_0074 ilxtr:hasIlxId ILX:0382761 .
 
-DICOM:0046_0075 ilxtr:hasIlxId ilx:0381495 .
+DICOM:0046_0075 ilxtr:hasIlxId ILX:0381495 .
 
-DICOM:0046_0076 ilxtr:hasIlxId ilx:0382748 .
+DICOM:0046_0076 ilxtr:hasIlxId ILX:0382748 .
 
-DICOM:0046_0077 ilxtr:hasIlxId ilx:0381480 .
+DICOM:0046_0077 ilxtr:hasIlxId ILX:0381480 .
 
-DICOM:0046_0080 ilxtr:hasIlxId ilx:0381725 .
+DICOM:0046_0080 ilxtr:hasIlxId ILX:0381725 .
 
-DICOM:0046_0092 ilxtr:hasIlxId ilx:0382868 .
+DICOM:0046_0092 ilxtr:hasIlxId ILX:0382868 .
 
-DICOM:0046_0094 ilxtr:hasIlxId ilx:0382889 .
+DICOM:0046_0094 ilxtr:hasIlxId ILX:0382889 .
 
-DICOM:0046_0095 ilxtr:hasIlxId ilx:0382386 .
+DICOM:0046_0095 ilxtr:hasIlxId ILX:0382386 .
 
-DICOM:0046_0097 ilxtr:hasIlxId ilx:0381976 .
+DICOM:0046_0097 ilxtr:hasIlxId ILX:0381976 .
 
-DICOM:0046_0098 ilxtr:hasIlxId ilx:0381578 .
+DICOM:0046_0098 ilxtr:hasIlxId ILX:0381578 .
 
-DICOM:0046_0100 ilxtr:hasIlxId ilx:0381466 .
+DICOM:0046_0100 ilxtr:hasIlxId ILX:0381466 .
 
-DICOM:0046_0101 ilxtr:hasIlxId ilx:0381608 .
+DICOM:0046_0101 ilxtr:hasIlxId ILX:0381608 .
 
-DICOM:0046_0102 ilxtr:hasIlxId ilx:0381773 .
+DICOM:0046_0102 ilxtr:hasIlxId ILX:0381773 .
 
-DICOM:0046_0104 ilxtr:hasIlxId ilx:0381668 .
+DICOM:0046_0104 ilxtr:hasIlxId ILX:0381668 .
 
-DICOM:0046_0106 ilxtr:hasIlxId ilx:0382421 .
+DICOM:0046_0106 ilxtr:hasIlxId ILX:0382421 .
 
-DICOM:0046_0121 ilxtr:hasIlxId ilx:0382564 .
+DICOM:0046_0121 ilxtr:hasIlxId ILX:0382564 .
 
-DICOM:0046_0122 ilxtr:hasIlxId ilx:0383021 .
+DICOM:0046_0122 ilxtr:hasIlxId ILX:0383021 .
 
-DICOM:0046_0123 ilxtr:hasIlxId ilx:0381638 .
+DICOM:0046_0123 ilxtr:hasIlxId ILX:0381638 .
 
-DICOM:0046_0124 ilxtr:hasIlxId ilx:0382741 .
+DICOM:0046_0124 ilxtr:hasIlxId ILX:0382741 .
 
-DICOM:0046_0125 ilxtr:hasIlxId ilx:0382088 .
+DICOM:0046_0125 ilxtr:hasIlxId ILX:0382088 .
 
-DICOM:0046_0135 ilxtr:hasIlxId ilx:0382209 .
+DICOM:0046_0135 ilxtr:hasIlxId ILX:0382209 .
 
-DICOM:0046_0137 ilxtr:hasIlxId ilx:0382632 .
+DICOM:0046_0137 ilxtr:hasIlxId ILX:0382632 .
 
-DICOM:0046_0139 ilxtr:hasIlxId ilx:0382432 .
+DICOM:0046_0139 ilxtr:hasIlxId ILX:0382432 .
 
-DICOM:0046_0145 ilxtr:hasIlxId ilx:0382036 .
+DICOM:0046_0145 ilxtr:hasIlxId ILX:0382036 .
 
-DICOM:0046_0146 ilxtr:hasIlxId ilx:0381522 .
+DICOM:0046_0146 ilxtr:hasIlxId ILX:0381522 .
 
-DICOM:0046_0147 ilxtr:hasIlxId ilx:0381881 .
+DICOM:0046_0147 ilxtr:hasIlxId ILX:0381881 .
 
-DICOM:0046_0201 ilxtr:hasIlxId ilx:0382937 .
+DICOM:0046_0201 ilxtr:hasIlxId ILX:0382937 .
 
-DICOM:0046_0202 ilxtr:hasIlxId ilx:0382300 .
+DICOM:0046_0202 ilxtr:hasIlxId ILX:0382300 .
 
-DICOM:0046_0203 ilxtr:hasIlxId ilx:0381541 .
+DICOM:0046_0203 ilxtr:hasIlxId ILX:0381541 .
 
-DICOM:0046_0204 ilxtr:hasIlxId ilx:0383162 .
+DICOM:0046_0204 ilxtr:hasIlxId ILX:0383162 .
 
-DICOM:0046_0205 ilxtr:hasIlxId ilx:0381986 .
+DICOM:0046_0205 ilxtr:hasIlxId ILX:0381986 .
 
-DICOM:0046_0207 ilxtr:hasIlxId ilx:0382855 .
+DICOM:0046_0207 ilxtr:hasIlxId ILX:0382855 .
 
-DICOM:0046_0208 ilxtr:hasIlxId ilx:0382354 .
+DICOM:0046_0208 ilxtr:hasIlxId ILX:0382354 .
 
-DICOM:0046_0210 ilxtr:hasIlxId ilx:0381744 .
+DICOM:0046_0210 ilxtr:hasIlxId ILX:0381744 .
 
-DICOM:0046_0211 ilxtr:hasIlxId ilx:0383165 .
+DICOM:0046_0211 ilxtr:hasIlxId ILX:0383165 .
 
-DICOM:0046_0212 ilxtr:hasIlxId ilx:0383131 .
+DICOM:0046_0212 ilxtr:hasIlxId ILX:0383131 .
 
-DICOM:0046_0213 ilxtr:hasIlxId ilx:0382231 .
+DICOM:0046_0213 ilxtr:hasIlxId ILX:0382231 .
 
-DICOM:0046_0215 ilxtr:hasIlxId ilx:0382618 .
+DICOM:0046_0215 ilxtr:hasIlxId ILX:0382618 .
 
-DICOM:0046_0218 ilxtr:hasIlxId ilx:0381459 .
+DICOM:0046_0218 ilxtr:hasIlxId ILX:0381459 .
 
-DICOM:0046_0220 ilxtr:hasIlxId ilx:0383034 .
+DICOM:0046_0220 ilxtr:hasIlxId ILX:0383034 .
 
-DICOM:0046_0224 ilxtr:hasIlxId ilx:0381952 .
+DICOM:0046_0224 ilxtr:hasIlxId ILX:0381952 .
 
-DICOM:0046_0227 ilxtr:hasIlxId ilx:0382502 .
+DICOM:0046_0227 ilxtr:hasIlxId ILX:0382502 .
 
-DICOM:0046_0230 ilxtr:hasIlxId ilx:0382177 .
+DICOM:0046_0230 ilxtr:hasIlxId ILX:0382177 .
 
-DICOM:0046_0232 ilxtr:hasIlxId ilx:0382582 .
+DICOM:0046_0232 ilxtr:hasIlxId ILX:0382582 .
 
-DICOM:0046_0234 ilxtr:hasIlxId ilx:0382143 .
+DICOM:0046_0234 ilxtr:hasIlxId ILX:0382143 .
 
-DICOM:0046_0236 ilxtr:hasIlxId ilx:0382980 .
+DICOM:0046_0236 ilxtr:hasIlxId ILX:0382980 .
 
-DICOM:0046_0238 ilxtr:hasIlxId ilx:0381777 .
+DICOM:0046_0238 ilxtr:hasIlxId ILX:0381777 .
 
-DICOM:0046_0242 ilxtr:hasIlxId ilx:0382393 .
+DICOM:0046_0242 ilxtr:hasIlxId ILX:0382393 .
 
-DICOM:0046_0244 ilxtr:hasIlxId ilx:0382902 .
+DICOM:0046_0244 ilxtr:hasIlxId ILX:0382902 .
 
-DICOM:0046_0247 ilxtr:hasIlxId ilx:0382525 .
+DICOM:0046_0247 ilxtr:hasIlxId ILX:0382525 .
 
-DICOM:0046_0248 ilxtr:hasIlxId ilx:0381815 .
+DICOM:0046_0248 ilxtr:hasIlxId ILX:0381815 .
 
-DICOM:0046_0249 ilxtr:hasIlxId ilx:0382020 .
+DICOM:0046_0249 ilxtr:hasIlxId ILX:0382020 .
 
-DICOM:0046_0250 ilxtr:hasIlxId ilx:0381911 .
+DICOM:0046_0250 ilxtr:hasIlxId ILX:0381911 .
 
-DICOM:0046_0251 ilxtr:hasIlxId ilx:0383118 .
+DICOM:0046_0251 ilxtr:hasIlxId ILX:0383118 .
 
-DICOM:0046_0252 ilxtr:hasIlxId ilx:0381868 .
+DICOM:0046_0252 ilxtr:hasIlxId ILX:0381868 .
 
-DICOM:0046_0253 ilxtr:hasIlxId ilx:0383049 .
+DICOM:0046_0253 ilxtr:hasIlxId ILX:0383049 .
 
-DICOM:0048_0001 ilxtr:hasIlxId ilx:0382642 .
+DICOM:0048_0001 ilxtr:hasIlxId ILX:0382642 .
 
-DICOM:0048_0002 ilxtr:hasIlxId ilx:0381545 .
+DICOM:0048_0002 ilxtr:hasIlxId ILX:0381545 .
 
-DICOM:0048_0003 ilxtr:hasIlxId ilx:0382338 .
+DICOM:0048_0003 ilxtr:hasIlxId ILX:0382338 .
 
-DICOM:0048_0006 ilxtr:hasIlxId ilx:0382649 .
+DICOM:0048_0006 ilxtr:hasIlxId ILX:0382649 .
 
-DICOM:0048_0007 ilxtr:hasIlxId ilx:0382651 .
+DICOM:0048_0007 ilxtr:hasIlxId ILX:0382651 .
 
-DICOM:0048_0008 ilxtr:hasIlxId ilx:0381546 .
+DICOM:0048_0008 ilxtr:hasIlxId ILX:0381546 .
 
-DICOM:0048_0010 ilxtr:hasIlxId ilx:0382709 .
+DICOM:0048_0010 ilxtr:hasIlxId ILX:0382709 .
 
-DICOM:0048_0011 ilxtr:hasIlxId ilx:0383080 .
+DICOM:0048_0011 ilxtr:hasIlxId ILX:0383080 .
 
-DICOM:0048_0012 ilxtr:hasIlxId ilx:0381785 .
+DICOM:0048_0012 ilxtr:hasIlxId ILX:0381785 .
 
-DICOM:0048_0013 ilxtr:hasIlxId ilx:0382747 .
+DICOM:0048_0013 ilxtr:hasIlxId ILX:0382747 .
 
-DICOM:0048_0014 ilxtr:hasIlxId ilx:0382054 .
+DICOM:0048_0014 ilxtr:hasIlxId ILX:0382054 .
 
-DICOM:0048_0015 ilxtr:hasIlxId ilx:0383005 .
+DICOM:0048_0015 ilxtr:hasIlxId ILX:0383005 .
 
-DICOM:0048_021A ilxtr:hasIlxId ilx:0381454 .
+DICOM:0048_021A ilxtr:hasIlxId ILX:0381454 .
 
-DICOM:0048_021E ilxtr:hasIlxId ilx:0382138 .
+DICOM:0048_021E ilxtr:hasIlxId ILX:0382138 .
 
-DICOM:0048_021F ilxtr:hasIlxId ilx:0382907 .
+DICOM:0048_021F ilxtr:hasIlxId ILX:0382907 .
 
-DICOM:0048_0100 ilxtr:hasIlxId ilx:0382842 .
+DICOM:0048_0100 ilxtr:hasIlxId ILX:0382842 .
 
-DICOM:0048_0102 ilxtr:hasIlxId ilx:0383030 .
+DICOM:0048_0102 ilxtr:hasIlxId ILX:0383030 .
 
-DICOM:0048_0105 ilxtr:hasIlxId ilx:0381494 .
+DICOM:0048_0105 ilxtr:hasIlxId ILX:0381494 .
 
-DICOM:0048_0106 ilxtr:hasIlxId ilx:0383161 .
+DICOM:0048_0106 ilxtr:hasIlxId ILX:0383161 .
 
-DICOM:0048_0107 ilxtr:hasIlxId ilx:0382660 .
+DICOM:0048_0107 ilxtr:hasIlxId ILX:0382660 .
 
-DICOM:0048_0108 ilxtr:hasIlxId ilx:0382820 .
+DICOM:0048_0108 ilxtr:hasIlxId ILX:0382820 .
 
-DICOM:0048_0110 ilxtr:hasIlxId ilx:0381478 .
+DICOM:0048_0110 ilxtr:hasIlxId ILX:0381478 .
 
-DICOM:0048_0111 ilxtr:hasIlxId ilx:0382817 .
+DICOM:0048_0111 ilxtr:hasIlxId ILX:0382817 .
 
-DICOM:0048_0112 ilxtr:hasIlxId ilx:0382137 .
+DICOM:0048_0112 ilxtr:hasIlxId ILX:0382137 .
 
-DICOM:0048_0113 ilxtr:hasIlxId ilx:0382087 .
+DICOM:0048_0113 ilxtr:hasIlxId ILX:0382087 .
 
-DICOM:0048_0120 ilxtr:hasIlxId ilx:0382782 .
+DICOM:0048_0120 ilxtr:hasIlxId ILX:0382782 .
 
-DICOM:0048_0200 ilxtr:hasIlxId ilx:0381636 .
+DICOM:0048_0200 ilxtr:hasIlxId ILX:0381636 .
 
-DICOM:0048_0201 ilxtr:hasIlxId ilx:0381808 .
+DICOM:0048_0201 ilxtr:hasIlxId ILX:0381808 .
 
-DICOM:0048_0202 ilxtr:hasIlxId ilx:0382371 .
+DICOM:0048_0202 ilxtr:hasIlxId ILX:0382371 .
 
-DICOM:0048_0207 ilxtr:hasIlxId ilx:0381906 .
+DICOM:0048_0207 ilxtr:hasIlxId ILX:0381906 .
 
-DICOM:0048_0301 ilxtr:hasIlxId ilx:0382066 .
+DICOM:0048_0301 ilxtr:hasIlxId ILX:0382066 .
 
-DICOM:0050_001A ilxtr:hasIlxId ilx:0382100 .
+DICOM:0050_001A ilxtr:hasIlxId ILX:0382100 .
 
-DICOM:0050_001B ilxtr:hasIlxId ilx:0381924 .
+DICOM:0050_001B ilxtr:hasIlxId ILX:0381924 .
 
-DICOM:0050_001C ilxtr:hasIlxId ilx:0381745 .
+DICOM:0050_001C ilxtr:hasIlxId ILX:0381745 .
 
-DICOM:0050_001D ilxtr:hasIlxId ilx:0381726 .
+DICOM:0050_001D ilxtr:hasIlxId ILX:0381726 .
 
-DICOM:0050_001E ilxtr:hasIlxId ilx:0382469 .
+DICOM:0050_001E ilxtr:hasIlxId ILX:0382469 .
 
-DICOM:0050_0004 ilxtr:hasIlxId ilx:0101581 .
+DICOM:0050_0004 ilxtr:hasIlxId ILX:0101581 .
 
-DICOM:0050_0010 ilxtr:hasIlxId ilx:0381709 .
+DICOM:0050_0010 ilxtr:hasIlxId ILX:0381709 .
 
-DICOM:0050_0012 ilxtr:hasIlxId ilx:0382261 .
+DICOM:0050_0012 ilxtr:hasIlxId ILX:0382261 .
 
-DICOM:0050_0013 ilxtr:hasIlxId ilx:0382935 .
+DICOM:0050_0013 ilxtr:hasIlxId ILX:0382935 .
 
-DICOM:0050_0014 ilxtr:hasIlxId ilx:0382284 .
+DICOM:0050_0014 ilxtr:hasIlxId ILX:0382284 .
 
-DICOM:0050_0015 ilxtr:hasIlxId ilx:0382731 .
+DICOM:0050_0015 ilxtr:hasIlxId ILX:0382731 .
 
-DICOM:0050_0016 ilxtr:hasIlxId ilx:0382400 .
+DICOM:0050_0016 ilxtr:hasIlxId ILX:0382400 .
 
-DICOM:0050_0017 ilxtr:hasIlxId ilx:0383037 .
+DICOM:0050_0017 ilxtr:hasIlxId ILX:0383037 .
 
-DICOM:0050_0018 ilxtr:hasIlxId ilx:0382475 .
+DICOM:0050_0018 ilxtr:hasIlxId ILX:0382475 .
 
-DICOM:0050_0019 ilxtr:hasIlxId ilx:0382033 .
+DICOM:0050_0019 ilxtr:hasIlxId ILX:0382033 .
 
-DICOM:0050_0020 ilxtr:hasIlxId ilx:0382208 .
+DICOM:0050_0020 ilxtr:hasIlxId ILX:0382208 .
 
-DICOM:50xx_0005 ilxtr:hasIlxId ilx:0102687 .
+DICOM:50xx_0005 ilxtr:hasIlxId ILX:0102687 .
 
-DICOM:50xx_0020 ilxtr:hasIlxId ilx:0112117 .
+DICOM:50xx_0020 ilxtr:hasIlxId ILX:0112117 .
 
-DICOM:50xx_0030 ilxtr:hasIlxId ilx:0101038 .
+DICOM:50xx_0030 ilxtr:hasIlxId ILX:0101038 .
 
-DICOM:50xx_1001 ilxtr:hasIlxId ilx:0102686 .
+DICOM:50xx_1001 ilxtr:hasIlxId ILX:0102686 .
 
-DICOM:0052_0001 ilxtr:hasIlxId ilx:0382609 .
+DICOM:0052_0001 ilxtr:hasIlxId ILX:0382609 .
 
-DICOM:0052_0002 ilxtr:hasIlxId ilx:0383045 .
+DICOM:0052_0002 ilxtr:hasIlxId ILX:0383045 .
 
-DICOM:0052_0003 ilxtr:hasIlxId ilx:0382871 .
+DICOM:0052_0003 ilxtr:hasIlxId ILX:0382871 .
 
-DICOM:0052_003A ilxtr:hasIlxId ilx:0382560 .
+DICOM:0052_003A ilxtr:hasIlxId ILX:0382560 .
 
-DICOM:0052_0004 ilxtr:hasIlxId ilx:0381568 .
+DICOM:0052_0004 ilxtr:hasIlxId ILX:0381568 .
 
-DICOM:0052_0006 ilxtr:hasIlxId ilx:0382422 .
+DICOM:0052_0006 ilxtr:hasIlxId ILX:0382422 .
 
-DICOM:0052_0007 ilxtr:hasIlxId ilx:0382312 .
+DICOM:0052_0007 ilxtr:hasIlxId ILX:0382312 .
 
-DICOM:0052_0008 ilxtr:hasIlxId ilx:0382451 .
+DICOM:0052_0008 ilxtr:hasIlxId ILX:0382451 .
 
-DICOM:0052_0009 ilxtr:hasIlxId ilx:0382803 .
+DICOM:0052_0009 ilxtr:hasIlxId ILX:0382803 .
 
-DICOM:0052_0011 ilxtr:hasIlxId ilx:0381869 .
+DICOM:0052_0011 ilxtr:hasIlxId ILX:0381869 .
 
-DICOM:0052_0012 ilxtr:hasIlxId ilx:0382719 .
+DICOM:0052_0012 ilxtr:hasIlxId ILX:0382719 .
 
-DICOM:0052_0013 ilxtr:hasIlxId ilx:0382974 .
+DICOM:0052_0013 ilxtr:hasIlxId ILX:0382974 .
 
-DICOM:0052_0014 ilxtr:hasIlxId ilx:0382436 .
+DICOM:0052_0014 ilxtr:hasIlxId ILX:0382436 .
 
-DICOM:0052_0016 ilxtr:hasIlxId ilx:0381894 .
+DICOM:0052_0016 ilxtr:hasIlxId ILX:0381894 .
 
-DICOM:0052_0025 ilxtr:hasIlxId ilx:0381486 .
+DICOM:0052_0025 ilxtr:hasIlxId ILX:0381486 .
 
-DICOM:0052_0026 ilxtr:hasIlxId ilx:0383058 .
+DICOM:0052_0026 ilxtr:hasIlxId ILX:0383058 .
 
-DICOM:0052_0027 ilxtr:hasIlxId ilx:0382916 .
+DICOM:0052_0027 ilxtr:hasIlxId ILX:0382916 .
 
-DICOM:0052_0028 ilxtr:hasIlxId ilx:0383091 .
+DICOM:0052_0028 ilxtr:hasIlxId ILX:0383091 .
 
-DICOM:0052_0029 ilxtr:hasIlxId ilx:0381778 .
+DICOM:0052_0029 ilxtr:hasIlxId ILX:0381778 .
 
-DICOM:0052_0030 ilxtr:hasIlxId ilx:0382347 .
+DICOM:0052_0030 ilxtr:hasIlxId ILX:0382347 .
 
-DICOM:0052_0031 ilxtr:hasIlxId ilx:0382585 .
+DICOM:0052_0031 ilxtr:hasIlxId ILX:0382585 .
 
-DICOM:0052_0033 ilxtr:hasIlxId ilx:0382835 .
+DICOM:0052_0033 ilxtr:hasIlxId ILX:0382835 .
 
-DICOM:0052_0034 ilxtr:hasIlxId ilx:0382511 .
+DICOM:0052_0034 ilxtr:hasIlxId ILX:0382511 .
 
-DICOM:0052_0036 ilxtr:hasIlxId ilx:0382543 .
+DICOM:0052_0036 ilxtr:hasIlxId ILX:0382543 .
 
-DICOM:0052_0038 ilxtr:hasIlxId ilx:0382827 .
+DICOM:0052_0038 ilxtr:hasIlxId ILX:0382827 .
 
-DICOM:0052_0039 ilxtr:hasIlxId ilx:0382631 .
+DICOM:0052_0039 ilxtr:hasIlxId ILX:0382631 .
 
-DICOM:0054_0010 ilxtr:hasIlxId ilx:0103820 .
+DICOM:0054_0010 ilxtr:hasIlxId ILX:0103820 .
 
-DICOM:0054_0011 ilxtr:hasIlxId ilx:0107818 .
+DICOM:0054_0011 ilxtr:hasIlxId ILX:0107818 .
 
-DICOM:0054_0012 ilxtr:hasIlxId ilx:0103814 .
+DICOM:0054_0012 ilxtr:hasIlxId ILX:0103814 .
 
-DICOM:0054_0013 ilxtr:hasIlxId ilx:0103818 .
+DICOM:0054_0013 ilxtr:hasIlxId ILX:0103818 .
 
-DICOM:0054_0014 ilxtr:hasIlxId ilx:0103815 .
+DICOM:0054_0014 ilxtr:hasIlxId ILX:0103815 .
 
-DICOM:0054_0015 ilxtr:hasIlxId ilx:0103819 .
+DICOM:0054_0015 ilxtr:hasIlxId ILX:0103819 .
 
-DICOM:0054_0016 ilxtr:hasIlxId ilx:0109627 .
+DICOM:0054_0016 ilxtr:hasIlxId ILX:0109627 .
 
-DICOM:0054_0017 ilxtr:hasIlxId ilx:0109956 .
+DICOM:0054_0017 ilxtr:hasIlxId ILX:0109956 .
 
-DICOM:0054_0018 ilxtr:hasIlxId ilx:0103816 .
+DICOM:0054_0018 ilxtr:hasIlxId ILX:0103816 .
 
-DICOM:0054_0020 ilxtr:hasIlxId ilx:0103157 .
+DICOM:0054_0020 ilxtr:hasIlxId ILX:0103157 .
 
-DICOM:0054_0021 ilxtr:hasIlxId ilx:0107816 .
+DICOM:0054_0021 ilxtr:hasIlxId ILX:0107816 .
 
-DICOM:0054_0022 ilxtr:hasIlxId ilx:0103146 .
+DICOM:0054_0022 ilxtr:hasIlxId ILX:0103146 .
 
-DICOM:0054_0030 ilxtr:hasIlxId ilx:0108792 .
+DICOM:0054_0030 ilxtr:hasIlxId ILX:0108792 .
 
-DICOM:0054_0031 ilxtr:hasIlxId ilx:0107833 .
+DICOM:0054_0031 ilxtr:hasIlxId ILX:0107833 .
 
-DICOM:0054_0032 ilxtr:hasIlxId ilx:0108790 .
+DICOM:0054_0032 ilxtr:hasIlxId ILX:0108790 .
 
-DICOM:0054_0033 ilxtr:hasIlxId ilx:0107825 .
+DICOM:0054_0033 ilxtr:hasIlxId ILX:0107825 .
 
-DICOM:0054_0036 ilxtr:hasIlxId ilx:0108788 .
+DICOM:0054_0036 ilxtr:hasIlxId ILX:0108788 .
 
-DICOM:0054_0038 ilxtr:hasIlxId ilx:0108623 .
+DICOM:0054_0038 ilxtr:hasIlxId ILX:0108623 .
 
-DICOM:0054_0039 ilxtr:hasIlxId ilx:0108789 .
+DICOM:0054_0039 ilxtr:hasIlxId ILX:0108789 .
 
-DICOM:0054_0050 ilxtr:hasIlxId ilx:0110233 .
+DICOM:0054_0050 ilxtr:hasIlxId ILX:0110233 .
 
-DICOM:0054_0051 ilxtr:hasIlxId ilx:0107836 .
+DICOM:0054_0051 ilxtr:hasIlxId ILX:0107836 .
 
-DICOM:0054_0052 ilxtr:hasIlxId ilx:0110231 .
+DICOM:0054_0052 ilxtr:hasIlxId ILX:0110231 .
 
-DICOM:0054_0053 ilxtr:hasIlxId ilx:0107826 .
+DICOM:0054_0053 ilxtr:hasIlxId ILX:0107826 .
 
-DICOM:0054_0060 ilxtr:hasIlxId ilx:0109590 .
+DICOM:0054_0060 ilxtr:hasIlxId ILX:0109590 .
 
-DICOM:0054_0061 ilxtr:hasIlxId ilx:0107835 .
+DICOM:0054_0061 ilxtr:hasIlxId ILX:0107835 .
 
-DICOM:0054_0062 ilxtr:hasIlxId ilx:0104568 .
+DICOM:0054_0062 ilxtr:hasIlxId ILX:0104568 .
 
-DICOM:0054_0063 ilxtr:hasIlxId ilx:0102822 .
+DICOM:0054_0063 ilxtr:hasIlxId ILX:0102822 .
 
-DICOM:0054_0070 ilxtr:hasIlxId ilx:0111757 .
+DICOM:0054_0070 ilxtr:hasIlxId ILX:0111757 .
 
-DICOM:0054_0071 ilxtr:hasIlxId ilx:0107846 .
+DICOM:0054_0071 ilxtr:hasIlxId ILX:0107846 .
 
-DICOM:0054_0072 ilxtr:hasIlxId ilx:0111755 .
+DICOM:0054_0072 ilxtr:hasIlxId ILX:0111755 .
 
-DICOM:0054_0073 ilxtr:hasIlxId ilx:0111756 .
+DICOM:0054_0073 ilxtr:hasIlxId ILX:0111756 .
 
-DICOM:0054_0080 ilxtr:hasIlxId ilx:0110674 .
+DICOM:0054_0080 ilxtr:hasIlxId ILX:0110674 .
 
-DICOM:0054_0081 ilxtr:hasIlxId ilx:0107838 .
+DICOM:0054_0081 ilxtr:hasIlxId ILX:0107838 .
 
-DICOM:0054_0090 ilxtr:hasIlxId ilx:0100631 .
+DICOM:0054_0090 ilxtr:hasIlxId ILX:0100631 .
 
-DICOM:0054_0100 ilxtr:hasIlxId ilx:0111754 .
+DICOM:0054_0100 ilxtr:hasIlxId ILX:0111754 .
 
-DICOM:0054_0101 ilxtr:hasIlxId ilx:0107845 .
+DICOM:0054_0101 ilxtr:hasIlxId ILX:0107845 .
 
-DICOM:0054_0200 ilxtr:hasIlxId ilx:0111022 .
+DICOM:0054_0200 ilxtr:hasIlxId ILX:0111022 .
 
-DICOM:0054_0202 ilxtr:hasIlxId ilx:0112118 .
+DICOM:0054_0202 ilxtr:hasIlxId ILX:0112118 .
 
-DICOM:0054_0210 ilxtr:hasIlxId ilx:0111974 .
+DICOM:0054_0210 ilxtr:hasIlxId ILX:0111974 .
 
-DICOM:0054_0211 ilxtr:hasIlxId ilx:0107848 .
+DICOM:0054_0211 ilxtr:hasIlxId ILX:0107848 .
 
-DICOM:0054_0220 ilxtr:hasIlxId ilx:0112473 .
+DICOM:0054_0220 ilxtr:hasIlxId ILX:0112473 .
 
-DICOM:0054_0222 ilxtr:hasIlxId ilx:0112474 .
+DICOM:0054_0222 ilxtr:hasIlxId ILX:0112474 .
 
-DICOM:0054_0300 ilxtr:hasIlxId ilx:0109621 .
+DICOM:0054_0300 ilxtr:hasIlxId ILX:0109621 .
 
-DICOM:0054_0302 ilxtr:hasIlxId ilx:0100332 .
+DICOM:0054_0302 ilxtr:hasIlxId ILX:0100332 .
 
-DICOM:0054_0304 ilxtr:hasIlxId ilx:0109626 .
+DICOM:0054_0304 ilxtr:hasIlxId ILX:0109626 .
 
-DICOM:0054_0306 ilxtr:hasIlxId ilx:0101580 .
+DICOM:0054_0306 ilxtr:hasIlxId ILX:0101580 .
 
-DICOM:0054_0308 ilxtr:hasIlxId ilx:0103817 .
+DICOM:0054_0308 ilxtr:hasIlxId ILX:0103817 .
 
-DICOM:0054_0400 ilxtr:hasIlxId ilx:0105236 .
+DICOM:0054_0400 ilxtr:hasIlxId ILX:0105236 .
 
-DICOM:0054_0410 ilxtr:hasIlxId ilx:0108591 .
+DICOM:0054_0410 ilxtr:hasIlxId ILX:0108591 .
 
-DICOM:0054_0412 ilxtr:hasIlxId ilx:0108592 .
+DICOM:0054_0412 ilxtr:hasIlxId ILX:0108592 .
 
-DICOM:0054_0414 ilxtr:hasIlxId ilx:0108588 .
+DICOM:0054_0414 ilxtr:hasIlxId ILX:0108588 .
 
-DICOM:0054_0500 ilxtr:hasIlxId ilx:0110671 .
+DICOM:0054_0500 ilxtr:hasIlxId ILX:0110671 .
 
-DICOM:0054_0501 ilxtr:hasIlxId ilx:0381549 .
+DICOM:0054_0501 ilxtr:hasIlxId ILX:0381549 .
 
-DICOM:0054_1000 ilxtr:hasIlxId ilx:0110548 .
+DICOM:0054_1000 ilxtr:hasIlxId ILX:0110548 .
 
-DICOM:0054_1001 ilxtr:hasIlxId ilx:0112181 .
+DICOM:0054_1001 ilxtr:hasIlxId ILX:0112181 .
 
-DICOM:0054_1002 ilxtr:hasIlxId ilx:0102604 .
+DICOM:0054_1002 ilxtr:hasIlxId ILX:0102604 .
 
-DICOM:0054_1004 ilxtr:hasIlxId ilx:0109929 .
+DICOM:0054_1004 ilxtr:hasIlxId ILX:0109929 .
 
-DICOM:0054_1006 ilxtr:hasIlxId ilx:0382590 .
+DICOM:0054_1006 ilxtr:hasIlxId ILX:0382590 .
 
-DICOM:0054_1100 ilxtr:hasIlxId ilx:0109642 .
+DICOM:0054_1100 ilxtr:hasIlxId ILX:0109642 .
 
-DICOM:0054_1101 ilxtr:hasIlxId ilx:0100986 .
+DICOM:0054_1101 ilxtr:hasIlxId ILX:0100986 .
 
-DICOM:0054_1102 ilxtr:hasIlxId ilx:0102868 .
+DICOM:0054_1102 ilxtr:hasIlxId ILX:0102868 .
 
-DICOM:0054_1103 ilxtr:hasIlxId ilx:0383190 .
+DICOM:0054_1103 ilxtr:hasIlxId ILX:0383190 .
 
-DICOM:0054_1104 ilxtr:hasIlxId ilx:0103147 .
+DICOM:0054_1104 ilxtr:hasIlxId ILX:0103147 .
 
-DICOM:0054_1105 ilxtr:hasIlxId ilx:0110371 .
+DICOM:0054_1105 ilxtr:hasIlxId ILX:0110371 .
 
-DICOM:0054_1200 ilxtr:hasIlxId ilx:0101033 .
+DICOM:0054_1200 ilxtr:hasIlxId ILX:0101033 .
 
-DICOM:0054_1201 ilxtr:hasIlxId ilx:0101035 .
+DICOM:0054_1201 ilxtr:hasIlxId ILX:0101035 .
 
-DICOM:0054_1202 ilxtr:hasIlxId ilx:0111904 .
+DICOM:0054_1202 ilxtr:hasIlxId ILX:0111904 .
 
-DICOM:0054_1203 ilxtr:hasIlxId ilx:0103143 .
+DICOM:0054_1203 ilxtr:hasIlxId ILX:0103143 .
 
-DICOM:0054_1210 ilxtr:hasIlxId ilx:0102347 .
+DICOM:0054_1210 ilxtr:hasIlxId ILX:0102347 .
 
-DICOM:0054_1220 ilxtr:hasIlxId ilx:0110439 .
+DICOM:0054_1220 ilxtr:hasIlxId ILX:0110439 .
 
-DICOM:0054_1300 ilxtr:hasIlxId ilx:0104421 .
+DICOM:0054_1300 ilxtr:hasIlxId ILX:0104421 .
 
-DICOM:0054_1310 ilxtr:hasIlxId ilx:0109285 .
+DICOM:0054_1310 ilxtr:hasIlxId ILX:0109285 .
 
-DICOM:0054_1311 ilxtr:hasIlxId ilx:0110438 .
+DICOM:0054_1311 ilxtr:hasIlxId ILX:0110438 .
 
-DICOM:0054_1320 ilxtr:hasIlxId ilx:0110672 .
+DICOM:0054_1320 ilxtr:hasIlxId ILX:0110672 .
 
-DICOM:0054_1321 ilxtr:hasIlxId ilx:0102869 .
+DICOM:0054_1321 ilxtr:hasIlxId ILX:0102869 .
 
-DICOM:0054_1322 ilxtr:hasIlxId ilx:0103521 .
+DICOM:0054_1322 ilxtr:hasIlxId ILX:0103521 .
 
-DICOM:0054_1323 ilxtr:hasIlxId ilx:0110372 .
+DICOM:0054_1323 ilxtr:hasIlxId ILX:0110372 .
 
-DICOM:0054_1324 ilxtr:hasIlxId ilx:0102861 .
+DICOM:0054_1324 ilxtr:hasIlxId ILX:0102861 .
 
-DICOM:0054_1330 ilxtr:hasIlxId ilx:0105237 .
+DICOM:0054_1330 ilxtr:hasIlxId ILX:0105237 .
 
-DICOM:0054_1400 ilxtr:hasIlxId ilx:0102603 .
+DICOM:0054_1400 ilxtr:hasIlxId ILX:0102603 .
 
-DICOM:0054_1401 ilxtr:hasIlxId ilx:0102860 .
+DICOM:0054_1401 ilxtr:hasIlxId ILX:0102860 .
 
-DICOM:0060_3000 ilxtr:hasIlxId ilx:0105078 .
+DICOM:0060_3000 ilxtr:hasIlxId ILX:0105078 .
 
-DICOM:0060_3002 ilxtr:hasIlxId ilx:0105077 .
+DICOM:0060_3002 ilxtr:hasIlxId ILX:0105077 .
 
-DICOM:0060_3004 ilxtr:hasIlxId ilx:0105075 .
+DICOM:0060_3004 ilxtr:hasIlxId ILX:0105075 .
 
-DICOM:0060_3006 ilxtr:hasIlxId ilx:0105076 .
+DICOM:0060_3006 ilxtr:hasIlxId ILX:0105076 .
 
-DICOM:0060_3008 ilxtr:hasIlxId ilx:0105072 .
+DICOM:0060_3008 ilxtr:hasIlxId ILX:0105072 .
 
-DICOM:0060_3010 ilxtr:hasIlxId ilx:0105074 .
+DICOM:0060_3010 ilxtr:hasIlxId ILX:0105074 .
 
-DICOM:0060_3020 ilxtr:hasIlxId ilx:0105073 .
+DICOM:0060_3020 ilxtr:hasIlxId ILX:0105073 .
 
-DICOM:60xx_0010 ilxtr:hasIlxId ilx:0108301 .
+DICOM:60xx_0010 ilxtr:hasIlxId ILX:0108301 .
 
-DICOM:60xx_0011 ilxtr:hasIlxId ilx:0108293 .
+DICOM:60xx_0011 ilxtr:hasIlxId ILX:0108293 .
 
-DICOM:60xx_0015 ilxtr:hasIlxId ilx:0107824 .
+DICOM:60xx_0015 ilxtr:hasIlxId ILX:0107824 .
 
-DICOM:60xx_0022 ilxtr:hasIlxId ilx:0108296 .
+DICOM:60xx_0022 ilxtr:hasIlxId ILX:0108296 .
 
-DICOM:60xx_0040 ilxtr:hasIlxId ilx:0108304 .
+DICOM:60xx_0040 ilxtr:hasIlxId ILX:0108304 .
 
-DICOM:60xx_0045 ilxtr:hasIlxId ilx:0108302 .
+DICOM:60xx_0045 ilxtr:hasIlxId ILX:0108302 .
 
-DICOM:60xx_0050 ilxtr:hasIlxId ilx:0108299 .
+DICOM:60xx_0050 ilxtr:hasIlxId ILX:0108299 .
 
-DICOM:60xx_0051 ilxtr:hasIlxId ilx:0105234 .
+DICOM:60xx_0051 ilxtr:hasIlxId ILX:0105234 .
 
-DICOM:60xx_0100 ilxtr:hasIlxId ilx:0108292 .
+DICOM:60xx_0100 ilxtr:hasIlxId ILX:0108292 .
 
-DICOM:60xx_0102 ilxtr:hasIlxId ilx:0108291 .
+DICOM:60xx_0102 ilxtr:hasIlxId ILX:0108291 .
 
-DICOM:60xx_1001 ilxtr:hasIlxId ilx:0108290 .
+DICOM:60xx_1001 ilxtr:hasIlxId ILX:0108290 .
 
-DICOM:60xx_1301 ilxtr:hasIlxId ilx:0110177 .
+DICOM:60xx_1301 ilxtr:hasIlxId ILX:0110177 .
 
-DICOM:60xx_1302 ilxtr:hasIlxId ilx:0110184 .
+DICOM:60xx_1302 ilxtr:hasIlxId ILX:0110184 .
 
-DICOM:60xx_1303 ilxtr:hasIlxId ilx:0110192 .
+DICOM:60xx_1303 ilxtr:hasIlxId ILX:0110192 .
 
-DICOM:60xx_1500 ilxtr:hasIlxId ilx:0108297 .
+DICOM:60xx_1500 ilxtr:hasIlxId ILX:0108297 .
 
-DICOM:60xx_3000 ilxtr:hasIlxId ilx:0108294 .
+DICOM:60xx_3000 ilxtr:hasIlxId ILX:0108294 .
 
-DICOM:0062_000A ilxtr:hasIlxId ilx:0382517 .
+DICOM:0062_000A ilxtr:hasIlxId ILX:0382517 .
 
-DICOM:0062_000B ilxtr:hasIlxId ilx:0382956 .
+DICOM:0062_000B ilxtr:hasIlxId ILX:0382956 .
 
-DICOM:0062_000C ilxtr:hasIlxId ilx:0382971 .
+DICOM:0062_000C ilxtr:hasIlxId ILX:0382971 .
 
-DICOM:0062_000D ilxtr:hasIlxId ilx:0382067 .
+DICOM:0062_000D ilxtr:hasIlxId ILX:0382067 .
 
-DICOM:0062_000E ilxtr:hasIlxId ilx:0381658 .
+DICOM:0062_000E ilxtr:hasIlxId ILX:0381658 .
 
-DICOM:0062_000F ilxtr:hasIlxId ilx:0381720 .
+DICOM:0062_000F ilxtr:hasIlxId ILX:0381720 .
 
-DICOM:0062_0001 ilxtr:hasIlxId ilx:0382348 .
+DICOM:0062_0001 ilxtr:hasIlxId ILX:0382348 .
 
-DICOM:0062_0002 ilxtr:hasIlxId ilx:0381762 .
+DICOM:0062_0002 ilxtr:hasIlxId ILX:0381762 .
 
-DICOM:0062_0003 ilxtr:hasIlxId ilx:0381481 .
+DICOM:0062_0003 ilxtr:hasIlxId ILX:0381481 .
 
-DICOM:0062_0004 ilxtr:hasIlxId ilx:0383127 .
+DICOM:0062_0004 ilxtr:hasIlxId ILX:0383127 .
 
-DICOM:0062_0005 ilxtr:hasIlxId ilx:0382232 .
+DICOM:0062_0005 ilxtr:hasIlxId ILX:0382232 .
 
-DICOM:0062_0006 ilxtr:hasIlxId ilx:0382625 .
+DICOM:0062_0006 ilxtr:hasIlxId ILX:0382625 .
 
-DICOM:0062_0007 ilxtr:hasIlxId ilx:0382732 .
+DICOM:0062_0007 ilxtr:hasIlxId ILX:0382732 .
 
-DICOM:0062_0008 ilxtr:hasIlxId ilx:0381642 .
+DICOM:0062_0008 ilxtr:hasIlxId ILX:0381642 .
 
-DICOM:0062_0009 ilxtr:hasIlxId ilx:0382637 .
+DICOM:0062_0009 ilxtr:hasIlxId ILX:0382637 .
 
-DICOM:0062_0010 ilxtr:hasIlxId ilx:0381567 .
+DICOM:0062_0010 ilxtr:hasIlxId ILX:0381567 .
 
-DICOM:0062_0011 ilxtr:hasIlxId ilx:0381755 .
+DICOM:0062_0011 ilxtr:hasIlxId ILX:0381755 .
 
-DICOM:0062_0012 ilxtr:hasIlxId ilx:0383163 .
+DICOM:0062_0012 ilxtr:hasIlxId ILX:0383163 .
 
-DICOM:0062_0020 ilxtr:hasIlxId ilx:0382616 .
+DICOM:0062_0020 ilxtr:hasIlxId ILX:0382616 .
 
-DICOM:0062_0021 ilxtr:hasIlxId ilx:0382882 .
+DICOM:0062_0021 ilxtr:hasIlxId ILX:0382882 .
 
-DICOM:0064_000F ilxtr:hasIlxId ilx:0383074 .
+DICOM:0064_000F ilxtr:hasIlxId ILX:0383074 .
 
-DICOM:0064_0002 ilxtr:hasIlxId ilx:0383063 .
+DICOM:0064_0002 ilxtr:hasIlxId ILX:0383063 .
 
-DICOM:0064_0003 ilxtr:hasIlxId ilx:0382443 .
+DICOM:0064_0003 ilxtr:hasIlxId ILX:0382443 .
 
-DICOM:0064_0005 ilxtr:hasIlxId ilx:0382264 .
+DICOM:0064_0005 ilxtr:hasIlxId ILX:0382264 .
 
-DICOM:0064_0007 ilxtr:hasIlxId ilx:0382441 .
+DICOM:0064_0007 ilxtr:hasIlxId ILX:0382441 .
 
-DICOM:0064_0008 ilxtr:hasIlxId ilx:0381477 .
+DICOM:0064_0008 ilxtr:hasIlxId ILX:0381477 .
 
-DICOM:0064_0009 ilxtr:hasIlxId ilx:0381803 .
+DICOM:0064_0009 ilxtr:hasIlxId ILX:0381803 .
 
-DICOM:0064_0010 ilxtr:hasIlxId ilx:0382594 .
+DICOM:0064_0010 ilxtr:hasIlxId ILX:0382594 .
 
-DICOM:0066_000A ilxtr:hasIlxId ilx:0382679 .
+DICOM:0066_000A ilxtr:hasIlxId ILX:0382679 .
 
-DICOM:0066_000B ilxtr:hasIlxId ilx:0381664 .
+DICOM:0066_000B ilxtr:hasIlxId ILX:0381664 .
 
-DICOM:0066_000C ilxtr:hasIlxId ilx:0382449 .
+DICOM:0066_000C ilxtr:hasIlxId ILX:0382449 .
 
-DICOM:0066_000D ilxtr:hasIlxId ilx:0382130 .
+DICOM:0066_000D ilxtr:hasIlxId ILX:0382130 .
 
-DICOM:0066_000E ilxtr:hasIlxId ilx:0382533 .
+DICOM:0066_000E ilxtr:hasIlxId ILX:0382533 .
 
-DICOM:0066_0001 ilxtr:hasIlxId ilx:0382671 .
+DICOM:0066_0001 ilxtr:hasIlxId ILX:0382671 .
 
-DICOM:0066_001A ilxtr:hasIlxId ilx:0382466 .
+DICOM:0066_001A ilxtr:hasIlxId ILX:0382466 .
 
-DICOM:0066_001B ilxtr:hasIlxId ilx:0382111 .
+DICOM:0066_001B ilxtr:hasIlxId ILX:0382111 .
 
-DICOM:0066_001C ilxtr:hasIlxId ilx:0382812 .
+DICOM:0066_001C ilxtr:hasIlxId ILX:0382812 .
 
-DICOM:0066_001E ilxtr:hasIlxId ilx:0382118 .
+DICOM:0066_001E ilxtr:hasIlxId ILX:0382118 .
 
-DICOM:0066_001F ilxtr:hasIlxId ilx:0382771 .
+DICOM:0066_001F ilxtr:hasIlxId ILX:0382771 .
 
-DICOM:0066_0002 ilxtr:hasIlxId ilx:0381475 .
+DICOM:0066_0002 ilxtr:hasIlxId ILX:0381475 .
 
-DICOM:0066_002A ilxtr:hasIlxId ilx:0382551 .
+DICOM:0066_002A ilxtr:hasIlxId ILX:0382551 .
 
-DICOM:0066_002B ilxtr:hasIlxId ilx:0383027 .
+DICOM:0066_002B ilxtr:hasIlxId ILX:0383027 .
 
-DICOM:0066_002C ilxtr:hasIlxId ilx:0382329 .
+DICOM:0066_002C ilxtr:hasIlxId ILX:0382329 .
 
-DICOM:0066_002D ilxtr:hasIlxId ilx:0381917 .
+DICOM:0066_002D ilxtr:hasIlxId ILX:0381917 .
 
-DICOM:0066_002E ilxtr:hasIlxId ilx:0382733 .
+DICOM:0066_002E ilxtr:hasIlxId ILX:0382733 .
 
-DICOM:0066_002F ilxtr:hasIlxId ilx:0381607 .
+DICOM:0066_002F ilxtr:hasIlxId ILX:0381607 .
 
-DICOM:0066_0003 ilxtr:hasIlxId ilx:0383044 .
+DICOM:0066_0003 ilxtr:hasIlxId ILX:0383044 .
 
-DICOM:0066_0004 ilxtr:hasIlxId ilx:0383136 .
+DICOM:0066_0004 ilxtr:hasIlxId ILX:0383136 .
 
-DICOM:0066_0009 ilxtr:hasIlxId ilx:0382602 .
+DICOM:0066_0009 ilxtr:hasIlxId ILX:0382602 .
 
-DICOM:0066_0010 ilxtr:hasIlxId ilx:0382406 .
+DICOM:0066_0010 ilxtr:hasIlxId ILX:0382406 .
 
-DICOM:0066_0011 ilxtr:hasIlxId ilx:0382832 .
+DICOM:0066_0011 ilxtr:hasIlxId ILX:0382832 .
 
-DICOM:0066_0012 ilxtr:hasIlxId ilx:0382703 .
+DICOM:0066_0012 ilxtr:hasIlxId ILX:0382703 .
 
-DICOM:0066_0013 ilxtr:hasIlxId ilx:0381501 .
+DICOM:0066_0013 ilxtr:hasIlxId ILX:0381501 .
 
-DICOM:0066_0015 ilxtr:hasIlxId ilx:0382781 .
+DICOM:0066_0015 ilxtr:hasIlxId ILX:0382781 .
 
-DICOM:0066_0016 ilxtr:hasIlxId ilx:0382777 .
+DICOM:0066_0016 ilxtr:hasIlxId ILX:0382777 .
 
-DICOM:0066_0017 ilxtr:hasIlxId ilx:0381822 .
+DICOM:0066_0017 ilxtr:hasIlxId ILX:0381822 .
 
-DICOM:0066_0018 ilxtr:hasIlxId ilx:0382947 .
+DICOM:0066_0018 ilxtr:hasIlxId ILX:0382947 .
 
-DICOM:0066_0019 ilxtr:hasIlxId ilx:0383141 .
+DICOM:0066_0019 ilxtr:hasIlxId ILX:0383141 .
 
-DICOM:0066_0020 ilxtr:hasIlxId ilx:0381788 .
+DICOM:0066_0020 ilxtr:hasIlxId ILX:0381788 .
 
-DICOM:0066_0021 ilxtr:hasIlxId ilx:0382828 .
+DICOM:0066_0021 ilxtr:hasIlxId ILX:0382828 .
 
-DICOM:0066_0026 ilxtr:hasIlxId ilx:0382388 .
+DICOM:0066_0026 ilxtr:hasIlxId ILX:0382388 .
 
-DICOM:0066_0027 ilxtr:hasIlxId ilx:0382426 .
+DICOM:0066_0027 ilxtr:hasIlxId ILX:0382426 .
 
-DICOM:0066_0028 ilxtr:hasIlxId ilx:0381584 .
+DICOM:0066_0028 ilxtr:hasIlxId ILX:0381584 .
 
-DICOM:0066_0030 ilxtr:hasIlxId ilx:0382185 .
+DICOM:0066_0030 ilxtr:hasIlxId ILX:0382185 .
 
-DICOM:0066_0031 ilxtr:hasIlxId ilx:0382161 .
+DICOM:0066_0031 ilxtr:hasIlxId ILX:0382161 .
 
-DICOM:0066_0032 ilxtr:hasIlxId ilx:0381805 .
+DICOM:0066_0032 ilxtr:hasIlxId ILX:0381805 .
 
-DICOM:0066_0034 ilxtr:hasIlxId ilx:0382901 .
+DICOM:0066_0034 ilxtr:hasIlxId ILX:0382901 .
 
-DICOM:0066_0035 ilxtr:hasIlxId ilx:0382058 .
+DICOM:0066_0035 ilxtr:hasIlxId ILX:0382058 .
 
-DICOM:0066_0036 ilxtr:hasIlxId ilx:0382157 .
+DICOM:0066_0036 ilxtr:hasIlxId ILX:0382157 .
 
-DICOM:0066_0037 ilxtr:hasIlxId ilx:0382028 .
+DICOM:0066_0037 ilxtr:hasIlxId ILX:0382028 .
 
-DICOM:0066_0038 ilxtr:hasIlxId ilx:0383066 .
+DICOM:0066_0038 ilxtr:hasIlxId ILX:0383066 .
 
-DICOM:0066_0040 ilxtr:hasIlxId ilx:0381993 .
+DICOM:0066_0040 ilxtr:hasIlxId ILX:0381993 .
 
-DICOM:0066_0041 ilxtr:hasIlxId ilx:0382370 .
+DICOM:0066_0041 ilxtr:hasIlxId ILX:0382370 .
 
-DICOM:0066_0042 ilxtr:hasIlxId ilx:0382897 .
+DICOM:0066_0042 ilxtr:hasIlxId ILX:0382897 .
 
-DICOM:0066_0043 ilxtr:hasIlxId ilx:0382247 .
+DICOM:0066_0043 ilxtr:hasIlxId ILX:0382247 .
 
-DICOM:0066_0101 ilxtr:hasIlxId ilx:0382346 .
+DICOM:0066_0101 ilxtr:hasIlxId ILX:0382346 .
 
-DICOM:0066_0102 ilxtr:hasIlxId ilx:0383009 .
+DICOM:0066_0102 ilxtr:hasIlxId ILX:0383009 .
 
-DICOM:0066_0103 ilxtr:hasIlxId ilx:0381872 .
+DICOM:0066_0103 ilxtr:hasIlxId ILX:0381872 .
 
-DICOM:0066_0104 ilxtr:hasIlxId ilx:0382285 .
+DICOM:0066_0104 ilxtr:hasIlxId ILX:0382285 .
 
-DICOM:0066_0105 ilxtr:hasIlxId ilx:0382672 .
+DICOM:0066_0105 ilxtr:hasIlxId ILX:0382672 .
 
-DICOM:0066_0106 ilxtr:hasIlxId ilx:0383121 .
+DICOM:0066_0106 ilxtr:hasIlxId ILX:0383121 .
 
-DICOM:0066_0107 ilxtr:hasIlxId ilx:0381474 .
+DICOM:0066_0107 ilxtr:hasIlxId ILX:0381474 .
 
-DICOM:0066_0108 ilxtr:hasIlxId ilx:0381680 .
+DICOM:0066_0108 ilxtr:hasIlxId ILX:0381680 .
 
-DICOM:0066_0121 ilxtr:hasIlxId ilx:0381633 .
+DICOM:0066_0121 ilxtr:hasIlxId ILX:0381633 .
 
-DICOM:0066_0124 ilxtr:hasIlxId ilx:0381593 .
+DICOM:0066_0124 ilxtr:hasIlxId ILX:0381593 .
 
-DICOM:0066_0125 ilxtr:hasIlxId ilx:0382474 .
+DICOM:0066_0125 ilxtr:hasIlxId ILX:0382474 .
 
-DICOM:0066_0129 ilxtr:hasIlxId ilx:0382356 .
+DICOM:0066_0129 ilxtr:hasIlxId ILX:0382356 .
 
-DICOM:0066_0130 ilxtr:hasIlxId ilx:0381757 .
+DICOM:0066_0130 ilxtr:hasIlxId ILX:0381757 .
 
-DICOM:0066_0132 ilxtr:hasIlxId ilx:0382200 .
+DICOM:0066_0132 ilxtr:hasIlxId ILX:0382200 .
 
-DICOM:0066_0133 ilxtr:hasIlxId ilx:0382460 .
+DICOM:0066_0133 ilxtr:hasIlxId ILX:0382460 .
 
-DICOM:0066_0134 ilxtr:hasIlxId ilx:0381652 .
+DICOM:0066_0134 ilxtr:hasIlxId ILX:0381652 .
 
-DICOM:0068_62A0 ilxtr:hasIlxId ilx:0382872 .
+DICOM:0068_62A0 ilxtr:hasIlxId ILX:0382872 .
 
-DICOM:0068_62A5 ilxtr:hasIlxId ilx:0381937 .
+DICOM:0068_62A5 ilxtr:hasIlxId ILX:0381937 .
 
-DICOM:0068_62C0 ilxtr:hasIlxId ilx:0382654 .
+DICOM:0068_62C0 ilxtr:hasIlxId ILX:0382654 .
 
-DICOM:0068_62D0 ilxtr:hasIlxId ilx:0382378 .
+DICOM:0068_62D0 ilxtr:hasIlxId ILX:0382378 .
 
-DICOM:0068_62D5 ilxtr:hasIlxId ilx:0381713 .
+DICOM:0068_62D5 ilxtr:hasIlxId ILX:0381713 .
 
-DICOM:0068_62E0 ilxtr:hasIlxId ilx:0381990 .
+DICOM:0068_62E0 ilxtr:hasIlxId ILX:0381990 .
 
-DICOM:0068_62F0 ilxtr:hasIlxId ilx:0381836 .
+DICOM:0068_62F0 ilxtr:hasIlxId ILX:0381836 .
 
-DICOM:0068_62F2 ilxtr:hasIlxId ilx:0381581 .
+DICOM:0068_62F2 ilxtr:hasIlxId ILX:0381581 .
 
-DICOM:0068_63A0 ilxtr:hasIlxId ilx:0382220 .
+DICOM:0068_63A0 ilxtr:hasIlxId ILX:0382220 .
 
-DICOM:0068_63A4 ilxtr:hasIlxId ilx:0382121 .
+DICOM:0068_63A4 ilxtr:hasIlxId ILX:0382121 .
 
-DICOM:0068_63A8 ilxtr:hasIlxId ilx:0381706 .
+DICOM:0068_63A8 ilxtr:hasIlxId ILX:0381706 .
 
-DICOM:0068_63AC ilxtr:hasIlxId ilx:0381802 .
+DICOM:0068_63AC ilxtr:hasIlxId ILX:0381802 .
 
-DICOM:0068_63B0 ilxtr:hasIlxId ilx:0382496 .
+DICOM:0068_63B0 ilxtr:hasIlxId ILX:0382496 .
 
-DICOM:0068_63C0 ilxtr:hasIlxId ilx:0382734 .
+DICOM:0068_63C0 ilxtr:hasIlxId ILX:0382734 .
 
-DICOM:0068_63D0 ilxtr:hasIlxId ilx:0383123 .
+DICOM:0068_63D0 ilxtr:hasIlxId ILX:0383123 .
 
-DICOM:0068_63E0 ilxtr:hasIlxId ilx:0383001 .
+DICOM:0068_63E0 ilxtr:hasIlxId ILX:0383001 .
 
-DICOM:0068_63F0 ilxtr:hasIlxId ilx:0382379 .
+DICOM:0068_63F0 ilxtr:hasIlxId ILX:0382379 .
 
-DICOM:0068_64A0 ilxtr:hasIlxId ilx:0381932 .
+DICOM:0068_64A0 ilxtr:hasIlxId ILX:0381932 .
 
-DICOM:0068_64C0 ilxtr:hasIlxId ilx:0381483 .
+DICOM:0068_64C0 ilxtr:hasIlxId ILX:0381483 .
 
-DICOM:0068_64D0 ilxtr:hasIlxId ilx:0382298 .
+DICOM:0068_64D0 ilxtr:hasIlxId ILX:0382298 .
 
-DICOM:0068_64F0 ilxtr:hasIlxId ilx:0381560 .
+DICOM:0068_64F0 ilxtr:hasIlxId ILX:0381560 .
 
-DICOM:0068_65A0 ilxtr:hasIlxId ilx:0382515 .
+DICOM:0068_65A0 ilxtr:hasIlxId ILX:0382515 .
 
-DICOM:0068_65B0 ilxtr:hasIlxId ilx:0381733 .
+DICOM:0068_65B0 ilxtr:hasIlxId ILX:0381733 .
 
-DICOM:0068_65D0 ilxtr:hasIlxId ilx:0382574 .
+DICOM:0068_65D0 ilxtr:hasIlxId ILX:0382574 .
 
-DICOM:0068_65E0 ilxtr:hasIlxId ilx:0381817 .
+DICOM:0068_65E0 ilxtr:hasIlxId ILX:0381817 .
 
-DICOM:0068_65F0 ilxtr:hasIlxId ilx:0382090 .
+DICOM:0068_65F0 ilxtr:hasIlxId ILX:0382090 .
 
-DICOM:0068_6210 ilxtr:hasIlxId ilx:0382795 .
+DICOM:0068_6210 ilxtr:hasIlxId ILX:0382795 .
 
-DICOM:0068_6221 ilxtr:hasIlxId ilx:0382035 .
+DICOM:0068_6221 ilxtr:hasIlxId ILX:0382035 .
 
-DICOM:0068_6222 ilxtr:hasIlxId ilx:0382676 .
+DICOM:0068_6222 ilxtr:hasIlxId ILX:0382676 .
 
-DICOM:0068_6223 ilxtr:hasIlxId ilx:0382770 .
+DICOM:0068_6223 ilxtr:hasIlxId ILX:0382770 .
 
-DICOM:0068_6224 ilxtr:hasIlxId ilx:0382539 .
+DICOM:0068_6224 ilxtr:hasIlxId ILX:0382539 .
 
-DICOM:0068_6225 ilxtr:hasIlxId ilx:0381533 .
+DICOM:0068_6225 ilxtr:hasIlxId ILX:0381533 .
 
-DICOM:0068_6226 ilxtr:hasIlxId ilx:0382505 .
+DICOM:0068_6226 ilxtr:hasIlxId ILX:0382505 .
 
-DICOM:0068_6230 ilxtr:hasIlxId ilx:0382870 .
+DICOM:0068_6230 ilxtr:hasIlxId ILX:0382870 .
 
-DICOM:0068_6260 ilxtr:hasIlxId ilx:0381678 .
+DICOM:0068_6260 ilxtr:hasIlxId ILX:0381678 .
 
-DICOM:0068_6265 ilxtr:hasIlxId ilx:0382758 .
+DICOM:0068_6265 ilxtr:hasIlxId ILX:0382758 .
 
-DICOM:0068_6270 ilxtr:hasIlxId ilx:0382333 .
+DICOM:0068_6270 ilxtr:hasIlxId ILX:0382333 .
 
-DICOM:0068_6280 ilxtr:hasIlxId ilx:0382373 .
+DICOM:0068_6280 ilxtr:hasIlxId ILX:0382373 .
 
-DICOM:0068_6300 ilxtr:hasIlxId ilx:0382752 .
+DICOM:0068_6300 ilxtr:hasIlxId ILX:0382752 .
 
-DICOM:0068_6310 ilxtr:hasIlxId ilx:0381631 .
+DICOM:0068_6310 ilxtr:hasIlxId ILX:0381631 .
 
-DICOM:0068_6320 ilxtr:hasIlxId ilx:0382071 .
+DICOM:0068_6320 ilxtr:hasIlxId ILX:0382071 .
 
-DICOM:0068_6330 ilxtr:hasIlxId ilx:0382790 .
+DICOM:0068_6330 ilxtr:hasIlxId ILX:0382790 .
 
-DICOM:0068_6340 ilxtr:hasIlxId ilx:0383029 .
+DICOM:0068_6340 ilxtr:hasIlxId ILX:0383029 .
 
-DICOM:0068_6345 ilxtr:hasIlxId ilx:0381838 .
+DICOM:0068_6345 ilxtr:hasIlxId ILX:0381838 .
 
-DICOM:0068_6346 ilxtr:hasIlxId ilx:0382073 .
+DICOM:0068_6346 ilxtr:hasIlxId ILX:0382073 .
 
-DICOM:0068_6347 ilxtr:hasIlxId ilx:0382647 .
+DICOM:0068_6347 ilxtr:hasIlxId ILX:0382647 .
 
-DICOM:0068_6350 ilxtr:hasIlxId ilx:0382392 .
+DICOM:0068_6350 ilxtr:hasIlxId ILX:0382392 .
 
-DICOM:0068_6360 ilxtr:hasIlxId ilx:0382892 .
+DICOM:0068_6360 ilxtr:hasIlxId ILX:0382892 .
 
-DICOM:0068_6380 ilxtr:hasIlxId ilx:0382380 .
+DICOM:0068_6380 ilxtr:hasIlxId ILX:0382380 .
 
-DICOM:0068_6390 ilxtr:hasIlxId ilx:0382002 .
+DICOM:0068_6390 ilxtr:hasIlxId ILX:0382002 .
 
-DICOM:0068_6400 ilxtr:hasIlxId ilx:0381653 .
+DICOM:0068_6400 ilxtr:hasIlxId ILX:0381653 .
 
-DICOM:0068_6410 ilxtr:hasIlxId ilx:0382684 .
+DICOM:0068_6410 ilxtr:hasIlxId ILX:0382684 .
 
-DICOM:0068_6420 ilxtr:hasIlxId ilx:0382295 .
+DICOM:0068_6420 ilxtr:hasIlxId ILX:0382295 .
 
-DICOM:0068_6430 ilxtr:hasIlxId ilx:0382611 .
+DICOM:0068_6430 ilxtr:hasIlxId ILX:0382611 .
 
-DICOM:0068_6440 ilxtr:hasIlxId ilx:0382856 .
+DICOM:0068_6440 ilxtr:hasIlxId ILX:0382856 .
 
-DICOM:0068_6450 ilxtr:hasIlxId ilx:0381820 .
+DICOM:0068_6450 ilxtr:hasIlxId ILX:0381820 .
 
-DICOM:0068_6460 ilxtr:hasIlxId ilx:0383152 .
+DICOM:0068_6460 ilxtr:hasIlxId ILX:0383152 .
 
-DICOM:0068_6470 ilxtr:hasIlxId ilx:0381508 .
+DICOM:0068_6470 ilxtr:hasIlxId ILX:0381508 .
 
-DICOM:0068_6490 ilxtr:hasIlxId ilx:0381908 .
+DICOM:0068_6490 ilxtr:hasIlxId ILX:0381908 .
 
-DICOM:0068_6500 ilxtr:hasIlxId ilx:0382934 .
+DICOM:0068_6500 ilxtr:hasIlxId ILX:0382934 .
 
-DICOM:0068_6510 ilxtr:hasIlxId ilx:0381665 .
+DICOM:0068_6510 ilxtr:hasIlxId ILX:0381665 .
 
-DICOM:0068_6520 ilxtr:hasIlxId ilx:0382112 .
+DICOM:0068_6520 ilxtr:hasIlxId ILX:0382112 .
 
-DICOM:0068_6530 ilxtr:hasIlxId ilx:0382115 .
+DICOM:0068_6530 ilxtr:hasIlxId ILX:0382115 .
 
-DICOM:0068_6540 ilxtr:hasIlxId ilx:0381623 .
+DICOM:0068_6540 ilxtr:hasIlxId ILX:0381623 .
 
-DICOM:0068_6545 ilxtr:hasIlxId ilx:0382610 .
+DICOM:0068_6545 ilxtr:hasIlxId ILX:0382610 .
 
-DICOM:0068_6550 ilxtr:hasIlxId ilx:0381616 .
+DICOM:0068_6550 ilxtr:hasIlxId ILX:0381616 .
 
-DICOM:0068_6560 ilxtr:hasIlxId ilx:0382914 .
+DICOM:0068_6560 ilxtr:hasIlxId ILX:0382914 .
 
-DICOM:0068_6590 ilxtr:hasIlxId ilx:0382280 .
+DICOM:0068_6590 ilxtr:hasIlxId ILX:0382280 .
 
-DICOM:0068_6610 ilxtr:hasIlxId ilx:0382448 .
+DICOM:0068_6610 ilxtr:hasIlxId ILX:0382448 .
 
-DICOM:0068_6620 ilxtr:hasIlxId ilx:0382636 .
+DICOM:0068_6620 ilxtr:hasIlxId ILX:0382636 .
 
-DICOM:0070_0001 ilxtr:hasIlxId ilx:0104750 .
+DICOM:0070_0001 ilxtr:hasIlxId ILX:0104750 .
 
-DICOM:0070_1A01 ilxtr:hasIlxId ilx:0382815 .
+DICOM:0070_1A01 ilxtr:hasIlxId ILX:0382815 .
 
-DICOM:0070_1A03 ilxtr:hasIlxId ilx:0381452 .
+DICOM:0070_1A03 ilxtr:hasIlxId ILX:0381452 .
 
-DICOM:0070_1A04 ilxtr:hasIlxId ilx:0382494 .
+DICOM:0070_1A04 ilxtr:hasIlxId ILX:0382494 .
 
-DICOM:0070_1A05 ilxtr:hasIlxId ilx:0381766 .
+DICOM:0070_1A05 ilxtr:hasIlxId ILX:0381766 .
 
-DICOM:0070_0002 ilxtr:hasIlxId ilx:0104755 .
+DICOM:0070_0002 ilxtr:hasIlxId ILX:0104755 .
 
-DICOM:0070_0003 ilxtr:hasIlxId ilx:0101401 .
+DICOM:0070_0003 ilxtr:hasIlxId ILX:0101401 .
 
-DICOM:0070_0004 ilxtr:hasIlxId ilx:0100618 .
+DICOM:0070_0004 ilxtr:hasIlxId ILX:0100618 .
 
-DICOM:0070_0005 ilxtr:hasIlxId ilx:0104751 .
+DICOM:0070_0005 ilxtr:hasIlxId ILX:0104751 .
 
-DICOM:0070_005A ilxtr:hasIlxId ilx:0382991 .
+DICOM:0070_005A ilxtr:hasIlxId ILX:0382991 .
 
-DICOM:0070_0006 ilxtr:hasIlxId ilx:0112170 .
+DICOM:0070_0006 ilxtr:hasIlxId ILX:0112170 .
 
-DICOM:0070_0008 ilxtr:hasIlxId ilx:0111647 .
+DICOM:0070_0008 ilxtr:hasIlxId ILX:0111647 .
 
-DICOM:0070_0009 ilxtr:hasIlxId ilx:0104761 .
+DICOM:0070_0009 ilxtr:hasIlxId ILX:0104761 .
 
-DICOM:0070_0010 ilxtr:hasIlxId ilx:0101404 .
+DICOM:0070_0010 ilxtr:hasIlxId ILX:0101404 .
 
-DICOM:0070_0011 ilxtr:hasIlxId ilx:0101402 .
+DICOM:0070_0011 ilxtr:hasIlxId ILX:0101402 .
 
-DICOM:0070_0012 ilxtr:hasIlxId ilx:0101403 .
+DICOM:0070_0012 ilxtr:hasIlxId ILX:0101403 .
 
-DICOM:0070_0014 ilxtr:hasIlxId ilx:0100617 .
+DICOM:0070_0014 ilxtr:hasIlxId ILX:0100617 .
 
-DICOM:0070_0015 ilxtr:hasIlxId ilx:0100619 .
+DICOM:0070_0015 ilxtr:hasIlxId ILX:0100619 .
 
-DICOM:0070_0020 ilxtr:hasIlxId ilx:0104753 .
+DICOM:0070_0020 ilxtr:hasIlxId ILX:0104753 .
 
-DICOM:0070_0021 ilxtr:hasIlxId ilx:0107827 .
+DICOM:0070_0021 ilxtr:hasIlxId ILX:0107827 .
 
-DICOM:0070_0022 ilxtr:hasIlxId ilx:0104752 .
+DICOM:0070_0022 ilxtr:hasIlxId ILX:0104752 .
 
-DICOM:0070_0023 ilxtr:hasIlxId ilx:0104762 .
+DICOM:0070_0023 ilxtr:hasIlxId ILX:0104762 .
 
-DICOM:0070_0024 ilxtr:hasIlxId ilx:0104754 .
+DICOM:0070_0024 ilxtr:hasIlxId ILX:0104754 .
 
-DICOM:0070_030A ilxtr:hasIlxId ilx:0381790 .
+DICOM:0070_030A ilxtr:hasIlxId ILX:0381790 .
 
-DICOM:0070_030B ilxtr:hasIlxId ilx:0383047 .
+DICOM:0070_030B ilxtr:hasIlxId ILX:0383047 .
 
-DICOM:0070_030C ilxtr:hasIlxId ilx:0382541 .
+DICOM:0070_030C ilxtr:hasIlxId ILX:0382541 .
 
-DICOM:0070_030D ilxtr:hasIlxId ilx:0109881 .
+DICOM:0070_030D ilxtr:hasIlxId ILX:0109881 .
 
-DICOM:0070_030F ilxtr:hasIlxId ilx:0104185 .
+DICOM:0070_030F ilxtr:hasIlxId ILX:0104185 .
 
-DICOM:0070_031A ilxtr:hasIlxId ilx:0104189 .
+DICOM:0070_031A ilxtr:hasIlxId ILX:0104189 .
 
-DICOM:0070_031C ilxtr:hasIlxId ilx:0382279 .
+DICOM:0070_031C ilxtr:hasIlxId ILX:0382279 .
 
-DICOM:0070_031E ilxtr:hasIlxId ilx:0104188 .
+DICOM:0070_031E ilxtr:hasIlxId ILX:0104188 .
 
-DICOM:0070_031F ilxtr:hasIlxId ilx:0382926 .
+DICOM:0070_031F ilxtr:hasIlxId ILX:0382926 .
 
-DICOM:0070_0041 ilxtr:hasIlxId ilx:0105235 .
+DICOM:0070_0041 ilxtr:hasIlxId ILX:0105235 .
 
-DICOM:0070_0042 ilxtr:hasIlxId ilx:0105252 .
+DICOM:0070_0042 ilxtr:hasIlxId ILX:0105252 .
 
-DICOM:0070_0052 ilxtr:hasIlxId ilx:0103326 .
+DICOM:0070_0052 ilxtr:hasIlxId ILX:0103326 .
 
-DICOM:0070_0053 ilxtr:hasIlxId ilx:0381518 .
+DICOM:0070_0053 ilxtr:hasIlxId ILX:0381518 .
 
-DICOM:0070_0060 ilxtr:hasIlxId ilx:0104760 .
+DICOM:0070_0060 ilxtr:hasIlxId ILX:0104760 .
 
-DICOM:0070_0062 ilxtr:hasIlxId ilx:0104757 .
+DICOM:0070_0062 ilxtr:hasIlxId ILX:0104757 .
 
-DICOM:0070_0066 ilxtr:hasIlxId ilx:0104758 .
+DICOM:0070_0066 ilxtr:hasIlxId ILX:0104758 .
 
-DICOM:0070_0067 ilxtr:hasIlxId ilx:0104759 .
+DICOM:0070_0067 ilxtr:hasIlxId ILX:0104759 .
 
-DICOM:0070_0068 ilxtr:hasIlxId ilx:0104756 .
+DICOM:0070_0068 ilxtr:hasIlxId ILX:0104756 .
 
-DICOM:0070_0080 ilxtr:hasIlxId ilx:0102509 .
+DICOM:0070_0080 ilxtr:hasIlxId ILX:0102509 .
 
-DICOM:0070_0081 ilxtr:hasIlxId ilx:0102507 .
+DICOM:0070_0081 ilxtr:hasIlxId ILX:0102507 .
 
-DICOM:0070_0082 ilxtr:hasIlxId ilx:0109238 .
+DICOM:0070_0082 ilxtr:hasIlxId ILX:0109238 .
 
-DICOM:0070_0083 ilxtr:hasIlxId ilx:0109239 .
+DICOM:0070_0083 ilxtr:hasIlxId ILX:0109239 .
 
-DICOM:0070_0084 ilxtr:hasIlxId ilx:0102505 .
+DICOM:0070_0084 ilxtr:hasIlxId ILX:0102505 .
 
-DICOM:0070_0086 ilxtr:hasIlxId ilx:0381900 .
+DICOM:0070_0086 ilxtr:hasIlxId ILX:0381900 .
 
-DICOM:0070_0087 ilxtr:hasIlxId ilx:0381558 .
+DICOM:0070_0087 ilxtr:hasIlxId ILX:0381558 .
 
-DICOM:0070_0100 ilxtr:hasIlxId ilx:0109246 .
+DICOM:0070_0100 ilxtr:hasIlxId ILX:0109246 .
 
-DICOM:0070_0101 ilxtr:hasIlxId ilx:0109245 .
+DICOM:0070_0101 ilxtr:hasIlxId ILX:0109245 .
 
-DICOM:0070_0102 ilxtr:hasIlxId ilx:0109243 .
+DICOM:0070_0102 ilxtr:hasIlxId ILX:0109243 .
 
-DICOM:0070_0103 ilxtr:hasIlxId ilx:0109244 .
+DICOM:0070_0103 ilxtr:hasIlxId ILX:0109244 .
 
-DICOM:0070_150C ilxtr:hasIlxId ilx:0382029 .
+DICOM:0070_150C ilxtr:hasIlxId ILX:0382029 .
 
-DICOM:0070_150D ilxtr:hasIlxId ilx:0381981 .
+DICOM:0070_150D ilxtr:hasIlxId ILX:0381981 .
 
-DICOM:0070_0207 ilxtr:hasIlxId ilx:0381572 .
+DICOM:0070_0207 ilxtr:hasIlxId ILX:0381572 .
 
-DICOM:0070_0208 ilxtr:hasIlxId ilx:0381837 .
+DICOM:0070_0208 ilxtr:hasIlxId ILX:0381837 .
 
-DICOM:0070_0209 ilxtr:hasIlxId ilx:0383075 .
+DICOM:0070_0209 ilxtr:hasIlxId ILX:0383075 .
 
-DICOM:0070_0226 ilxtr:hasIlxId ilx:0381544 .
+DICOM:0070_0226 ilxtr:hasIlxId ILX:0381544 .
 
-DICOM:0070_0227 ilxtr:hasIlxId ilx:0382547 .
+DICOM:0070_0227 ilxtr:hasIlxId ILX:0382547 .
 
-DICOM:0070_0228 ilxtr:hasIlxId ilx:0382244 .
+DICOM:0070_0228 ilxtr:hasIlxId ILX:0382244 .
 
-DICOM:0070_0229 ilxtr:hasIlxId ilx:0382004 .
+DICOM:0070_0229 ilxtr:hasIlxId ILX:0382004 .
 
-DICOM:0070_0230 ilxtr:hasIlxId ilx:0382182 .
+DICOM:0070_0230 ilxtr:hasIlxId ILX:0382182 .
 
-DICOM:0070_0231 ilxtr:hasIlxId ilx:0382468 .
+DICOM:0070_0231 ilxtr:hasIlxId ILX:0382468 .
 
-DICOM:0070_0232 ilxtr:hasIlxId ilx:0382352 .
+DICOM:0070_0232 ilxtr:hasIlxId ILX:0382352 .
 
-DICOM:0070_0233 ilxtr:hasIlxId ilx:0382746 .
+DICOM:0070_0233 ilxtr:hasIlxId ILX:0382746 .
 
-DICOM:0070_0234 ilxtr:hasIlxId ilx:0381535 .
+DICOM:0070_0234 ilxtr:hasIlxId ILX:0381535 .
 
-DICOM:0070_0241 ilxtr:hasIlxId ilx:0383099 .
+DICOM:0070_0241 ilxtr:hasIlxId ILX:0383099 .
 
-DICOM:0070_0242 ilxtr:hasIlxId ilx:0382681 .
+DICOM:0070_0242 ilxtr:hasIlxId ILX:0382681 .
 
-DICOM:0070_0243 ilxtr:hasIlxId ilx:0382424 .
+DICOM:0070_0243 ilxtr:hasIlxId ILX:0382424 .
 
-DICOM:0070_0244 ilxtr:hasIlxId ilx:0383056 .
+DICOM:0070_0244 ilxtr:hasIlxId ILX:0383056 .
 
-DICOM:0070_0245 ilxtr:hasIlxId ilx:0382141 .
+DICOM:0070_0245 ilxtr:hasIlxId ILX:0382141 .
 
-DICOM:0070_0246 ilxtr:hasIlxId ilx:0382826 .
+DICOM:0070_0246 ilxtr:hasIlxId ILX:0382826 .
 
-DICOM:0070_0247 ilxtr:hasIlxId ilx:0381647 .
+DICOM:0070_0247 ilxtr:hasIlxId ILX:0381647 .
 
-DICOM:0070_0248 ilxtr:hasIlxId ilx:0381595 .
+DICOM:0070_0248 ilxtr:hasIlxId ILX:0381595 .
 
-DICOM:0070_0249 ilxtr:hasIlxId ilx:0381455 .
+DICOM:0070_0249 ilxtr:hasIlxId ILX:0381455 .
 
-DICOM:0070_0250 ilxtr:hasIlxId ilx:0381557 .
+DICOM:0070_0250 ilxtr:hasIlxId ILX:0381557 .
 
-DICOM:0070_0251 ilxtr:hasIlxId ilx:0382078 .
+DICOM:0070_0251 ilxtr:hasIlxId ILX:0382078 .
 
-DICOM:0070_0252 ilxtr:hasIlxId ilx:0381683 .
+DICOM:0070_0252 ilxtr:hasIlxId ILX:0381683 .
 
-DICOM:0070_0253 ilxtr:hasIlxId ilx:0381659 .
+DICOM:0070_0253 ilxtr:hasIlxId ILX:0381659 .
 
-DICOM:0070_0254 ilxtr:hasIlxId ilx:0381781 .
+DICOM:0070_0254 ilxtr:hasIlxId ILX:0381781 .
 
-DICOM:0070_0255 ilxtr:hasIlxId ilx:0382252 .
+DICOM:0070_0255 ilxtr:hasIlxId ILX:0382252 .
 
-DICOM:0070_0256 ilxtr:hasIlxId ilx:0383092 .
+DICOM:0070_0256 ilxtr:hasIlxId ILX:0383092 .
 
-DICOM:0070_0257 ilxtr:hasIlxId ilx:0382026 .
+DICOM:0070_0257 ilxtr:hasIlxId ILX:0382026 .
 
-DICOM:0070_0258 ilxtr:hasIlxId ilx:0382645 .
+DICOM:0070_0258 ilxtr:hasIlxId ILX:0382645 .
 
-DICOM:0070_0261 ilxtr:hasIlxId ilx:0383160 .
+DICOM:0070_0261 ilxtr:hasIlxId ILX:0383160 .
 
-DICOM:0070_0262 ilxtr:hasIlxId ilx:0382630 .
+DICOM:0070_0262 ilxtr:hasIlxId ILX:0382630 .
 
-DICOM:0070_0273 ilxtr:hasIlxId ilx:0381979 .
+DICOM:0070_0273 ilxtr:hasIlxId ILX:0381979 .
 
-DICOM:0070_0274 ilxtr:hasIlxId ilx:0381527 .
+DICOM:0070_0274 ilxtr:hasIlxId ILX:0381527 .
 
-DICOM:0070_0278 ilxtr:hasIlxId ilx:0382845 .
+DICOM:0070_0278 ilxtr:hasIlxId ILX:0382845 .
 
-DICOM:0070_0279 ilxtr:hasIlxId ilx:0383014 .
+DICOM:0070_0279 ilxtr:hasIlxId ILX:0383014 .
 
-DICOM:0070_0282 ilxtr:hasIlxId ilx:0381514 .
+DICOM:0070_0282 ilxtr:hasIlxId ILX:0381514 .
 
-DICOM:0070_0284 ilxtr:hasIlxId ilx:0382725 .
+DICOM:0070_0284 ilxtr:hasIlxId ILX:0382725 .
 
-DICOM:0070_0285 ilxtr:hasIlxId ilx:0382900 .
+DICOM:0070_0285 ilxtr:hasIlxId ILX:0382900 .
 
-DICOM:0070_0287 ilxtr:hasIlxId ilx:0382186 .
+DICOM:0070_0287 ilxtr:hasIlxId ILX:0382186 .
 
-DICOM:0070_0288 ilxtr:hasIlxId ilx:0382011 .
+DICOM:0070_0288 ilxtr:hasIlxId ILX:0382011 .
 
-DICOM:0070_0289 ilxtr:hasIlxId ilx:0381625 .
+DICOM:0070_0289 ilxtr:hasIlxId ILX:0381625 .
 
-DICOM:0070_0294 ilxtr:hasIlxId ilx:0382236 .
+DICOM:0070_0294 ilxtr:hasIlxId ILX:0382236 .
 
-DICOM:0070_0295 ilxtr:hasIlxId ilx:0381575 .
+DICOM:0070_0295 ilxtr:hasIlxId ILX:0381575 .
 
-DICOM:0070_0306 ilxtr:hasIlxId ilx:0382420 .
+DICOM:0070_0306 ilxtr:hasIlxId ILX:0382420 .
 
-DICOM:0070_0308 ilxtr:hasIlxId ilx:0109879 .
+DICOM:0070_0308 ilxtr:hasIlxId ILX:0109879 .
 
-DICOM:0070_0309 ilxtr:hasIlxId ilx:0382940 .
+DICOM:0070_0309 ilxtr:hasIlxId ILX:0382940 .
 
-DICOM:0070_0310 ilxtr:hasIlxId ilx:0104186 .
+DICOM:0070_0310 ilxtr:hasIlxId ILX:0104186 .
 
-DICOM:0070_0311 ilxtr:hasIlxId ilx:0104187 .
+DICOM:0070_0311 ilxtr:hasIlxId ILX:0104187 .
 
-DICOM:0070_0312 ilxtr:hasIlxId ilx:0382275 .
+DICOM:0070_0312 ilxtr:hasIlxId ILX:0382275 .
 
-DICOM:0070_0314 ilxtr:hasIlxId ilx:0112212 .
+DICOM:0070_0314 ilxtr:hasIlxId ILX:0112212 .
 
-DICOM:0070_0318 ilxtr:hasIlxId ilx:0382757 .
+DICOM:0070_0318 ilxtr:hasIlxId ILX:0382757 .
 
-DICOM:0070_0401 ilxtr:hasIlxId ilx:0382677 .
+DICOM:0070_0401 ilxtr:hasIlxId ILX:0382677 .
 
-DICOM:0070_0402 ilxtr:hasIlxId ilx:0383031 .
+DICOM:0070_0402 ilxtr:hasIlxId ILX:0383031 .
 
-DICOM:0070_0403 ilxtr:hasIlxId ilx:0382227 .
+DICOM:0070_0403 ilxtr:hasIlxId ILX:0382227 .
 
-DICOM:0070_0404 ilxtr:hasIlxId ilx:0381891 .
+DICOM:0070_0404 ilxtr:hasIlxId ILX:0381891 .
 
-DICOM:0070_0405 ilxtr:hasIlxId ilx:0382669 .
+DICOM:0070_0405 ilxtr:hasIlxId ILX:0382669 .
 
-DICOM:0070_1101 ilxtr:hasIlxId ilx:0382434 .
+DICOM:0070_1101 ilxtr:hasIlxId ILX:0382434 .
 
-DICOM:0070_1102 ilxtr:hasIlxId ilx:0381922 .
+DICOM:0070_1102 ilxtr:hasIlxId ILX:0381922 .
 
-DICOM:0070_1103 ilxtr:hasIlxId ilx:0383072 .
+DICOM:0070_1103 ilxtr:hasIlxId ILX:0383072 .
 
-DICOM:0070_1104 ilxtr:hasIlxId ilx:0382938 .
+DICOM:0070_1104 ilxtr:hasIlxId ILX:0382938 .
 
-DICOM:0070_1201 ilxtr:hasIlxId ilx:0382305 .
+DICOM:0070_1201 ilxtr:hasIlxId ILX:0382305 .
 
-DICOM:0070_1202 ilxtr:hasIlxId ilx:0383095 .
+DICOM:0070_1202 ilxtr:hasIlxId ILX:0383095 .
 
-DICOM:0070_1203 ilxtr:hasIlxId ilx:0382620 .
+DICOM:0070_1203 ilxtr:hasIlxId ILX:0382620 .
 
-DICOM:0070_1204 ilxtr:hasIlxId ilx:0383135 .
+DICOM:0070_1204 ilxtr:hasIlxId ILX:0383135 .
 
-DICOM:0070_1205 ilxtr:hasIlxId ilx:0382847 .
+DICOM:0070_1205 ilxtr:hasIlxId ILX:0382847 .
 
-DICOM:0070_1206 ilxtr:hasIlxId ilx:0381620 .
+DICOM:0070_1206 ilxtr:hasIlxId ILX:0381620 .
 
-DICOM:0070_1207 ilxtr:hasIlxId ilx:0383144 .
+DICOM:0070_1207 ilxtr:hasIlxId ILX:0383144 .
 
-DICOM:0070_1301 ilxtr:hasIlxId ilx:0382315 .
+DICOM:0070_1301 ilxtr:hasIlxId ILX:0382315 .
 
-DICOM:0070_1302 ilxtr:hasIlxId ilx:0381944 .
+DICOM:0070_1302 ilxtr:hasIlxId ILX:0381944 .
 
-DICOM:0070_1303 ilxtr:hasIlxId ilx:0382077 .
+DICOM:0070_1303 ilxtr:hasIlxId ILX:0382077 .
 
-DICOM:0070_1304 ilxtr:hasIlxId ilx:0382314 .
+DICOM:0070_1304 ilxtr:hasIlxId ILX:0382314 .
 
-DICOM:0070_1305 ilxtr:hasIlxId ilx:0381768 .
+DICOM:0070_1305 ilxtr:hasIlxId ILX:0381768 .
 
-DICOM:0070_1306 ilxtr:hasIlxId ilx:0381507 .
+DICOM:0070_1306 ilxtr:hasIlxId ILX:0381507 .
 
-DICOM:0070_1309 ilxtr:hasIlxId ilx:0382922 .
+DICOM:0070_1309 ilxtr:hasIlxId ILX:0382922 .
 
-DICOM:0070_1501 ilxtr:hasIlxId ilx:0382169 .
+DICOM:0070_1501 ilxtr:hasIlxId ILX:0382169 .
 
-DICOM:0070_1502 ilxtr:hasIlxId ilx:0381469 .
+DICOM:0070_1502 ilxtr:hasIlxId ILX:0381469 .
 
-DICOM:0070_1505 ilxtr:hasIlxId ilx:0382753 .
+DICOM:0070_1505 ilxtr:hasIlxId ILX:0382753 .
 
-DICOM:0070_1507 ilxtr:hasIlxId ilx:0382431 .
+DICOM:0070_1507 ilxtr:hasIlxId ILX:0382431 .
 
-DICOM:0070_1508 ilxtr:hasIlxId ilx:0382259 .
+DICOM:0070_1508 ilxtr:hasIlxId ILX:0382259 .
 
-DICOM:0070_1511 ilxtr:hasIlxId ilx:0383053 .
+DICOM:0070_1511 ilxtr:hasIlxId ILX:0383053 .
 
-DICOM:0070_1512 ilxtr:hasIlxId ilx:0382509 .
+DICOM:0070_1512 ilxtr:hasIlxId ILX:0382509 .
 
-DICOM:0070_1801 ilxtr:hasIlxId ilx:0381855 .
+DICOM:0070_1801 ilxtr:hasIlxId ILX:0381855 .
 
-DICOM:0070_1802 ilxtr:hasIlxId ilx:0382738 .
+DICOM:0070_1802 ilxtr:hasIlxId ILX:0382738 .
 
-DICOM:0070_1803 ilxtr:hasIlxId ilx:0382714 .
+DICOM:0070_1803 ilxtr:hasIlxId ILX:0382714 .
 
-DICOM:0070_1804 ilxtr:hasIlxId ilx:0382534 .
+DICOM:0070_1804 ilxtr:hasIlxId ILX:0382534 .
 
-DICOM:0070_1805 ilxtr:hasIlxId ilx:0382395 .
+DICOM:0070_1805 ilxtr:hasIlxId ILX:0382395 .
 
-DICOM:0070_1806 ilxtr:hasIlxId ilx:0381968 .
+DICOM:0070_1806 ilxtr:hasIlxId ILX:0381968 .
 
-DICOM:0070_1901 ilxtr:hasIlxId ilx:0383138 .
+DICOM:0070_1901 ilxtr:hasIlxId ILX:0383138 .
 
-DICOM:0070_1903 ilxtr:hasIlxId ilx:0382824 .
+DICOM:0070_1903 ilxtr:hasIlxId ILX:0382824 .
 
-DICOM:0070_1904 ilxtr:hasIlxId ilx:0382156 .
+DICOM:0070_1904 ilxtr:hasIlxId ILX:0382156 .
 
-DICOM:0070_1905 ilxtr:hasIlxId ilx:0382268 .
+DICOM:0070_1905 ilxtr:hasIlxId ILX:0382268 .
 
-DICOM:0070_1907 ilxtr:hasIlxId ilx:0381799 .
+DICOM:0070_1907 ilxtr:hasIlxId ILX:0381799 .
 
-DICOM:0072_000A ilxtr:hasIlxId ilx:0382410 .
+DICOM:0072_000A ilxtr:hasIlxId ILX:0382410 .
 
-DICOM:0072_000C ilxtr:hasIlxId ilx:0383148 .
+DICOM:0072_000C ilxtr:hasIlxId ILX:0383148 .
 
-DICOM:0072_000E ilxtr:hasIlxId ilx:0382987 .
+DICOM:0072_000E ilxtr:hasIlxId ILX:0382987 .
 
-DICOM:0072_0002 ilxtr:hasIlxId ilx:0382074 .
+DICOM:0072_0002 ilxtr:hasIlxId ILX:0382074 .
 
-DICOM:0072_003A ilxtr:hasIlxId ilx:0382127 .
+DICOM:0072_003A ilxtr:hasIlxId ILX:0382127 .
 
-DICOM:0072_003C ilxtr:hasIlxId ilx:0382412 .
+DICOM:0072_003C ilxtr:hasIlxId ILX:0382412 .
 
-DICOM:0072_003E ilxtr:hasIlxId ilx:0383032 .
+DICOM:0072_003E ilxtr:hasIlxId ILX:0383032 .
 
-DICOM:0072_0004 ilxtr:hasIlxId ilx:0381919 .
+DICOM:0072_0004 ilxtr:hasIlxId ILX:0381919 .
 
-DICOM:0072_005E ilxtr:hasIlxId ilx:0382210 .
+DICOM:0072_005E ilxtr:hasIlxId ILX:0382210 .
 
-DICOM:0072_005F ilxtr:hasIlxId ilx:0382906 .
+DICOM:0072_005F ilxtr:hasIlxId ILX:0382906 .
 
-DICOM:0072_0006 ilxtr:hasIlxId ilx:0382235 .
+DICOM:0072_0006 ilxtr:hasIlxId ILX:0382235 .
 
-DICOM:0072_006A ilxtr:hasIlxId ilx:0382063 .
+DICOM:0072_006A ilxtr:hasIlxId ILX:0382063 .
 
-DICOM:0072_006B ilxtr:hasIlxId ilx:0381743 .
+DICOM:0072_006B ilxtr:hasIlxId ILX:0381743 .
 
-DICOM:0072_006C ilxtr:hasIlxId ilx:0381513 .
+DICOM:0072_006C ilxtr:hasIlxId ILX:0381513 .
 
-DICOM:0072_006D ilxtr:hasIlxId ilx:0381918 .
+DICOM:0072_006D ilxtr:hasIlxId ILX:0381918 .
 
-DICOM:0072_006E ilxtr:hasIlxId ilx:0381666 .
+DICOM:0072_006E ilxtr:hasIlxId ILX:0381666 .
 
-DICOM:0072_006F ilxtr:hasIlxId ilx:0381939 .
+DICOM:0072_006F ilxtr:hasIlxId ILX:0381939 .
 
-DICOM:0072_007A ilxtr:hasIlxId ilx:0382070 .
+DICOM:0072_007A ilxtr:hasIlxId ILX:0382070 .
 
-DICOM:0072_007C ilxtr:hasIlxId ilx:0382508 .
+DICOM:0072_007C ilxtr:hasIlxId ILX:0382508 .
 
-DICOM:0072_007E ilxtr:hasIlxId ilx:0382572 .
+DICOM:0072_007E ilxtr:hasIlxId ILX:0382572 .
 
-DICOM:0072_007F ilxtr:hasIlxId ilx:0382749 .
+DICOM:0072_007F ilxtr:hasIlxId ILX:0382749 .
 
-DICOM:0072_0008 ilxtr:hasIlxId ilx:0383103 .
+DICOM:0072_0008 ilxtr:hasIlxId ILX:0383103 .
 
-DICOM:0072_0010 ilxtr:hasIlxId ilx:0382792 .
+DICOM:0072_0010 ilxtr:hasIlxId ILX:0382792 .
 
-DICOM:0072_010A ilxtr:hasIlxId ilx:0381556 .
+DICOM:0072_010A ilxtr:hasIlxId ILX:0381556 .
 
-DICOM:0072_010C ilxtr:hasIlxId ilx:0381704 .
+DICOM:0072_010C ilxtr:hasIlxId ILX:0381704 .
 
-DICOM:0072_010E ilxtr:hasIlxId ilx:0382119 .
+DICOM:0072_010E ilxtr:hasIlxId ILX:0382119 .
 
-DICOM:0072_0012 ilxtr:hasIlxId ilx:0382586 .
+DICOM:0072_0012 ilxtr:hasIlxId ILX:0382586 .
 
-DICOM:0072_0014 ilxtr:hasIlxId ilx:0381797 .
+DICOM:0072_0014 ilxtr:hasIlxId ILX:0381797 .
 
-DICOM:0072_0020 ilxtr:hasIlxId ilx:0382846 .
+DICOM:0072_0020 ilxtr:hasIlxId ILX:0382846 .
 
-DICOM:0072_0022 ilxtr:hasIlxId ilx:0381701 .
+DICOM:0072_0022 ilxtr:hasIlxId ILX:0381701 .
 
-DICOM:0072_0024 ilxtr:hasIlxId ilx:0381458 .
+DICOM:0072_0024 ilxtr:hasIlxId ILX:0381458 .
 
-DICOM:0072_0026 ilxtr:hasIlxId ilx:0382658 .
+DICOM:0072_0026 ilxtr:hasIlxId ILX:0382658 .
 
-DICOM:0072_0028 ilxtr:hasIlxId ilx:0382655 .
+DICOM:0072_0028 ilxtr:hasIlxId ILX:0382655 .
 
-DICOM:0072_0030 ilxtr:hasIlxId ilx:0382288 .
+DICOM:0072_0030 ilxtr:hasIlxId ILX:0382288 .
 
-DICOM:0072_0032 ilxtr:hasIlxId ilx:0381614 .
+DICOM:0072_0032 ilxtr:hasIlxId ILX:0381614 .
 
-DICOM:0072_0034 ilxtr:hasIlxId ilx:0381769 .
+DICOM:0072_0034 ilxtr:hasIlxId ILX:0381769 .
 
-DICOM:0072_0038 ilxtr:hasIlxId ilx:0382017 .
+DICOM:0072_0038 ilxtr:hasIlxId ILX:0382017 .
 
-DICOM:0072_0040 ilxtr:hasIlxId ilx:0381859 .
+DICOM:0072_0040 ilxtr:hasIlxId ILX:0381859 .
 
-DICOM:0072_0050 ilxtr:hasIlxId ilx:0382120 .
+DICOM:0072_0050 ilxtr:hasIlxId ILX:0382120 .
 
-DICOM:0072_0052 ilxtr:hasIlxId ilx:0381884 .
+DICOM:0072_0052 ilxtr:hasIlxId ILX:0381884 .
 
-DICOM:0072_0054 ilxtr:hasIlxId ilx:0381690 .
+DICOM:0072_0054 ilxtr:hasIlxId ILX:0381690 .
 
-DICOM:0072_0056 ilxtr:hasIlxId ilx:0382168 .
+DICOM:0072_0056 ilxtr:hasIlxId ILX:0382168 .
 
-DICOM:0072_0060 ilxtr:hasIlxId ilx:0383067 .
+DICOM:0072_0060 ilxtr:hasIlxId ILX:0383067 .
 
-DICOM:0072_0061 ilxtr:hasIlxId ilx:0382962 .
+DICOM:0072_0061 ilxtr:hasIlxId ILX:0382962 .
 
-DICOM:0072_0062 ilxtr:hasIlxId ilx:0382428 .
+DICOM:0072_0062 ilxtr:hasIlxId ILX:0382428 .
 
-DICOM:0072_0063 ilxtr:hasIlxId ilx:0382217 .
+DICOM:0072_0063 ilxtr:hasIlxId ILX:0382217 .
 
-DICOM:0072_0064 ilxtr:hasIlxId ilx:0382713 .
+DICOM:0072_0064 ilxtr:hasIlxId ILX:0382713 .
 
-DICOM:0072_0065 ilxtr:hasIlxId ilx:0382766 .
+DICOM:0072_0065 ilxtr:hasIlxId ILX:0382766 .
 
-DICOM:0072_0066 ilxtr:hasIlxId ilx:0383050 .
+DICOM:0072_0066 ilxtr:hasIlxId ILX:0383050 .
 
-DICOM:0072_0067 ilxtr:hasIlxId ilx:0381960 .
+DICOM:0072_0067 ilxtr:hasIlxId ILX:0381960 .
 
-DICOM:0072_0068 ilxtr:hasIlxId ilx:0382199 .
+DICOM:0072_0068 ilxtr:hasIlxId ILX:0382199 .
 
-DICOM:0072_0069 ilxtr:hasIlxId ilx:0381761 .
+DICOM:0072_0069 ilxtr:hasIlxId ILX:0381761 .
 
-DICOM:0072_0070 ilxtr:hasIlxId ilx:0381851 .
+DICOM:0072_0070 ilxtr:hasIlxId ILX:0381851 .
 
-DICOM:0072_0071 ilxtr:hasIlxId ilx:0383159 .
+DICOM:0072_0071 ilxtr:hasIlxId ILX:0383159 .
 
-DICOM:0072_0072 ilxtr:hasIlxId ilx:0382318 .
+DICOM:0072_0072 ilxtr:hasIlxId ILX:0382318 .
 
-DICOM:0072_0073 ilxtr:hasIlxId ilx:0382695 .
+DICOM:0072_0073 ilxtr:hasIlxId ILX:0382695 .
 
-DICOM:0072_0074 ilxtr:hasIlxId ilx:0382818 .
+DICOM:0072_0074 ilxtr:hasIlxId ILX:0382818 .
 
-DICOM:0072_0075 ilxtr:hasIlxId ilx:0382621 .
+DICOM:0072_0075 ilxtr:hasIlxId ILX:0382621 .
 
-DICOM:0072_0076 ilxtr:hasIlxId ilx:0382316 .
+DICOM:0072_0076 ilxtr:hasIlxId ILX:0382316 .
 
-DICOM:0072_0078 ilxtr:hasIlxId ilx:0382635 .
+DICOM:0072_0078 ilxtr:hasIlxId ILX:0382635 .
 
-DICOM:0072_0080 ilxtr:hasIlxId ilx:0381497 .
+DICOM:0072_0080 ilxtr:hasIlxId ILX:0381497 .
 
-DICOM:0072_0100 ilxtr:hasIlxId ilx:0382702 .
+DICOM:0072_0100 ilxtr:hasIlxId ILX:0382702 .
 
-DICOM:0072_0102 ilxtr:hasIlxId ilx:0381715 .
+DICOM:0072_0102 ilxtr:hasIlxId ILX:0381715 .
 
-DICOM:0072_0104 ilxtr:hasIlxId ilx:0381793 .
+DICOM:0072_0104 ilxtr:hasIlxId ILX:0381793 .
 
-DICOM:0072_0106 ilxtr:hasIlxId ilx:0382013 .
+DICOM:0072_0106 ilxtr:hasIlxId ILX:0382013 .
 
-DICOM:0072_0108 ilxtr:hasIlxId ilx:0382042 .
+DICOM:0072_0108 ilxtr:hasIlxId ILX:0382042 .
 
-DICOM:0072_0200 ilxtr:hasIlxId ilx:0381951 .
+DICOM:0072_0200 ilxtr:hasIlxId ILX:0381951 .
 
-DICOM:0072_0202 ilxtr:hasIlxId ilx:0382928 .
+DICOM:0072_0202 ilxtr:hasIlxId ILX:0382928 .
 
-DICOM:0072_0203 ilxtr:hasIlxId ilx:0382278 .
+DICOM:0072_0203 ilxtr:hasIlxId ILX:0382278 .
 
-DICOM:0072_0204 ilxtr:hasIlxId ilx:0381734 .
+DICOM:0072_0204 ilxtr:hasIlxId ILX:0381734 .
 
-DICOM:0072_0206 ilxtr:hasIlxId ilx:0382589 .
+DICOM:0072_0206 ilxtr:hasIlxId ILX:0382589 .
 
-DICOM:0072_0208 ilxtr:hasIlxId ilx:0381962 .
+DICOM:0072_0208 ilxtr:hasIlxId ILX:0381962 .
 
-DICOM:0072_0210 ilxtr:hasIlxId ilx:0382353 .
+DICOM:0072_0210 ilxtr:hasIlxId ILX:0382353 .
 
-DICOM:0072_0212 ilxtr:hasIlxId ilx:0382485 .
+DICOM:0072_0212 ilxtr:hasIlxId ILX:0382485 .
 
-DICOM:0072_0214 ilxtr:hasIlxId ilx:0382563 .
+DICOM:0072_0214 ilxtr:hasIlxId ILX:0382563 .
 
-DICOM:0072_0216 ilxtr:hasIlxId ilx:0382045 .
+DICOM:0072_0216 ilxtr:hasIlxId ILX:0382045 .
 
-DICOM:0072_0218 ilxtr:hasIlxId ilx:0382221 .
+DICOM:0072_0218 ilxtr:hasIlxId ILX:0382221 .
 
-DICOM:0072_0300 ilxtr:hasIlxId ilx:0381691 .
+DICOM:0072_0300 ilxtr:hasIlxId ILX:0381691 .
 
-DICOM:0072_0302 ilxtr:hasIlxId ilx:0382959 .
+DICOM:0072_0302 ilxtr:hasIlxId ILX:0382959 .
 
-DICOM:0072_0304 ilxtr:hasIlxId ilx:0381705 .
+DICOM:0072_0304 ilxtr:hasIlxId ILX:0381705 .
 
-DICOM:0072_0306 ilxtr:hasIlxId ilx:0382417 .
+DICOM:0072_0306 ilxtr:hasIlxId ILX:0382417 .
 
-DICOM:0072_0308 ilxtr:hasIlxId ilx:0382638 .
+DICOM:0072_0308 ilxtr:hasIlxId ILX:0382638 .
 
-DICOM:0072_0310 ilxtr:hasIlxId ilx:0382258 .
+DICOM:0072_0310 ilxtr:hasIlxId ILX:0382258 .
 
-DICOM:0072_0312 ilxtr:hasIlxId ilx:0382237 .
+DICOM:0072_0312 ilxtr:hasIlxId ILX:0382237 .
 
-DICOM:0072_0314 ilxtr:hasIlxId ilx:0381555 .
+DICOM:0072_0314 ilxtr:hasIlxId ILX:0381555 .
 
-DICOM:0072_0316 ilxtr:hasIlxId ilx:0382550 .
+DICOM:0072_0316 ilxtr:hasIlxId ILX:0382550 .
 
-DICOM:0072_0318 ilxtr:hasIlxId ilx:0383042 .
+DICOM:0072_0318 ilxtr:hasIlxId ILX:0383042 .
 
-DICOM:0072_0320 ilxtr:hasIlxId ilx:0382774 .
+DICOM:0072_0320 ilxtr:hasIlxId ILX:0382774 .
 
-DICOM:0072_0330 ilxtr:hasIlxId ilx:0382402 .
+DICOM:0072_0330 ilxtr:hasIlxId ILX:0382402 .
 
-DICOM:0072_0400 ilxtr:hasIlxId ilx:0381601 .
+DICOM:0072_0400 ilxtr:hasIlxId ILX:0381601 .
 
-DICOM:0072_0402 ilxtr:hasIlxId ilx:0381604 .
+DICOM:0072_0402 ilxtr:hasIlxId ILX:0381604 .
 
-DICOM:0072_0404 ilxtr:hasIlxId ilx:0382396 .
+DICOM:0072_0404 ilxtr:hasIlxId ILX:0382396 .
 
-DICOM:0072_0406 ilxtr:hasIlxId ilx:0381612 .
+DICOM:0072_0406 ilxtr:hasIlxId ILX:0381612 .
 
-DICOM:0072_0420 ilxtr:hasIlxId ilx:0381456 .
+DICOM:0072_0420 ilxtr:hasIlxId ILX:0381456 .
 
-DICOM:0072_0421 ilxtr:hasIlxId ilx:0382097 .
+DICOM:0072_0421 ilxtr:hasIlxId ILX:0382097 .
 
-DICOM:0072_0422 ilxtr:hasIlxId ilx:0382641 .
+DICOM:0072_0422 ilxtr:hasIlxId ILX:0382641 .
 
-DICOM:0072_0424 ilxtr:hasIlxId ilx:0383102 .
+DICOM:0072_0424 ilxtr:hasIlxId ILX:0383102 .
 
-DICOM:0072_0427 ilxtr:hasIlxId ilx:0382963 .
+DICOM:0072_0427 ilxtr:hasIlxId ILX:0382963 .
 
-DICOM:0072_0430 ilxtr:hasIlxId ilx:0381832 .
+DICOM:0072_0430 ilxtr:hasIlxId ILX:0381832 .
 
-DICOM:0072_0432 ilxtr:hasIlxId ilx:0381779 .
+DICOM:0072_0432 ilxtr:hasIlxId ILX:0381779 .
 
-DICOM:0072_0434 ilxtr:hasIlxId ilx:0382692 .
+DICOM:0072_0434 ilxtr:hasIlxId ILX:0382692 .
 
-DICOM:0072_0500 ilxtr:hasIlxId ilx:0381591 .
+DICOM:0072_0500 ilxtr:hasIlxId ILX:0381591 .
 
-DICOM:0072_0510 ilxtr:hasIlxId ilx:0381796 .
+DICOM:0072_0510 ilxtr:hasIlxId ILX:0381796 .
 
-DICOM:0072_0512 ilxtr:hasIlxId ilx:0381871 .
+DICOM:0072_0512 ilxtr:hasIlxId ILX:0381871 .
 
-DICOM:0072_0514 ilxtr:hasIlxId ilx:0383078 .
+DICOM:0072_0514 ilxtr:hasIlxId ILX:0383078 .
 
-DICOM:0072_0516 ilxtr:hasIlxId ilx:0382503 .
+DICOM:0072_0516 ilxtr:hasIlxId ILX:0382503 .
 
-DICOM:0072_0520 ilxtr:hasIlxId ilx:0382061 .
+DICOM:0072_0520 ilxtr:hasIlxId ILX:0382061 .
 
-DICOM:0072_0600 ilxtr:hasIlxId ilx:0382793 .
+DICOM:0072_0600 ilxtr:hasIlxId ILX:0382793 .
 
-DICOM:0072_0602 ilxtr:hasIlxId ilx:0381569 .
+DICOM:0072_0602 ilxtr:hasIlxId ILX:0381569 .
 
-DICOM:0072_0604 ilxtr:hasIlxId ilx:0383062 .
+DICOM:0072_0604 ilxtr:hasIlxId ILX:0383062 .
 
-DICOM:0072_0700 ilxtr:hasIlxId ilx:0382240 .
+DICOM:0072_0700 ilxtr:hasIlxId ILX:0382240 .
 
-DICOM:0072_0702 ilxtr:hasIlxId ilx:0382988 .
+DICOM:0072_0702 ilxtr:hasIlxId ILX:0382988 .
 
-DICOM:0072_0704 ilxtr:hasIlxId ilx:0382960 .
+DICOM:0072_0704 ilxtr:hasIlxId ILX:0382960 .
 
-DICOM:0072_0705 ilxtr:hasIlxId ilx:0382866 .
+DICOM:0072_0705 ilxtr:hasIlxId ILX:0382866 .
 
-DICOM:0072_0706 ilxtr:hasIlxId ilx:0381925 .
+DICOM:0072_0706 ilxtr:hasIlxId ILX:0381925 .
 
-DICOM:0072_0710 ilxtr:hasIlxId ilx:0381742 .
+DICOM:0072_0710 ilxtr:hasIlxId ILX:0381742 .
 
-DICOM:0072_0712 ilxtr:hasIlxId ilx:0382174 .
+DICOM:0072_0712 ilxtr:hasIlxId ILX:0382174 .
 
-DICOM:0072_0714 ilxtr:hasIlxId ilx:0382500 .
+DICOM:0072_0714 ilxtr:hasIlxId ILX:0382500 .
 
-DICOM:0072_0716 ilxtr:hasIlxId ilx:0382569 .
+DICOM:0072_0716 ilxtr:hasIlxId ILX:0382569 .
 
-DICOM:0072_0717 ilxtr:hasIlxId ilx:0383149 .
+DICOM:0072_0717 ilxtr:hasIlxId ILX:0383149 .
 
-DICOM:0072_0718 ilxtr:hasIlxId ilx:0381703 .
+DICOM:0072_0718 ilxtr:hasIlxId ILX:0381703 .
 
-DICOM:0074_1057 ilxtr:hasIlxId ilx:0382019 .
+DICOM:0074_1057 ilxtr:hasIlxId ILX:0382019 .
 
-DICOM:0076_000A ilxtr:hasIlxId ilx:0382857 .
+DICOM:0076_000A ilxtr:hasIlxId ILX:0382857 .
 
-DICOM:0076_00A0 ilxtr:hasIlxId ilx:0381852 .
+DICOM:0076_00A0 ilxtr:hasIlxId ILX:0381852 .
 
-DICOM:0076_00B0 ilxtr:hasIlxId ilx:0382879 .
+DICOM:0076_00B0 ilxtr:hasIlxId ILX:0382879 .
 
-DICOM:0076_000C ilxtr:hasIlxId ilx:0382696 .
+DICOM:0076_000C ilxtr:hasIlxId ILX:0382696 .
 
-DICOM:0076_00C0 ilxtr:hasIlxId ilx:0382767 .
+DICOM:0076_00C0 ilxtr:hasIlxId ILX:0382767 .
 
-DICOM:0076_000E ilxtr:hasIlxId ilx:0382580 .
+DICOM:0076_000E ilxtr:hasIlxId ILX:0382580 .
 
-DICOM:0076_0001 ilxtr:hasIlxId ilx:0383129 .
+DICOM:0076_0001 ilxtr:hasIlxId ILX:0383129 .
 
-DICOM:0076_0003 ilxtr:hasIlxId ilx:0382599 .
+DICOM:0076_0003 ilxtr:hasIlxId ILX:0382599 .
 
-DICOM:0076_0006 ilxtr:hasIlxId ilx:0382537 .
+DICOM:0076_0006 ilxtr:hasIlxId ILX:0382537 .
 
-DICOM:0076_0008 ilxtr:hasIlxId ilx:0383000 .
+DICOM:0076_0008 ilxtr:hasIlxId ILX:0383000 .
 
-DICOM:0076_0010 ilxtr:hasIlxId ilx:0382328 .
+DICOM:0076_0010 ilxtr:hasIlxId ILX:0382328 .
 
-DICOM:0076_0020 ilxtr:hasIlxId ilx:0382715 .
+DICOM:0076_0020 ilxtr:hasIlxId ILX:0382715 .
 
-DICOM:0076_0030 ilxtr:hasIlxId ilx:0381676 .
+DICOM:0076_0030 ilxtr:hasIlxId ILX:0381676 .
 
-DICOM:0076_0032 ilxtr:hasIlxId ilx:0382584 .
+DICOM:0076_0032 ilxtr:hasIlxId ILX:0382584 .
 
-DICOM:0076_0034 ilxtr:hasIlxId ilx:0382957 .
+DICOM:0076_0034 ilxtr:hasIlxId ILX:0382957 .
 
-DICOM:0076_0036 ilxtr:hasIlxId ilx:0383172 .
+DICOM:0076_0036 ilxtr:hasIlxId ILX:0383172 .
 
-DICOM:0076_0038 ilxtr:hasIlxId ilx:0381764 .
+DICOM:0076_0038 ilxtr:hasIlxId ILX:0381764 .
 
-DICOM:0076_0040 ilxtr:hasIlxId ilx:0382439 .
+DICOM:0076_0040 ilxtr:hasIlxId ILX:0382439 .
 
-DICOM:0076_0055 ilxtr:hasIlxId ilx:0381752 .
+DICOM:0076_0055 ilxtr:hasIlxId ILX:0381752 .
 
-DICOM:0076_0060 ilxtr:hasIlxId ilx:0382320 .
+DICOM:0076_0060 ilxtr:hasIlxId ILX:0382320 .
 
-DICOM:0076_0070 ilxtr:hasIlxId ilx:0381887 .
+DICOM:0076_0070 ilxtr:hasIlxId ILX:0381887 .
 
-DICOM:0076_0080 ilxtr:hasIlxId ilx:0382223 .
+DICOM:0076_0080 ilxtr:hasIlxId ILX:0382223 .
 
-DICOM:0076_0090 ilxtr:hasIlxId ilx:0382086 .
+DICOM:0076_0090 ilxtr:hasIlxId ILX:0382086 .
 
-DICOM:0078_00A0 ilxtr:hasIlxId ilx:0382367 .
+DICOM:0078_00A0 ilxtr:hasIlxId ILX:0382367 .
 
-DICOM:0078_00B0 ilxtr:hasIlxId ilx:0381740 .
+DICOM:0078_00B0 ilxtr:hasIlxId ILX:0381740 .
 
-DICOM:0078_00B2 ilxtr:hasIlxId ilx:0382368 .
+DICOM:0078_00B2 ilxtr:hasIlxId ILX:0382368 .
 
-DICOM:0078_00B4 ilxtr:hasIlxId ilx:0383150 .
+DICOM:0078_00B4 ilxtr:hasIlxId ILX:0383150 .
 
-DICOM:0078_00B6 ilxtr:hasIlxId ilx:0381464 .
+DICOM:0078_00B6 ilxtr:hasIlxId ILX:0381464 .
 
-DICOM:0078_00B8 ilxtr:hasIlxId ilx:0382462 .
+DICOM:0078_00B8 ilxtr:hasIlxId ILX:0382462 .
 
-DICOM:0078_0001 ilxtr:hasIlxId ilx:0382811 .
+DICOM:0078_0001 ilxtr:hasIlxId ILX:0382811 .
 
-DICOM:0078_002A ilxtr:hasIlxId ilx:0382775 .
+DICOM:0078_002A ilxtr:hasIlxId ILX:0382775 .
 
-DICOM:0078_002E ilxtr:hasIlxId ilx:0382359 .
+DICOM:0078_002E ilxtr:hasIlxId ILX:0382359 .
 
-DICOM:0078_0010 ilxtr:hasIlxId ilx:0381816 .
+DICOM:0078_0010 ilxtr:hasIlxId ILX:0381816 .
 
-DICOM:0078_0020 ilxtr:hasIlxId ilx:0381610 .
+DICOM:0078_0020 ilxtr:hasIlxId ILX:0381610 .
 
-DICOM:0078_0024 ilxtr:hasIlxId ilx:0382939 .
+DICOM:0078_0024 ilxtr:hasIlxId ILX:0382939 .
 
-DICOM:0078_0026 ilxtr:hasIlxId ilx:0382238 .
+DICOM:0078_0026 ilxtr:hasIlxId ILX:0382238 .
 
-DICOM:0078_0028 ilxtr:hasIlxId ilx:0382453 .
+DICOM:0078_0028 ilxtr:hasIlxId ILX:0382453 .
 
-DICOM:0078_0050 ilxtr:hasIlxId ilx:0382917 .
+DICOM:0078_0050 ilxtr:hasIlxId ILX:0382917 .
 
-DICOM:0078_0060 ilxtr:hasIlxId ilx:0382756 .
+DICOM:0078_0060 ilxtr:hasIlxId ILX:0382756 .
 
-DICOM:0078_0070 ilxtr:hasIlxId ilx:0381931 .
+DICOM:0078_0070 ilxtr:hasIlxId ILX:0381931 .
 
-DICOM:0078_0090 ilxtr:hasIlxId ilx:0381957 .
+DICOM:0078_0090 ilxtr:hasIlxId ILX:0381957 .
 
-DICOM:0080_0001 ilxtr:hasIlxId ilx:0382623 .
+DICOM:0080_0001 ilxtr:hasIlxId ILX:0382623 .
 
-DICOM:0080_0002 ilxtr:hasIlxId ilx:0381629 .
+DICOM:0080_0002 ilxtr:hasIlxId ILX:0381629 .
 
-DICOM:0080_0003 ilxtr:hasIlxId ilx:0381714 .
+DICOM:0080_0003 ilxtr:hasIlxId ILX:0381714 .
 
-DICOM:0080_0004 ilxtr:hasIlxId ilx:0382140 .
+DICOM:0080_0004 ilxtr:hasIlxId ILX:0382140 .
 
-DICOM:0080_0005 ilxtr:hasIlxId ilx:0382797 .
+DICOM:0080_0005 ilxtr:hasIlxId ILX:0382797 .
 
-DICOM:0080_0006 ilxtr:hasIlxId ilx:0381789 .
+DICOM:0080_0006 ilxtr:hasIlxId ILX:0381789 .
 
-DICOM:0080_0007 ilxtr:hasIlxId ilx:0382051 .
+DICOM:0080_0007 ilxtr:hasIlxId ILX:0382051 .
 
-DICOM:0080_0008 ilxtr:hasIlxId ilx:0382255 .
+DICOM:0080_0008 ilxtr:hasIlxId ILX:0382255 .
 
-DICOM:0080_0009 ilxtr:hasIlxId ilx:0382282 .
+DICOM:0080_0009 ilxtr:hasIlxId ILX:0382282 .
 
-DICOM:0080_0010 ilxtr:hasIlxId ilx:0382965 .
+DICOM:0080_0010 ilxtr:hasIlxId ILX:0382965 .
 
-DICOM:0080_0011 ilxtr:hasIlxId ilx:0382760 .
+DICOM:0080_0011 ilxtr:hasIlxId ILX:0382760 .
 
-DICOM:0080_0012 ilxtr:hasIlxId ilx:0382219 .
+DICOM:0080_0012 ilxtr:hasIlxId ILX:0382219 .
 
-DICOM:0080_0013 ilxtr:hasIlxId ilx:0381780 .
+DICOM:0080_0013 ilxtr:hasIlxId ILX:0381780 .
 
-DICOM:0082_000A ilxtr:hasIlxId ilx:0382796 .
+DICOM:0082_000A ilxtr:hasIlxId ILX:0382796 .
 
-DICOM:0082_000C ilxtr:hasIlxId ilx:0381844 .
+DICOM:0082_000C ilxtr:hasIlxId ILX:0381844 .
 
-DICOM:0082_0001 ilxtr:hasIlxId ilx:0382044 .
+DICOM:0082_0001 ilxtr:hasIlxId ILX:0382044 .
 
-DICOM:0082_0003 ilxtr:hasIlxId ilx:0382666 .
+DICOM:0082_0003 ilxtr:hasIlxId ILX:0382666 .
 
-DICOM:0082_0004 ilxtr:hasIlxId ilx:0382952 .
+DICOM:0082_0004 ilxtr:hasIlxId ILX:0382952 .
 
-DICOM:0082_0005 ilxtr:hasIlxId ilx:0382578 .
+DICOM:0082_0005 ilxtr:hasIlxId ILX:0382578 .
 
-DICOM:0082_0006 ilxtr:hasIlxId ilx:0382575 .
+DICOM:0082_0006 ilxtr:hasIlxId ILX:0382575 .
 
-DICOM:0082_0007 ilxtr:hasIlxId ilx:0382110 .
+DICOM:0082_0007 ilxtr:hasIlxId ILX:0382110 .
 
-DICOM:0082_0008 ilxtr:hasIlxId ilx:0381776 .
+DICOM:0082_0008 ilxtr:hasIlxId ILX:0381776 .
 
-DICOM:0082_0010 ilxtr:hasIlxId ilx:0383013 .
+DICOM:0082_0010 ilxtr:hasIlxId ILX:0383013 .
 
-DICOM:0082_0016 ilxtr:hasIlxId ilx:0381609 .
+DICOM:0082_0016 ilxtr:hasIlxId ILX:0381609 .
 
-DICOM:0082_0017 ilxtr:hasIlxId ilx:0382345 .
+DICOM:0082_0017 ilxtr:hasIlxId ILX:0382345 .
 
-DICOM:0082_0018 ilxtr:hasIlxId ilx:0382408 .
+DICOM:0082_0018 ilxtr:hasIlxId ILX:0382408 .
 
-DICOM:0082_0019 ilxtr:hasIlxId ilx:0382385 .
+DICOM:0082_0019 ilxtr:hasIlxId ILX:0382385 .
 
-DICOM:0082_0021 ilxtr:hasIlxId ilx:0381585 .
+DICOM:0082_0021 ilxtr:hasIlxId ILX:0381585 .
 
-DICOM:0082_0022 ilxtr:hasIlxId ilx:0381898 .
+DICOM:0082_0022 ilxtr:hasIlxId ILX:0381898 .
 
-DICOM:0082_0023 ilxtr:hasIlxId ilx:0382722 .
+DICOM:0082_0023 ilxtr:hasIlxId ILX:0382722 .
 
-DICOM:0082_0032 ilxtr:hasIlxId ilx:0381747 .
+DICOM:0082_0032 ilxtr:hasIlxId ILX:0381747 .
 
-DICOM:0082_0033 ilxtr:hasIlxId ilx:0382739 .
+DICOM:0082_0033 ilxtr:hasIlxId ILX:0382739 .
 
-DICOM:0082_0034 ilxtr:hasIlxId ilx:0381965 .
+DICOM:0082_0034 ilxtr:hasIlxId ILX:0381965 .
 
-DICOM:0082_0035 ilxtr:hasIlxId ilx:0382129 .
+DICOM:0082_0035 ilxtr:hasIlxId ILX:0382129 .
 
-DICOM:0082_0036 ilxtr:hasIlxId ilx:0382978 .
+DICOM:0082_0036 ilxtr:hasIlxId ILX:0382978 .
 
-DICOM:0082_0037 ilxtr:hasIlxId ilx:0382764 .
+DICOM:0082_0037 ilxtr:hasIlxId ILX:0382764 .
 
-DICOM:0082_0038 ilxtr:hasIlxId ilx:0382624 .
+DICOM:0082_0038 ilxtr:hasIlxId ILX:0382624 .
 
-DICOM:0088_0130 ilxtr:hasIlxId ilx:0111070 .
+DICOM:0088_0130 ilxtr:hasIlxId ILX:0111070 .
 
-DICOM:0088_0140 ilxtr:hasIlxId ilx:0111071 .
+DICOM:0088_0140 ilxtr:hasIlxId ILX:0111071 .
 
-DICOM:0088_0200 ilxtr:hasIlxId ilx:0105206 .
+DICOM:0088_0200 ilxtr:hasIlxId ILX:0105206 .
 
-DICOM:0100_0410 ilxtr:hasIlxId ilx:0110766 .
+DICOM:0100_0410 ilxtr:hasIlxId ILX:0110766 .
 
-DICOM:0100_0420 ilxtr:hasIlxId ilx:0110763 .
+DICOM:0100_0420 ilxtr:hasIlxId ILX:0110763 .
 
-DICOM:0100_0424 ilxtr:hasIlxId ilx:0110762 .
+DICOM:0100_0424 ilxtr:hasIlxId ILX:0110762 .
 
-DICOM:0100_0426 ilxtr:hasIlxId ilx:0101014 .
+DICOM:0100_0426 ilxtr:hasIlxId ILX:0101014 .
 
-DICOM:300A_000A ilxtr:hasIlxId ilx:0111931 .
+DICOM:300A_000A ilxtr:hasIlxId ILX:0111931 .
 
-DICOM:300A_00A0 ilxtr:hasIlxId ilx:0107812 .
+DICOM:300A_00A0 ilxtr:hasIlxId ILX:0107812 .
 
-DICOM:300A_00A2 ilxtr:hasIlxId ilx:0101419 .
+DICOM:300A_00A2 ilxtr:hasIlxId ILX:0101419 .
 
-DICOM:300A_00A4 ilxtr:hasIlxId ilx:0101418 .
+DICOM:300A_00A4 ilxtr:hasIlxId ILX:0101418 .
 
-DICOM:300A_000B ilxtr:hasIlxId ilx:0111937 .
+DICOM:300A_000B ilxtr:hasIlxId ILX:0111937 .
 
-DICOM:300A_00B0 ilxtr:hasIlxId ilx:0101155 .
+DICOM:300A_00B0 ilxtr:hasIlxId ILX:0101155 .
 
-DICOM:300A_00B2 ilxtr:hasIlxId ilx:0111932 .
+DICOM:300A_00B2 ilxtr:hasIlxId ILX:0111932 .
 
-DICOM:300A_00B3 ilxtr:hasIlxId ilx:0109269 .
+DICOM:300A_00B3 ilxtr:hasIlxId ILX:0109269 .
 
-DICOM:300A_00B4 ilxtr:hasIlxId ilx:0110811 .
+DICOM:300A_00B4 ilxtr:hasIlxId ILX:0110811 .
 
-DICOM:300A_00B6 ilxtr:hasIlxId ilx:0101150 .
+DICOM:300A_00B6 ilxtr:hasIlxId ILX:0101150 .
 
-DICOM:300A_00B8 ilxtr:hasIlxId ilx:0110241 .
+DICOM:300A_00B8 ilxtr:hasIlxId ILX:0110241 .
 
-DICOM:300A_00BA ilxtr:hasIlxId ilx:0110802 .
+DICOM:300A_00BA ilxtr:hasIlxId ILX:0110802 .
 
-DICOM:300A_00BC ilxtr:hasIlxId ilx:0382705 .
+DICOM:300A_00BC ilxtr:hasIlxId ILX:0382705 .
 
-DICOM:300A_00BE ilxtr:hasIlxId ilx:0106149 .
+DICOM:300A_00BE ilxtr:hasIlxId ILX:0106149 .
 
-DICOM:300A_000C ilxtr:hasIlxId ilx:0110252 .
+DICOM:300A_000C ilxtr:hasIlxId ILX:0110252 .
 
-DICOM:300A_00C0 ilxtr:hasIlxId ilx:0101154 .
+DICOM:300A_00C0 ilxtr:hasIlxId ILX:0101154 .
 
-DICOM:300A_00C2 ilxtr:hasIlxId ilx:0101153 .
+DICOM:300A_00C2 ilxtr:hasIlxId ILX:0101153 .
 
-DICOM:300A_00C3 ilxtr:hasIlxId ilx:0101141 .
+DICOM:300A_00C3 ilxtr:hasIlxId ILX:0101141 .
 
-DICOM:300A_00C4 ilxtr:hasIlxId ilx:0101157 .
+DICOM:300A_00C4 ilxtr:hasIlxId ILX:0101157 .
 
-DICOM:300A_00C5 ilxtr:hasIlxId ilx:0382629 .
+DICOM:300A_00C5 ilxtr:hasIlxId ILX:0382629 .
 
-DICOM:300A_00C6 ilxtr:hasIlxId ilx:0109617 .
+DICOM:300A_00C6 ilxtr:hasIlxId ILX:0109617 .
 
-DICOM:300A_00C7 ilxtr:hasIlxId ilx:0104998 .
+DICOM:300A_00C7 ilxtr:hasIlxId ILX:0104998 .
 
-DICOM:300A_00C8 ilxtr:hasIlxId ilx:0109731 .
+DICOM:300A_00C8 ilxtr:hasIlxId ILX:0109731 .
 
-DICOM:300A_00CA ilxtr:hasIlxId ilx:0108972 .
+DICOM:300A_00CA ilxtr:hasIlxId ILX:0108972 .
 
-DICOM:300A_00CC ilxtr:hasIlxId ilx:0105261 .
+DICOM:300A_00CC ilxtr:hasIlxId ILX:0105261 .
 
-DICOM:300A_00CE ilxtr:hasIlxId ilx:0111930 .
+DICOM:300A_00CE ilxtr:hasIlxId ILX:0111930 .
 
-DICOM:300A_00D0 ilxtr:hasIlxId ilx:0107852 .
+DICOM:300A_00D0 ilxtr:hasIlxId ILX:0107852 .
 
-DICOM:300A_00D1 ilxtr:hasIlxId ilx:0112614 .
+DICOM:300A_00D1 ilxtr:hasIlxId ILX:0112614 .
 
-DICOM:300A_00D2 ilxtr:hasIlxId ilx:0112610 .
+DICOM:300A_00D2 ilxtr:hasIlxId ILX:0112610 .
 
-DICOM:300A_00D3 ilxtr:hasIlxId ilx:0112615 .
+DICOM:300A_00D3 ilxtr:hasIlxId ILX:0112615 .
 
-DICOM:300A_00D4 ilxtr:hasIlxId ilx:0112609 .
+DICOM:300A_00D4 ilxtr:hasIlxId ILX:0112609 .
 
-DICOM:300A_00D5 ilxtr:hasIlxId ilx:0112607 .
+DICOM:300A_00D5 ilxtr:hasIlxId ILX:0112607 .
 
-DICOM:300A_00D6 ilxtr:hasIlxId ilx:0112608 .
+DICOM:300A_00D6 ilxtr:hasIlxId ILX:0112608 .
 
-DICOM:300A_00D8 ilxtr:hasIlxId ilx:0112611 .
+DICOM:300A_00D8 ilxtr:hasIlxId ILX:0112611 .
 
-DICOM:300A_00DA ilxtr:hasIlxId ilx:0110808 .
+DICOM:300A_00DA ilxtr:hasIlxId ILX:0110808 .
 
-DICOM:300A_00DC ilxtr:hasIlxId ilx:0381736 .
+DICOM:300A_00DC ilxtr:hasIlxId ILX:0381736 .
 
-DICOM:300A_00DD ilxtr:hasIlxId ilx:0383083 .
+DICOM:300A_00DD ilxtr:hasIlxId ILX:0383083 .
 
-DICOM:300A_00DE ilxtr:hasIlxId ilx:0382716 .
+DICOM:300A_00DE ilxtr:hasIlxId ILX:0382716 .
 
-DICOM:300A_000E ilxtr:hasIlxId ilx:0109237 .
+DICOM:300A_000E ilxtr:hasIlxId ILX:0109237 .
 
-DICOM:300A_00E0 ilxtr:hasIlxId ilx:0107813 .
+DICOM:300A_00E0 ilxtr:hasIlxId ILX:0107813 .
 
-DICOM:300A_00E1 ilxtr:hasIlxId ilx:0106553 .
+DICOM:300A_00E1 ilxtr:hasIlxId ILX:0106553 .
 
-DICOM:300A_00E2 ilxtr:hasIlxId ilx:0111827 .
+DICOM:300A_00E2 ilxtr:hasIlxId ILX:0111827 .
 
-DICOM:300A_00E3 ilxtr:hasIlxId ilx:0102424 .
+DICOM:300A_00E3 ilxtr:hasIlxId ILX:0102424 .
 
-DICOM:300A_00E4 ilxtr:hasIlxId ilx:0102420 .
+DICOM:300A_00E4 ilxtr:hasIlxId ILX:0102420 .
 
-DICOM:300A_00E5 ilxtr:hasIlxId ilx:0102418 .
+DICOM:300A_00E5 ilxtr:hasIlxId ILX:0102418 .
 
-DICOM:300A_00E6 ilxtr:hasIlxId ilx:0110805 .
+DICOM:300A_00E6 ilxtr:hasIlxId ILX:0110805 .
 
-DICOM:300A_00E7 ilxtr:hasIlxId ilx:0102423 .
+DICOM:300A_00E7 ilxtr:hasIlxId ILX:0102423 .
 
-DICOM:300A_00E8 ilxtr:hasIlxId ilx:0102416 .
+DICOM:300A_00E8 ilxtr:hasIlxId ILX:0102416 .
 
-DICOM:300A_00E9 ilxtr:hasIlxId ilx:0102421 .
+DICOM:300A_00E9 ilxtr:hasIlxId ILX:0102421 .
 
-DICOM:300A_00EA ilxtr:hasIlxId ilx:0102422 .
+DICOM:300A_00EA ilxtr:hasIlxId ILX:0102422 .
 
-DICOM:300A_00EB ilxtr:hasIlxId ilx:0102426 .
+DICOM:300A_00EB ilxtr:hasIlxId ILX:0102426 .
 
-DICOM:300A_00EC ilxtr:hasIlxId ilx:0102425 .
+DICOM:300A_00EC ilxtr:hasIlxId ILX:0102425 .
 
-DICOM:300A_00ED ilxtr:hasIlxId ilx:0107811 .
+DICOM:300A_00ED ilxtr:hasIlxId ILX:0107811 .
 
-DICOM:300A_00EE ilxtr:hasIlxId ilx:0383181 .
+DICOM:300A_00EE ilxtr:hasIlxId ILX:0383181 .
 
-DICOM:300A_00EF ilxtr:hasIlxId ilx:0382323 .
+DICOM:300A_00EF ilxtr:hasIlxId ILX:0382323 .
 
-DICOM:300A_00F0 ilxtr:hasIlxId ilx:0107810 .
+DICOM:300A_00F0 ilxtr:hasIlxId ILX:0107810 .
 
-DICOM:300A_00F2 ilxtr:hasIlxId ilx:0111826 .
+DICOM:300A_00F2 ilxtr:hasIlxId ILX:0111826 .
 
-DICOM:300A_00F4 ilxtr:hasIlxId ilx:0101347 .
+DICOM:300A_00F4 ilxtr:hasIlxId ILX:0101347 .
 
-DICOM:300A_00F5 ilxtr:hasIlxId ilx:0101351 .
+DICOM:300A_00F5 ilxtr:hasIlxId ILX:0101351 .
 
-DICOM:300A_00F6 ilxtr:hasIlxId ilx:0110803 .
+DICOM:300A_00F6 ilxtr:hasIlxId ILX:0110803 .
 
-DICOM:300A_00F8 ilxtr:hasIlxId ilx:0101352 .
+DICOM:300A_00F8 ilxtr:hasIlxId ILX:0101352 .
 
-DICOM:300A_00F9 ilxtr:hasIlxId ilx:0100210 .
+DICOM:300A_00F9 ilxtr:hasIlxId ILX:0100210 .
 
-DICOM:300A_00FA ilxtr:hasIlxId ilx:0101342 .
+DICOM:300A_00FA ilxtr:hasIlxId ILX:0101342 .
 
-DICOM:300A_00FB ilxtr:hasIlxId ilx:0101343 .
+DICOM:300A_00FB ilxtr:hasIlxId ILX:0101343 .
 
-DICOM:300A_00FC ilxtr:hasIlxId ilx:0101345 .
+DICOM:300A_00FC ilxtr:hasIlxId ILX:0101345 .
 
-DICOM:300A_00FE ilxtr:hasIlxId ilx:0101344 .
+DICOM:300A_00FE ilxtr:hasIlxId ILX:0101344 .
 
-DICOM:300A_001A ilxtr:hasIlxId ilx:0107647 .
+DICOM:300A_001A ilxtr:hasIlxId ILX:0107647 .
 
-DICOM:300A_01A0 ilxtr:hasIlxId ilx:0110606 .
+DICOM:300A_01A0 ilxtr:hasIlxId ILX:0110606 .
 
-DICOM:300A_01A2 ilxtr:hasIlxId ilx:0110607 .
+DICOM:300A_01A2 ilxtr:hasIlxId ILX:0110607 .
 
-DICOM:300A_01A4 ilxtr:hasIlxId ilx:0110604 .
+DICOM:300A_01A4 ilxtr:hasIlxId ILX:0110604 .
 
-DICOM:300A_01A6 ilxtr:hasIlxId ilx:0110603 .
+DICOM:300A_01A6 ilxtr:hasIlxId ILX:0110603 .
 
-DICOM:300A_01A8 ilxtr:hasIlxId ilx:0110605 .
+DICOM:300A_01A8 ilxtr:hasIlxId ILX:0110605 .
 
-DICOM:300A_01B0 ilxtr:hasIlxId ilx:0110581 .
+DICOM:300A_01B0 ilxtr:hasIlxId ILX:0110581 .
 
-DICOM:300A_01B2 ilxtr:hasIlxId ilx:0110582 .
+DICOM:300A_01B2 ilxtr:hasIlxId ILX:0110582 .
 
-DICOM:300A_01B4 ilxtr:hasIlxId ilx:0110578 .
+DICOM:300A_01B4 ilxtr:hasIlxId ILX:0110578 .
 
-DICOM:300A_01B6 ilxtr:hasIlxId ilx:0110579 .
+DICOM:300A_01B6 ilxtr:hasIlxId ILX:0110579 .
 
-DICOM:300A_01B8 ilxtr:hasIlxId ilx:0110576 .
+DICOM:300A_01B8 ilxtr:hasIlxId ILX:0110576 .
 
-DICOM:300A_01BA ilxtr:hasIlxId ilx:0110575 .
+DICOM:300A_01BA ilxtr:hasIlxId ILX:0110575 .
 
-DICOM:300A_01BC ilxtr:hasIlxId ilx:0110577 .
+DICOM:300A_01BC ilxtr:hasIlxId ILX:0110577 .
 
-DICOM:300A_01D0 ilxtr:hasIlxId ilx:0110580 .
+DICOM:300A_01D0 ilxtr:hasIlxId ILX:0110580 .
 
-DICOM:300A_01D2 ilxtr:hasIlxId ilx:0111476 .
+DICOM:300A_01D2 ilxtr:hasIlxId ILX:0111476 .
 
-DICOM:300A_01D4 ilxtr:hasIlxId ilx:0111473 .
+DICOM:300A_01D4 ilxtr:hasIlxId ILX:0111473 .
 
-DICOM:300A_01D6 ilxtr:hasIlxId ilx:0111470 .
+DICOM:300A_01D6 ilxtr:hasIlxId ILX:0111470 .
 
-DICOM:300A_0002 ilxtr:hasIlxId ilx:0110253 .
+DICOM:300A_0002 ilxtr:hasIlxId ILX:0110253 .
 
-DICOM:300A_002A ilxtr:hasIlxId ilx:0108125 .
+DICOM:300A_002A ilxtr:hasIlxId ILX:0108125 .
 
-DICOM:300A_02A0 ilxtr:hasIlxId ilx:0110785 .
+DICOM:300A_02A0 ilxtr:hasIlxId ILX:0110785 .
 
-DICOM:300A_02A2 ilxtr:hasIlxId ilx:0111872 .
+DICOM:300A_02A2 ilxtr:hasIlxId ILX:0111872 .
 
-DICOM:300A_02A4 ilxtr:hasIlxId ilx:0111871 .
+DICOM:300A_02A4 ilxtr:hasIlxId ILX:0111871 .
 
-DICOM:300A_002B ilxtr:hasIlxId ilx:0108126 .
+DICOM:300A_002B ilxtr:hasIlxId ILX:0108126 .
 
-DICOM:300A_02B0 ilxtr:hasIlxId ilx:0102049 .
+DICOM:300A_02B0 ilxtr:hasIlxId ILX:0102049 .
 
-DICOM:300A_02B2 ilxtr:hasIlxId ilx:0102048 .
+DICOM:300A_02B2 ilxtr:hasIlxId ILX:0102048 .
 
-DICOM:300A_02B3 ilxtr:hasIlxId ilx:0102044 .
+DICOM:300A_02B3 ilxtr:hasIlxId ILX:0102044 .
 
-DICOM:300A_02B4 ilxtr:hasIlxId ilx:0102045 .
+DICOM:300A_02B4 ilxtr:hasIlxId ILX:0102045 .
 
-DICOM:300A_02B8 ilxtr:hasIlxId ilx:0102046 .
+DICOM:300A_02B8 ilxtr:hasIlxId ILX:0102046 .
 
-DICOM:300A_02BA ilxtr:hasIlxId ilx:0102047 .
+DICOM:300A_02BA ilxtr:hasIlxId ILX:0102047 .
 
-DICOM:300A_002C ilxtr:hasIlxId ilx:0108127 .
+DICOM:300A_002C ilxtr:hasIlxId ILX:0108127 .
 
-DICOM:300A_02C8 ilxtr:hasIlxId ilx:0104246 .
+DICOM:300A_02C8 ilxtr:hasIlxId ILX:0104246 .
 
-DICOM:300A_002D ilxtr:hasIlxId ilx:0108128 .
+DICOM:300A_002D ilxtr:hasIlxId ILX:0108128 .
 
-DICOM:300A_02D0 ilxtr:hasIlxId ilx:0101421 .
+DICOM:300A_02D0 ilxtr:hasIlxId ILX:0101421 .
 
-DICOM:300A_02D2 ilxtr:hasIlxId ilx:0102541 .
+DICOM:300A_02D2 ilxtr:hasIlxId ILX:0102541 .
 
-DICOM:300A_02D4 ilxtr:hasIlxId ilx:0102538 .
+DICOM:300A_02D4 ilxtr:hasIlxId ILX:0102538 .
 
-DICOM:300A_02D6 ilxtr:hasIlxId ilx:0102665 .
+DICOM:300A_02D6 ilxtr:hasIlxId ILX:0102665 .
 
-DICOM:300A_02E0 ilxtr:hasIlxId ilx:0102417 .
+DICOM:300A_02E0 ilxtr:hasIlxId ILX:0102417 .
 
-DICOM:300A_02E1 ilxtr:hasIlxId ilx:0102419 .
+DICOM:300A_02E1 ilxtr:hasIlxId ILX:0102419 .
 
-DICOM:300A_02E2 ilxtr:hasIlxId ilx:0110804 .
+DICOM:300A_02E2 ilxtr:hasIlxId ILX:0110804 .
 
-DICOM:300A_02EB ilxtr:hasIlxId ilx:0383097 .
+DICOM:300A_02EB ilxtr:hasIlxId ILX:0383097 .
 
-DICOM:300A_0003 ilxtr:hasIlxId ilx:0110254 .
+DICOM:300A_0003 ilxtr:hasIlxId ILX:0110254 .
 
-DICOM:300A_0004 ilxtr:hasIlxId ilx:0110251 .
+DICOM:300A_0004 ilxtr:hasIlxId ILX:0110251 .
 
-DICOM:300A_004A ilxtr:hasIlxId ilx:0101148 .
+DICOM:300A_004A ilxtr:hasIlxId ILX:0101148 .
 
-DICOM:300A_004C ilxtr:hasIlxId ilx:0108600 .
+DICOM:300A_004C ilxtr:hasIlxId ILX:0108600 .
 
-DICOM:300A_004E ilxtr:hasIlxId ilx:0111465 .
+DICOM:300A_004E ilxtr:hasIlxId ILX:0111465 .
 
-DICOM:300A_004F ilxtr:hasIlxId ilx:0382678 .
+DICOM:300A_004F ilxtr:hasIlxId ILX:0382678 .
 
-DICOM:300A_0006 ilxtr:hasIlxId ilx:0110250 .
+DICOM:300A_0006 ilxtr:hasIlxId ILX:0110250 .
 
-DICOM:300A_0007 ilxtr:hasIlxId ilx:0110256 .
+DICOM:300A_0007 ilxtr:hasIlxId ILX:0110256 .
 
-DICOM:300A_007A ilxtr:hasIlxId ilx:0109920 .
+DICOM:300A_007A ilxtr:hasIlxId ILX:0109920 .
 
-DICOM:300A_007B ilxtr:hasIlxId ilx:0104393 .
+DICOM:300A_007B ilxtr:hasIlxId ILX:0104393 .
 
-DICOM:300A_008B ilxtr:hasIlxId ilx:0382834 .
+DICOM:300A_008B ilxtr:hasIlxId ILX:0382834 .
 
-DICOM:300A_008C ilxtr:hasIlxId ilx:0382615 .
+DICOM:300A_008C ilxtr:hasIlxId ILX:0382615 .
 
-DICOM:300A_008D ilxtr:hasIlxId ilx:0382880 .
+DICOM:300A_008D ilxtr:hasIlxId ILX:0382880 .
 
-DICOM:300A_008E ilxtr:hasIlxId ilx:0382579 .
+DICOM:300A_008E ilxtr:hasIlxId ILX:0382579 .
 
-DICOM:300A_008F ilxtr:hasIlxId ilx:0381984 .
+DICOM:300A_008F ilxtr:hasIlxId ILX:0381984 .
 
-DICOM:300A_0009 ilxtr:hasIlxId ilx:0111934 .
+DICOM:300A_0009 ilxtr:hasIlxId ILX:0111934 .
 
-DICOM:300A_0010 ilxtr:hasIlxId ilx:0103529 .
+DICOM:300A_0010 ilxtr:hasIlxId ILX:0103529 .
 
-DICOM:300A_010A ilxtr:hasIlxId ilx:0100861 .
+DICOM:300A_010A ilxtr:hasIlxId ILX:0100861 .
 
-DICOM:300A_010C ilxtr:hasIlxId ilx:0102662 .
+DICOM:300A_010C ilxtr:hasIlxId ILX:0102662 .
 
-DICOM:300A_010E ilxtr:hasIlxId ilx:0104245 .
+DICOM:300A_010E ilxtr:hasIlxId ILX:0104245 .
 
-DICOM:300A_011A ilxtr:hasIlxId ilx:0101147 .
+DICOM:300A_011A ilxtr:hasIlxId ILX:0101147 .
 
-DICOM:300A_011C ilxtr:hasIlxId ilx:0381926 .
+DICOM:300A_011C ilxtr:hasIlxId ILX:0381926 .
 
-DICOM:300A_011E ilxtr:hasIlxId ilx:0104550 .
+DICOM:300A_011E ilxtr:hasIlxId ILX:0104550 .
 
-DICOM:300A_011F ilxtr:hasIlxId ilx:0104552 .
+DICOM:300A_011F ilxtr:hasIlxId ILX:0104552 .
 
-DICOM:300A_0012 ilxtr:hasIlxId ilx:0103527 .
+DICOM:300A_0012 ilxtr:hasIlxId ILX:0103527 .
 
-DICOM:300A_012A ilxtr:hasIlxId ilx:0111468 .
+DICOM:300A_012A ilxtr:hasIlxId ILX:0111468 .
 
-DICOM:300A_012C ilxtr:hasIlxId ilx:0105735 .
+DICOM:300A_012C ilxtr:hasIlxId ILX:0105735 .
 
-DICOM:300A_012E ilxtr:hasIlxId ilx:0111368 .
+DICOM:300A_012E ilxtr:hasIlxId ILX:0111368 .
 
-DICOM:300A_0013 ilxtr:hasIlxId ilx:0103532 .
+DICOM:300A_0013 ilxtr:hasIlxId ILX:0103532 .
 
-DICOM:300A_0014 ilxtr:hasIlxId ilx:0103530 .
+DICOM:300A_0014 ilxtr:hasIlxId ILX:0103530 .
 
-DICOM:300A_014A ilxtr:hasIlxId ilx:0382683 .
+DICOM:300A_014A ilxtr:hasIlxId ILX:0382683 .
 
-DICOM:300A_014C ilxtr:hasIlxId ilx:0381729 .
+DICOM:300A_014C ilxtr:hasIlxId ILX:0381729 .
 
-DICOM:300A_014E ilxtr:hasIlxId ilx:0382095 .
+DICOM:300A_014E ilxtr:hasIlxId ILX:0382095 .
 
-DICOM:300A_0015 ilxtr:hasIlxId ilx:0107645 .
+DICOM:300A_0015 ilxtr:hasIlxId ILX:0107645 .
 
-DICOM:300A_0016 ilxtr:hasIlxId ilx:0103526 .
+DICOM:300A_0016 ilxtr:hasIlxId ILX:0103526 .
 
-DICOM:300A_0018 ilxtr:hasIlxId ilx:0103528 .
+DICOM:300A_0018 ilxtr:hasIlxId ILX:0103528 .
 
-DICOM:300A_019A ilxtr:hasIlxId ilx:0383111 .
+DICOM:300A_019A ilxtr:hasIlxId ILX:0383111 .
 
-DICOM:300A_0020 ilxtr:hasIlxId ilx:0103531 .
+DICOM:300A_0020 ilxtr:hasIlxId ILX:0103531 .
 
-DICOM:300A_0021 ilxtr:hasIlxId ilx:0102500 .
+DICOM:300A_0021 ilxtr:hasIlxId ILX:0102500 .
 
-DICOM:300A_021A ilxtr:hasIlxId ilx:0100289 .
+DICOM:300A_021A ilxtr:hasIlxId ILX:0100289 .
 
-DICOM:300A_021B ilxtr:hasIlxId ilx:0382858 .
+DICOM:300A_021B ilxtr:hasIlxId ILX:0382858 .
 
-DICOM:300A_021C ilxtr:hasIlxId ilx:0382023 .
+DICOM:300A_021C ilxtr:hasIlxId ILX:0382023 .
 
-DICOM:300A_0022 ilxtr:hasIlxId ilx:0103005 .
+DICOM:300A_0022 ilxtr:hasIlxId ILX:0103005 .
 
-DICOM:300A_022A ilxtr:hasIlxId ilx:0109728 .
+DICOM:300A_022A ilxtr:hasIlxId ILX:0109728 .
 
-DICOM:300A_022B ilxtr:hasIlxId ilx:0382614 .
+DICOM:300A_022B ilxtr:hasIlxId ILX:0382614 .
 
-DICOM:300A_022C ilxtr:hasIlxId ilx:0100435 .
+DICOM:300A_022C ilxtr:hasIlxId ILX:0100435 .
 
-DICOM:300A_022E ilxtr:hasIlxId ilx:0100436 .
+DICOM:300A_022E ilxtr:hasIlxId ILX:0100436 .
 
-DICOM:300A_0023 ilxtr:hasIlxId ilx:0103004 .
+DICOM:300A_0023 ilxtr:hasIlxId ILX:0103004 .
 
-DICOM:300A_0025 ilxtr:hasIlxId ilx:0111526 .
+DICOM:300A_0025 ilxtr:hasIlxId ILX:0111526 .
 
-DICOM:300A_0026 ilxtr:hasIlxId ilx:0111527 .
+DICOM:300A_0026 ilxtr:hasIlxId ILX:0111527 .
 
-DICOM:300A_026A ilxtr:hasIlxId ilx:0101413 .
+DICOM:300A_026A ilxtr:hasIlxId ILX:0101413 .
 
-DICOM:300A_026C ilxtr:hasIlxId ilx:0101414 .
+DICOM:300A_026C ilxtr:hasIlxId ILX:0101414 .
 
-DICOM:300A_0027 ilxtr:hasIlxId ilx:0111525 .
+DICOM:300A_0027 ilxtr:hasIlxId ILX:0111525 .
 
-DICOM:300A_0028 ilxtr:hasIlxId ilx:0111528 .
+DICOM:300A_0028 ilxtr:hasIlxId ILX:0111528 .
 
-DICOM:300A_028A ilxtr:hasIlxId ilx:0107834 .
+DICOM:300A_028A ilxtr:hasIlxId ILX:0107834 .
 
-DICOM:300A_028C ilxtr:hasIlxId ilx:0109514 .
+DICOM:300A_028C ilxtr:hasIlxId ILX:0109514 .
 
-DICOM:300A_029C ilxtr:hasIlxId ilx:0110787 .
+DICOM:300A_029C ilxtr:hasIlxId ILX:0110787 .
 
-DICOM:300A_029E ilxtr:hasIlxId ilx:0110788 .
+DICOM:300A_029E ilxtr:hasIlxId ILX:0110788 .
 
-DICOM:300A_0040 ilxtr:hasIlxId ilx:0111798 .
+DICOM:300A_0040 ilxtr:hasIlxId ILX:0111798 .
 
-DICOM:300A_0042 ilxtr:hasIlxId ilx:0111797 .
+DICOM:300A_0042 ilxtr:hasIlxId ILX:0111797 .
 
-DICOM:300A_0043 ilxtr:hasIlxId ilx:0111796 .
+DICOM:300A_0043 ilxtr:hasIlxId ILX:0111796 .
 
-DICOM:300A_0044 ilxtr:hasIlxId ilx:0104551 .
+DICOM:300A_0044 ilxtr:hasIlxId ILX:0104551 .
 
-DICOM:300A_0046 ilxtr:hasIlxId ilx:0101145 .
+DICOM:300A_0046 ilxtr:hasIlxId ILX:0101145 .
 
-DICOM:300A_0048 ilxtr:hasIlxId ilx:0101151 .
+DICOM:300A_0048 ilxtr:hasIlxId ILX:0101151 .
 
-DICOM:300A_0050 ilxtr:hasIlxId ilx:0382852 .
+DICOM:300A_0050 ilxtr:hasIlxId ILX:0382852 .
 
-DICOM:300A_0051 ilxtr:hasIlxId ilx:0111475 .
+DICOM:300A_0051 ilxtr:hasIlxId ILX:0111475 .
 
-DICOM:300A_0052 ilxtr:hasIlxId ilx:0111472 .
+DICOM:300A_0052 ilxtr:hasIlxId ILX:0111472 .
 
-DICOM:300A_0053 ilxtr:hasIlxId ilx:0111469 .
+DICOM:300A_0053 ilxtr:hasIlxId ILX:0111469 .
 
-DICOM:300A_0055 ilxtr:hasIlxId ilx:0110255 .
+DICOM:300A_0055 ilxtr:hasIlxId ILX:0110255 .
 
-DICOM:300A_0070 ilxtr:hasIlxId ilx:0104389 .
+DICOM:300A_0070 ilxtr:hasIlxId ILX:0104389 .
 
-DICOM:300A_0071 ilxtr:hasIlxId ilx:0104388 .
+DICOM:300A_0071 ilxtr:hasIlxId ILX:0104388 .
 
-DICOM:300A_0072 ilxtr:hasIlxId ilx:0104387 .
+DICOM:300A_0072 ilxtr:hasIlxId ILX:0104387 .
 
-DICOM:300A_0078 ilxtr:hasIlxId ilx:0107822 .
+DICOM:300A_0078 ilxtr:hasIlxId ILX:0107822 .
 
-DICOM:300A_0079 ilxtr:hasIlxId ilx:0107820 .
+DICOM:300A_0079 ilxtr:hasIlxId ILX:0107820 .
 
-DICOM:300A_0080 ilxtr:hasIlxId ilx:0107809 .
+DICOM:300A_0080 ilxtr:hasIlxId ILX:0107809 .
 
-DICOM:300A_0082 ilxtr:hasIlxId ilx:0101143 .
+DICOM:300A_0082 ilxtr:hasIlxId ILX:0101143 .
 
-DICOM:300A_0084 ilxtr:hasIlxId ilx:0101142 .
+DICOM:300A_0084 ilxtr:hasIlxId ILX:0101142 .
 
-DICOM:300A_0086 ilxtr:hasIlxId ilx:0101152 .
+DICOM:300A_0086 ilxtr:hasIlxId ILX:0101152 .
 
-DICOM:300A_0090 ilxtr:hasIlxId ilx:0383085 .
+DICOM:300A_0090 ilxtr:hasIlxId ILX:0383085 .
 
-DICOM:300A_0091 ilxtr:hasIlxId ilx:0381989 .
+DICOM:300A_0091 ilxtr:hasIlxId ILX:0381989 .
 
-DICOM:300A_0092 ilxtr:hasIlxId ilx:0382108 .
+DICOM:300A_0092 ilxtr:hasIlxId ILX:0382108 .
 
-DICOM:300A_0100 ilxtr:hasIlxId ilx:0101349 .
+DICOM:300A_0100 ilxtr:hasIlxId ILX:0101349 .
 
-DICOM:300A_0102 ilxtr:hasIlxId ilx:0383182 .
+DICOM:300A_0102 ilxtr:hasIlxId ILX:0383182 .
 
-DICOM:300A_0104 ilxtr:hasIlxId ilx:0101346 .
+DICOM:300A_0104 ilxtr:hasIlxId ILX:0101346 .
 
-DICOM:300A_0106 ilxtr:hasIlxId ilx:0101339 .
+DICOM:300A_0106 ilxtr:hasIlxId ILX:0101339 .
 
-DICOM:300A_0107 ilxtr:hasIlxId ilx:0100863 .
+DICOM:300A_0107 ilxtr:hasIlxId ILX:0100863 .
 
-DICOM:300A_0108 ilxtr:hasIlxId ilx:0100862 .
+DICOM:300A_0108 ilxtr:hasIlxId ILX:0100862 .
 
-DICOM:300A_0109 ilxtr:hasIlxId ilx:0100864 .
+DICOM:300A_0109 ilxtr:hasIlxId ILX:0100864 .
 
-DICOM:300A_0110 ilxtr:hasIlxId ilx:0107815 .
+DICOM:300A_0110 ilxtr:hasIlxId ILX:0107815 .
 
-DICOM:300A_0111 ilxtr:hasIlxId ilx:0102542 .
+DICOM:300A_0111 ilxtr:hasIlxId ILX:0102542 .
 
-DICOM:300A_0112 ilxtr:hasIlxId ilx:0102540 .
+DICOM:300A_0112 ilxtr:hasIlxId ILX:0102540 .
 
-DICOM:300A_0114 ilxtr:hasIlxId ilx:0107644 .
+DICOM:300A_0114 ilxtr:hasIlxId ILX:0107644 .
 
-DICOM:300A_0115 ilxtr:hasIlxId ilx:0103525 .
+DICOM:300A_0115 ilxtr:hasIlxId ILX:0103525 .
 
-DICOM:300A_0116 ilxtr:hasIlxId ilx:0112613 .
+DICOM:300A_0116 ilxtr:hasIlxId ILX:0112613 .
 
-DICOM:300A_0118 ilxtr:hasIlxId ilx:0112612 .
+DICOM:300A_0118 ilxtr:hasIlxId ILX:0112612 .
 
-DICOM:300A_0120 ilxtr:hasIlxId ilx:0101144 .
+DICOM:300A_0120 ilxtr:hasIlxId ILX:0101144 .
 
-DICOM:300A_0121 ilxtr:hasIlxId ilx:0101149 .
+DICOM:300A_0121 ilxtr:hasIlxId ILX:0101149 .
 
-DICOM:300A_0122 ilxtr:hasIlxId ilx:0108599 .
+DICOM:300A_0122 ilxtr:hasIlxId ILX:0108599 .
 
-DICOM:300A_0123 ilxtr:hasIlxId ilx:0108601 .
+DICOM:300A_0123 ilxtr:hasIlxId ILX:0108601 .
 
-DICOM:300A_0124 ilxtr:hasIlxId ilx:0111466 .
+DICOM:300A_0124 ilxtr:hasIlxId ILX:0111466 .
 
-DICOM:300A_0125 ilxtr:hasIlxId ilx:0111464 .
+DICOM:300A_0125 ilxtr:hasIlxId ILX:0111464 .
 
-DICOM:300A_0126 ilxtr:hasIlxId ilx:0111467 .
+DICOM:300A_0126 ilxtr:hasIlxId ILX:0111467 .
 
-DICOM:300A_0128 ilxtr:hasIlxId ilx:0111474 .
+DICOM:300A_0128 ilxtr:hasIlxId ILX:0111474 .
 
-DICOM:300A_0129 ilxtr:hasIlxId ilx:0111471 .
+DICOM:300A_0129 ilxtr:hasIlxId ILX:0111471 .
 
-DICOM:300A_0130 ilxtr:hasIlxId ilx:0110807 .
+DICOM:300A_0130 ilxtr:hasIlxId ILX:0110807 .
 
-DICOM:300A_0131 ilxtr:hasIlxId ilx:0382876 .
+DICOM:300A_0131 ilxtr:hasIlxId ILX:0382876 .
 
-DICOM:300A_0132 ilxtr:hasIlxId ilx:0382510 .
+DICOM:300A_0132 ilxtr:hasIlxId ILX:0382510 .
 
-DICOM:300A_0133 ilxtr:hasIlxId ilx:0382561 .
+DICOM:300A_0133 ilxtr:hasIlxId ILX:0382561 .
 
-DICOM:300A_0134 ilxtr:hasIlxId ilx:0102664 .
+DICOM:300A_0134 ilxtr:hasIlxId ILX:0102664 .
 
-DICOM:300A_0140 ilxtr:hasIlxId ilx:0382433 .
+DICOM:300A_0140 ilxtr:hasIlxId ILX:0382433 .
 
-DICOM:300A_0142 ilxtr:hasIlxId ilx:0382040 .
+DICOM:300A_0142 ilxtr:hasIlxId ILX:0382040 .
 
-DICOM:300A_0144 ilxtr:hasIlxId ilx:0382838 .
+DICOM:300A_0144 ilxtr:hasIlxId ILX:0382838 .
 
-DICOM:300A_0146 ilxtr:hasIlxId ilx:0382878 .
+DICOM:300A_0146 ilxtr:hasIlxId ILX:0382878 .
 
-DICOM:300A_0180 ilxtr:hasIlxId ilx:0108597 .
+DICOM:300A_0180 ilxtr:hasIlxId ILX:0108597 .
 
-DICOM:300A_0182 ilxtr:hasIlxId ilx:0108596 .
+DICOM:300A_0182 ilxtr:hasIlxId ILX:0108596 .
 
-DICOM:300A_0183 ilxtr:hasIlxId ilx:0382670 .
+DICOM:300A_0183 ilxtr:hasIlxId ILX:0382670 .
 
-DICOM:300A_0184 ilxtr:hasIlxId ilx:0108584 .
+DICOM:300A_0184 ilxtr:hasIlxId ILX:0108584 .
 
-DICOM:300A_0190 ilxtr:hasIlxId ilx:0104267 .
+DICOM:300A_0190 ilxtr:hasIlxId ILX:0104267 .
 
-DICOM:300A_0192 ilxtr:hasIlxId ilx:0104268 .
+DICOM:300A_0192 ilxtr:hasIlxId ILX:0104268 .
 
-DICOM:300A_0194 ilxtr:hasIlxId ilx:0104265 .
+DICOM:300A_0194 ilxtr:hasIlxId ILX:0104265 .
 
-DICOM:300A_0196 ilxtr:hasIlxId ilx:0104264 .
+DICOM:300A_0196 ilxtr:hasIlxId ILX:0104264 .
 
-DICOM:300A_0198 ilxtr:hasIlxId ilx:0104266 .
+DICOM:300A_0198 ilxtr:hasIlxId ILX:0104266 .
 
-DICOM:300A_0199 ilxtr:hasIlxId ilx:0381946 .
+DICOM:300A_0199 ilxtr:hasIlxId ILX:0381946 .
 
-DICOM:300A_0200 ilxtr:hasIlxId ilx:0101423 .
+DICOM:300A_0200 ilxtr:hasIlxId ILX:0101423 .
 
-DICOM:300A_0202 ilxtr:hasIlxId ilx:0101424 .
+DICOM:300A_0202 ilxtr:hasIlxId ILX:0101424 .
 
-DICOM:300A_0206 ilxtr:hasIlxId ilx:0111933 .
+DICOM:300A_0206 ilxtr:hasIlxId ILX:0111933 .
 
-DICOM:300A_0210 ilxtr:hasIlxId ilx:0110800 .
+DICOM:300A_0210 ilxtr:hasIlxId ILX:0110800 .
 
-DICOM:300A_0212 ilxtr:hasIlxId ilx:0110799 .
+DICOM:300A_0212 ilxtr:hasIlxId ILX:0110799 .
 
-DICOM:300A_0214 ilxtr:hasIlxId ilx:0110809 .
+DICOM:300A_0214 ilxtr:hasIlxId ILX:0110809 .
 
-DICOM:300A_0216 ilxtr:hasIlxId ilx:0110796 .
+DICOM:300A_0216 ilxtr:hasIlxId ILX:0110796 .
 
-DICOM:300A_0218 ilxtr:hasIlxId ilx:0100288 .
+DICOM:300A_0218 ilxtr:hasIlxId ILX:0100288 .
 
-DICOM:300A_0222 ilxtr:hasIlxId ilx:0110790 .
+DICOM:300A_0222 ilxtr:hasIlxId ILX:0110790 .
 
-DICOM:300A_0224 ilxtr:hasIlxId ilx:0110791 .
+DICOM:300A_0224 ilxtr:hasIlxId ILX:0110791 .
 
-DICOM:300A_0226 ilxtr:hasIlxId ilx:0110795 .
+DICOM:300A_0226 ilxtr:hasIlxId ILX:0110795 .
 
-DICOM:300A_0228 ilxtr:hasIlxId ilx:0110794 .
+DICOM:300A_0228 ilxtr:hasIlxId ILX:0110794 .
 
-DICOM:300A_0229 ilxtr:hasIlxId ilx:0383041 .
+DICOM:300A_0229 ilxtr:hasIlxId ILX:0383041 .
 
-DICOM:300A_0230 ilxtr:hasIlxId ilx:0100859 .
+DICOM:300A_0230 ilxtr:hasIlxId ILX:0100859 .
 
-DICOM:300A_0232 ilxtr:hasIlxId ilx:0100860 .
+DICOM:300A_0232 ilxtr:hasIlxId ILX:0100860 .
 
-DICOM:300A_0234 ilxtr:hasIlxId ilx:0100858 .
+DICOM:300A_0234 ilxtr:hasIlxId ILX:0100858 .
 
-DICOM:300A_0236 ilxtr:hasIlxId ilx:0100857 .
+DICOM:300A_0236 ilxtr:hasIlxId ILX:0100857 .
 
-DICOM:300A_0238 ilxtr:hasIlxId ilx:0100856 .
+DICOM:300A_0238 ilxtr:hasIlxId ILX:0100856 .
 
-DICOM:300A_0240 ilxtr:hasIlxId ilx:0111577 .
+DICOM:300A_0240 ilxtr:hasIlxId ILX:0111577 .
 
-DICOM:300A_0242 ilxtr:hasIlxId ilx:0111578 .
+DICOM:300A_0242 ilxtr:hasIlxId ILX:0111578 .
 
-DICOM:300A_0244 ilxtr:hasIlxId ilx:0111576 .
+DICOM:300A_0244 ilxtr:hasIlxId ILX:0111576 .
 
-DICOM:300A_0250 ilxtr:hasIlxId ilx:0111830 .
+DICOM:300A_0250 ilxtr:hasIlxId ILX:0111830 .
 
-DICOM:300A_0260 ilxtr:hasIlxId ilx:0101416 .
+DICOM:300A_0260 ilxtr:hasIlxId ILX:0101416 .
 
-DICOM:300A_0262 ilxtr:hasIlxId ilx:0101415 .
+DICOM:300A_0262 ilxtr:hasIlxId ILX:0101415 .
 
-DICOM:300A_0263 ilxtr:hasIlxId ilx:0101411 .
+DICOM:300A_0263 ilxtr:hasIlxId ILX:0101411 .
 
-DICOM:300A_0264 ilxtr:hasIlxId ilx:0101417 .
+DICOM:300A_0264 ilxtr:hasIlxId ILX:0101417 .
 
-DICOM:300A_0266 ilxtr:hasIlxId ilx:0101412 .
+DICOM:300A_0266 ilxtr:hasIlxId ILX:0101412 .
 
-DICOM:300A_0280 ilxtr:hasIlxId ilx:0102043 .
+DICOM:300A_0280 ilxtr:hasIlxId ILX:0102043 .
 
-DICOM:300A_0282 ilxtr:hasIlxId ilx:0102037 .
+DICOM:300A_0282 ilxtr:hasIlxId ILX:0102037 .
 
-DICOM:300A_0284 ilxtr:hasIlxId ilx:0102034 .
+DICOM:300A_0284 ilxtr:hasIlxId ILX:0102034 .
 
-DICOM:300A_0286 ilxtr:hasIlxId ilx:0102053 .
+DICOM:300A_0286 ilxtr:hasIlxId ILX:0102053 .
 
-DICOM:300A_0288 ilxtr:hasIlxId ilx:0110798 .
+DICOM:300A_0288 ilxtr:hasIlxId ILX:0110798 .
 
-DICOM:300A_0290 ilxtr:hasIlxId ilx:0110784 .
+DICOM:300A_0290 ilxtr:hasIlxId ILX:0110784 .
 
-DICOM:300A_0291 ilxtr:hasIlxId ilx:0110780 .
+DICOM:300A_0291 ilxtr:hasIlxId ILX:0110780 .
 
-DICOM:300A_0292 ilxtr:hasIlxId ilx:0110786 .
+DICOM:300A_0292 ilxtr:hasIlxId ILX:0110786 .
 
-DICOM:300A_0294 ilxtr:hasIlxId ilx:0110783 .
+DICOM:300A_0294 ilxtr:hasIlxId ILX:0110783 .
 
-DICOM:300A_0296 ilxtr:hasIlxId ilx:0110781 .
+DICOM:300A_0296 ilxtr:hasIlxId ILX:0110781 .
 
-DICOM:300A_0298 ilxtr:hasIlxId ilx:0110782 .
+DICOM:300A_0298 ilxtr:hasIlxId ILX:0110782 .
 
-DICOM:300A_0355 ilxtr:hasIlxId ilx:0382973 .
+DICOM:300A_0355 ilxtr:hasIlxId ILX:0382973 .
 
-DICOM:300A_0401 ilxtr:hasIlxId ilx:0381809 .
+DICOM:300A_0401 ilxtr:hasIlxId ILX:0381809 .
 
-DICOM:300A_0402 ilxtr:hasIlxId ilx:0382863 .
+DICOM:300A_0402 ilxtr:hasIlxId ILX:0382863 .
 
-DICOM:300A_0410 ilxtr:hasIlxId ilx:0382415 .
+DICOM:300A_0410 ilxtr:hasIlxId ILX:0382415 .
 
-DICOM:300A_0412 ilxtr:hasIlxId ilx:0383033 .
+DICOM:300A_0412 ilxtr:hasIlxId ILX:0383033 .
 
-DICOM:300A_0420 ilxtr:hasIlxId ilx:0381947 .
+DICOM:300A_0420 ilxtr:hasIlxId ILX:0381947 .
 
-DICOM:300A_0421 ilxtr:hasIlxId ilx:0381630 .
+DICOM:300A_0421 ilxtr:hasIlxId ILX:0381630 .
 
-DICOM:300A_0422 ilxtr:hasIlxId ilx:0382662 .
+DICOM:300A_0422 ilxtr:hasIlxId ILX:0382662 .
 
-DICOM:300A_0423 ilxtr:hasIlxId ilx:0382512 .
+DICOM:300A_0423 ilxtr:hasIlxId ILX:0382512 .
 
-DICOM:300A_0424 ilxtr:hasIlxId ilx:0381566 .
+DICOM:300A_0424 ilxtr:hasIlxId ILX:0381566 .
 
-DICOM:300A_0425 ilxtr:hasIlxId ilx:0382743 .
+DICOM:300A_0425 ilxtr:hasIlxId ILX:0382743 .
 
-DICOM:300A_0431 ilxtr:hasIlxId ilx:0382787 .
+DICOM:300A_0431 ilxtr:hasIlxId ILX:0382787 .
 
-DICOM:300A_0432 ilxtr:hasIlxId ilx:0383003 .
+DICOM:300A_0432 ilxtr:hasIlxId ILX:0383003 .
 
-DICOM:300A_0433 ilxtr:hasIlxId ilx:0381784 .
+DICOM:300A_0433 ilxtr:hasIlxId ILX:0381784 .
 
-DICOM:300A_0434 ilxtr:hasIlxId ilx:0382267 .
+DICOM:300A_0434 ilxtr:hasIlxId ILX:0382267 .
 
-DICOM:300A_0435 ilxtr:hasIlxId ilx:0382103 .
+DICOM:300A_0435 ilxtr:hasIlxId ILX:0382103 .
 
-DICOM:300A_0436 ilxtr:hasIlxId ilx:0382012 .
+DICOM:300A_0436 ilxtr:hasIlxId ILX:0382012 .
 
-DICOM:300A_0450 ilxtr:hasIlxId ilx:0382954 .
+DICOM:300A_0450 ilxtr:hasIlxId ILX:0382954 .
 
-DICOM:300A_0451 ilxtr:hasIlxId ilx:0382281 .
+DICOM:300A_0451 ilxtr:hasIlxId ILX:0382281 .
 
-DICOM:300A_0452 ilxtr:hasIlxId ilx:0382524 .
+DICOM:300A_0452 ilxtr:hasIlxId ILX:0382524 .
 
-DICOM:300A_0453 ilxtr:hasIlxId ilx:0382532 .
+DICOM:300A_0453 ilxtr:hasIlxId ILX:0382532 .
 
-DICOM:300C_000A ilxtr:hasIlxId ilx:0109744 .
+DICOM:300C_000A ilxtr:hasIlxId ILX:0109744 .
 
-DICOM:300C_00A0 ilxtr:hasIlxId ilx:0109799 .
+DICOM:300C_00A0 ilxtr:hasIlxId ILX:0109799 .
 
-DICOM:300C_00B0 ilxtr:hasIlxId ilx:0109741 .
+DICOM:300C_00B0 ilxtr:hasIlxId ILX:0109741 .
 
-DICOM:300C_000C ilxtr:hasIlxId ilx:0109743 .
+DICOM:300C_000C ilxtr:hasIlxId ILX:0109743 .
 
-DICOM:300C_00C0 ilxtr:hasIlxId ilx:0109805 .
+DICOM:300C_00C0 ilxtr:hasIlxId ILX:0109805 .
 
-DICOM:300C_00D0 ilxtr:hasIlxId ilx:0109747 .
+DICOM:300C_00D0 ilxtr:hasIlxId ILX:0109747 .
 
-DICOM:300C_000E ilxtr:hasIlxId ilx:0109793 .
+DICOM:300C_000E ilxtr:hasIlxId ILX:0109793 .
 
-DICOM:300C_00E0 ilxtr:hasIlxId ilx:0109740 .
+DICOM:300C_00E0 ilxtr:hasIlxId ILX:0109740 .
 
-DICOM:300C_00F0 ilxtr:hasIlxId ilx:0109749 .
+DICOM:300C_00F0 ilxtr:hasIlxId ILX:0109749 .
 
-DICOM:300C_00F2 ilxtr:hasIlxId ilx:0381605 .
+DICOM:300C_00F2 ilxtr:hasIlxId ILX:0381605 .
 
-DICOM:300C_00F4 ilxtr:hasIlxId ilx:0381853 .
+DICOM:300C_00F4 ilxtr:hasIlxId ILX:0381853 .
 
-DICOM:300C_00F6 ilxtr:hasIlxId ilx:0381974 .
+DICOM:300C_00F6 ilxtr:hasIlxId ILX:0381974 .
 
-DICOM:300C_0002 ilxtr:hasIlxId ilx:0109786 .
+DICOM:300C_0002 ilxtr:hasIlxId ILX:0109786 .
 
-DICOM:300C_0004 ilxtr:hasIlxId ilx:0109739 .
+DICOM:300C_0004 ilxtr:hasIlxId ILX:0109739 .
 
-DICOM:300C_0006 ilxtr:hasIlxId ilx:0109738 .
+DICOM:300C_0006 ilxtr:hasIlxId ILX:0109738 .
 
-DICOM:300C_006A ilxtr:hasIlxId ilx:0109776 .
+DICOM:300C_006A ilxtr:hasIlxId ILX:0109776 .
 
-DICOM:300C_0007 ilxtr:hasIlxId ilx:0109781 .
+DICOM:300C_0007 ilxtr:hasIlxId ILX:0109781 .
 
-DICOM:300C_0008 ilxtr:hasIlxId ilx:0111023 .
+DICOM:300C_0008 ilxtr:hasIlxId ILX:0111023 .
 
-DICOM:300C_0009 ilxtr:hasIlxId ilx:0103773 .
+DICOM:300C_0009 ilxtr:hasIlxId ILX:0103773 .
 
-DICOM:300C_0020 ilxtr:hasIlxId ilx:0109756 .
+DICOM:300C_0020 ilxtr:hasIlxId ILX:0109756 .
 
-DICOM:300C_0022 ilxtr:hasIlxId ilx:0109755 .
+DICOM:300C_0022 ilxtr:hasIlxId ILX:0109755 .
 
-DICOM:300C_0040 ilxtr:hasIlxId ilx:0109801 .
+DICOM:300C_0040 ilxtr:hasIlxId ILX:0109801 .
 
-DICOM:300C_0042 ilxtr:hasIlxId ilx:0109782 .
+DICOM:300C_0042 ilxtr:hasIlxId ILX:0109782 .
 
-DICOM:300C_0050 ilxtr:hasIlxId ilx:0109753 .
+DICOM:300C_0050 ilxtr:hasIlxId ILX:0109753 .
 
-DICOM:300C_0051 ilxtr:hasIlxId ilx:0109752 .
+DICOM:300C_0051 ilxtr:hasIlxId ILX:0109752 .
 
-DICOM:300C_0055 ilxtr:hasIlxId ilx:0101422 .
+DICOM:300C_0055 ilxtr:hasIlxId ILX:0101422 .
 
-DICOM:300C_0060 ilxtr:hasIlxId ilx:0109796 .
+DICOM:300C_0060 ilxtr:hasIlxId ILX:0109796 .
 
-DICOM:300C_0080 ilxtr:hasIlxId ilx:0109754 .
+DICOM:300C_0080 ilxtr:hasIlxId ILX:0109754 .
 
-DICOM:300E_0002 ilxtr:hasIlxId ilx:0381890 .
+DICOM:300E_0002 ilxtr:hasIlxId ILX:0381890 .
 
-DICOM:300E_0004 ilxtr:hasIlxId ilx:0382476 .
+DICOM:300E_0004 ilxtr:hasIlxId ILX:0382476 .
 
-DICOM:300E_0005 ilxtr:hasIlxId ilx:0383120 .
+DICOM:300E_0005 ilxtr:hasIlxId ILX:0383120 .
 
-DICOM:300E_0008 ilxtr:hasIlxId ilx:0381970 .
+DICOM:300E_0008 ilxtr:hasIlxId ILX:0381970 .
 
-DICOM:0400_0005 ilxtr:hasIlxId ilx:0383088 .
+DICOM:0400_0005 ilxtr:hasIlxId ILX:0383088 .
 
-DICOM:0400_0010 ilxtr:hasIlxId ilx:0383004 .
+DICOM:0400_0010 ilxtr:hasIlxId ILX:0383004 .
 
-DICOM:0400_0015 ilxtr:hasIlxId ilx:0383082 .
+DICOM:0400_0015 ilxtr:hasIlxId ILX:0383082 .
 
-DICOM:0400_0020 ilxtr:hasIlxId ilx:0382993 .
+DICOM:0400_0020 ilxtr:hasIlxId ILX:0382993 .
 
-DICOM:0400_0100 ilxtr:hasIlxId ilx:0383094 .
+DICOM:0400_0100 ilxtr:hasIlxId ILX:0383094 .
 
-DICOM:0400_0105 ilxtr:hasIlxId ilx:0382325 .
+DICOM:0400_0105 ilxtr:hasIlxId ILX:0382325 .
 
-DICOM:0400_0110 ilxtr:hasIlxId ilx:0382685 .
+DICOM:0400_0110 ilxtr:hasIlxId ILX:0382685 .
 
-DICOM:0400_0115 ilxtr:hasIlxId ilx:0381479 .
+DICOM:0400_0115 ilxtr:hasIlxId ILX:0381479 .
 
-DICOM:0400_0120 ilxtr:hasIlxId ilx:0381621 .
+DICOM:0400_0120 ilxtr:hasIlxId ILX:0381621 .
 
-DICOM:0400_0305 ilxtr:hasIlxId ilx:0382552 .
+DICOM:0400_0305 ilxtr:hasIlxId ILX:0382552 .
 
-DICOM:0400_0310 ilxtr:hasIlxId ilx:0382840 .
+DICOM:0400_0310 ilxtr:hasIlxId ILX:0382840 .
 
-DICOM:0400_0401 ilxtr:hasIlxId ilx:0382454 .
+DICOM:0400_0401 ilxtr:hasIlxId ILX:0382454 .
 
-DICOM:0400_0402 ilxtr:hasIlxId ilx:0381622 .
+DICOM:0400_0402 ilxtr:hasIlxId ILX:0381622 .
 
-DICOM:0400_0403 ilxtr:hasIlxId ilx:0382958 .
+DICOM:0400_0403 ilxtr:hasIlxId ILX:0382958 .
 
-DICOM:0400_0404 ilxtr:hasIlxId ilx:0382499 .
+DICOM:0400_0404 ilxtr:hasIlxId ILX:0382499 .
 
-DICOM:0400_0500 ilxtr:hasIlxId ilx:0103770 .
+DICOM:0400_0500 ilxtr:hasIlxId ILX:0103770 .
 
-DICOM:0400_0510 ilxtr:hasIlxId ilx:0103772 .
+DICOM:0400_0510 ilxtr:hasIlxId ILX:0103772 .
 
-DICOM:0400_0520 ilxtr:hasIlxId ilx:0103771 .
+DICOM:0400_0520 ilxtr:hasIlxId ILX:0103771 .
 
-DICOM:0400_0550 ilxtr:hasIlxId ilx:0107054 .
+DICOM:0400_0550 ilxtr:hasIlxId ILX:0107054 .
 
-DICOM:0400_0561 ilxtr:hasIlxId ilx:0382266 .
+DICOM:0400_0561 ilxtr:hasIlxId ILX:0382266 .
 
-DICOM:0400_0562 ilxtr:hasIlxId ilx:0382765 .
+DICOM:0400_0562 ilxtr:hasIlxId ILX:0382765 .
 
-DICOM:0400_0563 ilxtr:hasIlxId ilx:0381484 .
+DICOM:0400_0563 ilxtr:hasIlxId ILX:0381484 .
 
-DICOM:0400_0564 ilxtr:hasIlxId ilx:0382894 .
+DICOM:0400_0564 ilxtr:hasIlxId ILX:0382894 .
 
-DICOM:0400_0565 ilxtr:hasIlxId ilx:0382613 .
+DICOM:0400_0565 ilxtr:hasIlxId ILX:0382613 .
 
-DICOM:2000_00A0 ilxtr:hasIlxId ilx:0106780 .
+DICOM:2000_00A0 ilxtr:hasIlxId ILX:0106780 .
 
-DICOM:2000_00A1 ilxtr:hasIlxId ilx:0109365 .
+DICOM:2000_00A1 ilxtr:hasIlxId ILX:0109365 .
 
-DICOM:2000_00A4 ilxtr:hasIlxId ilx:0108231 .
+DICOM:2000_00A4 ilxtr:hasIlxId ILX:0108231 .
 
-DICOM:2000_00A8 ilxtr:hasIlxId ilx:0111338 .
+DICOM:2000_00A8 ilxtr:hasIlxId ILX:0111338 .
 
-DICOM:2000_001E ilxtr:hasIlxId ilx:0109359 .
+DICOM:2000_001E ilxtr:hasIlxId ILX:0109359 .
 
-DICOM:2000_0061 ilxtr:hasIlxId ilx:0106583 .
+DICOM:2000_0061 ilxtr:hasIlxId ILX:0106583 .
 
-DICOM:2000_0063 ilxtr:hasIlxId ilx:0102362 .
+DICOM:2000_0063 ilxtr:hasIlxId ILX:0102362 .
 
-DICOM:2000_0510 ilxtr:hasIlxId ilx:0109795 .
+DICOM:2000_0510 ilxtr:hasIlxId ILX:0109795 .
 
-DICOM:2010_00A6 ilxtr:hasIlxId ilx:0102974 .
+DICOM:2010_00A6 ilxtr:hasIlxId ILX:0102974 .
 
-DICOM:2010_00A7 ilxtr:hasIlxId ilx:0108230 .
+DICOM:2010_00A7 ilxtr:hasIlxId ILX:0108230 .
 
-DICOM:2010_00A8 ilxtr:hasIlxId ilx:0102976 .
+DICOM:2010_00A8 ilxtr:hasIlxId ILX:0102976 .
 
-DICOM:2010_00A9 ilxtr:hasIlxId ilx:0108279 .
+DICOM:2010_00A9 ilxtr:hasIlxId ILX:0108279 .
 
-DICOM:2010_015E ilxtr:hasIlxId ilx:0105222 .
+DICOM:2010_015E ilxtr:hasIlxId ILX:0105222 .
 
-DICOM:2010_0052 ilxtr:hasIlxId ilx:0109362 .
+DICOM:2010_0052 ilxtr:hasIlxId ILX:0109362 .
 
-DICOM:2010_0054 ilxtr:hasIlxId ilx:0102975 .
+DICOM:2010_0054 ilxtr:hasIlxId ILX:0102975 .
 
-DICOM:2010_0110 ilxtr:hasIlxId ilx:0103761 .
+DICOM:2010_0110 ilxtr:hasIlxId ILX:0103761 .
 
-DICOM:2010_0160 ilxtr:hasIlxId ilx:0109810 .
+DICOM:2010_0160 ilxtr:hasIlxId ILX:0109810 .
 
-DICOM:2010_0376 ilxtr:hasIlxId ilx:0109361 .
+DICOM:2010_0376 ilxtr:hasIlxId ILX:0109361 .
 
-DICOM:2020_00A0 ilxtr:hasIlxId ilx:0109934 .
+DICOM:2020_00A0 ilxtr:hasIlxId ILX:0109934 .
 
-DICOM:2020_0030 ilxtr:hasIlxId ilx:0109933 .
+DICOM:2020_0030 ilxtr:hasIlxId ILX:0109933 .
 
-DICOM:2020_0130 ilxtr:hasIlxId ilx:0109766 .
+DICOM:2020_0130 ilxtr:hasIlxId ILX:0109766 .
 
-DICOM:2050_0010 ilxtr:hasIlxId ilx:0109241 .
+DICOM:2050_0010 ilxtr:hasIlxId ILX:0109241 .
 
-DICOM:2050_0020 ilxtr:hasIlxId ilx:0109242 .
+DICOM:2050_0020 ilxtr:hasIlxId ILX:0109242 .
 
-DICOM:2050_0500 ilxtr:hasIlxId ilx:0109778 .
+DICOM:2050_0500 ilxtr:hasIlxId ILX:0109778 .
 
-DICOM:2100_0020 ilxtr:hasIlxId ilx:0104011 .
+DICOM:2100_0020 ilxtr:hasIlxId ILX:0104011 .
 
-DICOM:2100_0030 ilxtr:hasIlxId ilx:0104012 .
+DICOM:2100_0030 ilxtr:hasIlxId ILX:0104012 .
 
-DICOM:2100_0040 ilxtr:hasIlxId ilx:0102618 .
+DICOM:2100_0040 ilxtr:hasIlxId ILX:0102618 .
 
-DICOM:2100_0050 ilxtr:hasIlxId ilx:0102619 .
+DICOM:2100_0050 ilxtr:hasIlxId ILX:0102619 .
 
-DICOM:2100_0070 ilxtr:hasIlxId ilx:0108144 .
+DICOM:2100_0070 ilxtr:hasIlxId ILX:0108144 .
 
-DICOM:2100_0140 ilxtr:hasIlxId ilx:0103130 .
+DICOM:2100_0140 ilxtr:hasIlxId ILX:0103130 .
 
-DICOM:2110_0010 ilxtr:hasIlxId ilx:0109363 .
+DICOM:2110_0010 ilxtr:hasIlxId ILX:0109363 .
 
-DICOM:2110_0020 ilxtr:hasIlxId ilx:0109364 .
+DICOM:2110_0020 ilxtr:hasIlxId ILX:0109364 .
 
-DICOM:2110_0030 ilxtr:hasIlxId ilx:0109360 .
+DICOM:2110_0030 ilxtr:hasIlxId ILX:0109360 .
 
-DICOM:2120_0010 ilxtr:hasIlxId ilx:0109581 .
+DICOM:2120_0010 ilxtr:hasIlxId ILX:0109581 .
 
-DICOM:2120_0070 ilxtr:hasIlxId ilx:0109779 .
+DICOM:2120_0070 ilxtr:hasIlxId ILX:0109779 .
 
-DICOM:2130_0010 ilxtr:hasIlxId ilx:0109357 .
+DICOM:2130_0010 ilxtr:hasIlxId ILX:0109357 .
 
-DICOM:2130_0015 ilxtr:hasIlxId ilx:0109358 .
+DICOM:2130_0015 ilxtr:hasIlxId ILX:0109358 .
 
-DICOM:2130_0030 ilxtr:hasIlxId ilx:0104228 .
+DICOM:2130_0030 ilxtr:hasIlxId ILX:0104228 .
 
-DICOM:2200_000A ilxtr:hasIlxId ilx:0109247 .
+DICOM:2200_000A ilxtr:hasIlxId ILX:0109247 .
 
-DICOM:2200_000B ilxtr:hasIlxId ilx:0111829 .
+DICOM:2200_000B ilxtr:hasIlxId ILX:0111829 .
 
-DICOM:2200_000C ilxtr:hasIlxId ilx:0109935 .
+DICOM:2200_000C ilxtr:hasIlxId ILX:0109935 .
 
-DICOM:2200_000D ilxtr:hasIlxId ilx:0109794 .
+DICOM:2200_000D ilxtr:hasIlxId ILX:0109794 .
 
-DICOM:2200_000F ilxtr:hasIlxId ilx:0100478 .
+DICOM:2200_000F ilxtr:hasIlxId ILX:0100478 .
 
-DICOM:2200_0002 ilxtr:hasIlxId ilx:0105961 .
+DICOM:2200_0002 ilxtr:hasIlxId ILX:0105961 .
 
-DICOM:2200_0003 ilxtr:hasIlxId ilx:0105960 .
+DICOM:2200_0003 ilxtr:hasIlxId ILX:0105960 .
 
-DICOM:2200_0005 ilxtr:hasIlxId ilx:0101092 .
+DICOM:2200_0005 ilxtr:hasIlxId ILX:0101092 .
 
-DICOM:2200_0007 ilxtr:hasIlxId ilx:0100479 .
+DICOM:2200_0007 ilxtr:hasIlxId ILX:0100479 .
 
-DICOM:2200_0020 ilxtr:hasIlxId ilx:0109931 .
+DICOM:2200_0020 ilxtr:hasIlxId ILX:0109931 .
 
-DICOM:3002_000A ilxtr:hasIlxId ilx:0109924 .
+DICOM:3002_000A ilxtr:hasIlxId ILX:0109924 .
 
-DICOM:3002_000C ilxtr:hasIlxId ilx:0110247 .
+DICOM:3002_000C ilxtr:hasIlxId ILX:0110247 .
 
-DICOM:3002_000D ilxtr:hasIlxId ilx:0112682 .
+DICOM:3002_000D ilxtr:hasIlxId ILX:0112682 .
 
-DICOM:3002_000E ilxtr:hasIlxId ilx:0112681 .
+DICOM:3002_000E ilxtr:hasIlxId ILX:0112681 .
 
-DICOM:3002_0002 ilxtr:hasIlxId ilx:0110244 .
+DICOM:3002_0002 ilxtr:hasIlxId ILX:0110244 .
 
-DICOM:3002_0003 ilxtr:hasIlxId ilx:0110245 .
+DICOM:3002_0003 ilxtr:hasIlxId ILX:0110245 .
 
-DICOM:3002_0004 ilxtr:hasIlxId ilx:0110243 .
+DICOM:3002_0004 ilxtr:hasIlxId ILX:0110243 .
 
-DICOM:3002_0010 ilxtr:hasIlxId ilx:0110246 .
+DICOM:3002_0010 ilxtr:hasIlxId ILX:0110246 .
 
-DICOM:3002_0011 ilxtr:hasIlxId ilx:0105245 .
+DICOM:3002_0011 ilxtr:hasIlxId ILX:0105245 .
 
-DICOM:3002_0012 ilxtr:hasIlxId ilx:0110248 .
+DICOM:3002_0012 ilxtr:hasIlxId ILX:0110248 .
 
-DICOM:3002_0020 ilxtr:hasIlxId ilx:0109610 .
+DICOM:3002_0020 ilxtr:hasIlxId ILX:0109610 .
 
-DICOM:3002_0022 ilxtr:hasIlxId ilx:0109611 .
+DICOM:3002_0022 ilxtr:hasIlxId ILX:0109611 .
 
-DICOM:3002_0024 ilxtr:hasIlxId ilx:0109612 .
+DICOM:3002_0024 ilxtr:hasIlxId ILX:0109612 .
 
-DICOM:3002_0026 ilxtr:hasIlxId ilx:0110249 .
+DICOM:3002_0026 ilxtr:hasIlxId ILX:0110249 .
 
-DICOM:3002_0028 ilxtr:hasIlxId ilx:0110806 .
+DICOM:3002_0028 ilxtr:hasIlxId ILX:0110806 .
 
-DICOM:3002_0029 ilxtr:hasIlxId ilx:0104392 .
+DICOM:3002_0029 ilxtr:hasIlxId ILX:0104392 .
 
-DICOM:3002_0030 ilxtr:hasIlxId ilx:0104028 .
+DICOM:3002_0030 ilxtr:hasIlxId ILX:0104028 .
 
-DICOM:3002_0032 ilxtr:hasIlxId ilx:0106846 .
+DICOM:3002_0032 ilxtr:hasIlxId ILX:0106846 .
 
-DICOM:3002_0034 ilxtr:hasIlxId ilx:0103195 .
+DICOM:3002_0034 ilxtr:hasIlxId ILX:0103195 .
 
-DICOM:3002_0040 ilxtr:hasIlxId ilx:0104305 .
+DICOM:3002_0040 ilxtr:hasIlxId ILX:0104305 .
 
-DICOM:3002_0041 ilxtr:hasIlxId ilx:0104304 .
+DICOM:3002_0041 ilxtr:hasIlxId ILX:0104304 .
 
-DICOM:3002_0042 ilxtr:hasIlxId ilx:0104303 .
+DICOM:3002_0042 ilxtr:hasIlxId ILX:0104303 .
 
-DICOM:3002_0050 ilxtr:hasIlxId ilx:0381700 .
+DICOM:3002_0050 ilxtr:hasIlxId ILX:0381700 .
 
-DICOM:3002_0051 ilxtr:hasIlxId ilx:0382018 .
+DICOM:3002_0051 ilxtr:hasIlxId ILX:0382018 .
 
-DICOM:3002_0052 ilxtr:hasIlxId ilx:0382016 .
+DICOM:3002_0052 ilxtr:hasIlxId ILX:0382016 .
 
-DICOM:3004_000A ilxtr:hasIlxId ilx:0103533 .
+DICOM:3004_000A ilxtr:hasIlxId ILX:0103533 .
 
-DICOM:3004_000C ilxtr:hasIlxId ilx:0104789 .
+DICOM:3004_000C ilxtr:hasIlxId ILX:0104789 .
 
-DICOM:3004_000E ilxtr:hasIlxId ilx:0103523 .
+DICOM:3004_000E ilxtr:hasIlxId ILX:0103523 .
 
-DICOM:3004_00EE ilxtr:hasIlxId ilx:0102427 .
+DICOM:3004_00EE ilxtr:hasIlxId ILX:0102427 .
 
-DICOM:3004_0001 ilxtr:hasIlxId ilx:0103613 .
+DICOM:3004_0001 ilxtr:hasIlxId ILX:0103613 .
 
-DICOM:3004_0002 ilxtr:hasIlxId ilx:0103535 .
+DICOM:3004_0002 ilxtr:hasIlxId ILX:0103535 .
 
-DICOM:3004_0004 ilxtr:hasIlxId ilx:0103534 .
+DICOM:3004_0004 ilxtr:hasIlxId ILX:0103534 .
 
-DICOM:3004_0005 ilxtr:hasIlxId ilx:0381856 .
+DICOM:3004_0005 ilxtr:hasIlxId ILX:0381856 .
 
-DICOM:3004_0006 ilxtr:hasIlxId ilx:0103522 .
+DICOM:3004_0006 ilxtr:hasIlxId ILX:0103522 .
 
-DICOM:3004_0008 ilxtr:hasIlxId ilx:0107686 .
+DICOM:3004_0008 ilxtr:hasIlxId ILX:0107686 .
 
-DICOM:3004_0010 ilxtr:hasIlxId ilx:0110242 .
+DICOM:3004_0010 ilxtr:hasIlxId ILX:0110242 .
 
-DICOM:3004_0012 ilxtr:hasIlxId ilx:0103536 .
+DICOM:3004_0012 ilxtr:hasIlxId ILX:0103536 .
 
-DICOM:3004_0014 ilxtr:hasIlxId ilx:0111773 .
+DICOM:3004_0014 ilxtr:hasIlxId ILX:0111773 .
 
-DICOM:3004_0040 ilxtr:hasIlxId ilx:0103608 .
+DICOM:3004_0040 ilxtr:hasIlxId ILX:0103608 .
 
-DICOM:3004_0042 ilxtr:hasIlxId ilx:0103607 .
+DICOM:3004_0042 ilxtr:hasIlxId ILX:0103607 .
 
-DICOM:3004_0050 ilxtr:hasIlxId ilx:0103612 .
+DICOM:3004_0050 ilxtr:hasIlxId ILX:0103612 .
 
-DICOM:3004_0052 ilxtr:hasIlxId ilx:0103603 .
+DICOM:3004_0052 ilxtr:hasIlxId ILX:0103603 .
 
-DICOM:3004_0054 ilxtr:hasIlxId ilx:0103614 .
+DICOM:3004_0054 ilxtr:hasIlxId ILX:0103614 .
 
-DICOM:3004_0056 ilxtr:hasIlxId ilx:0103609 .
+DICOM:3004_0056 ilxtr:hasIlxId ILX:0103609 .
 
-DICOM:3004_0058 ilxtr:hasIlxId ilx:0103602 .
+DICOM:3004_0058 ilxtr:hasIlxId ILX:0103602 .
 
-DICOM:3004_0060 ilxtr:hasIlxId ilx:0103610 .
+DICOM:3004_0060 ilxtr:hasIlxId ILX:0103610 .
 
-DICOM:3004_0062 ilxtr:hasIlxId ilx:0103611 .
+DICOM:3004_0062 ilxtr:hasIlxId ILX:0103611 .
 
-DICOM:3004_0070 ilxtr:hasIlxId ilx:0103606 .
+DICOM:3004_0070 ilxtr:hasIlxId ILX:0103606 .
 
-DICOM:3004_0072 ilxtr:hasIlxId ilx:0103604 .
+DICOM:3004_0072 ilxtr:hasIlxId ILX:0103604 .
 
-DICOM:3004_0074 ilxtr:hasIlxId ilx:0103605 .
+DICOM:3004_0074 ilxtr:hasIlxId ILX:0103605 .
 
-DICOM:3006_00A0 ilxtr:hasIlxId ilx:0109890 .
+DICOM:3006_00A0 ilxtr:hasIlxId ILX:0109890 .
 
-DICOM:3006_00A4 ilxtr:hasIlxId ilx:0110261 .
+DICOM:3006_00A4 ilxtr:hasIlxId ILX:0110261 .
 
-DICOM:3006_00A6 ilxtr:hasIlxId ilx:0110183 .
+DICOM:3006_00A6 ilxtr:hasIlxId ILX:0110183 .
 
-DICOM:3006_00B0 ilxtr:hasIlxId ilx:0110189 .
+DICOM:3006_00B0 ilxtr:hasIlxId ILX:0110189 .
 
-DICOM:3006_00B2 ilxtr:hasIlxId ilx:0110190 .
+DICOM:3006_00B2 ilxtr:hasIlxId ILX:0110190 .
 
-DICOM:3006_00B4 ilxtr:hasIlxId ilx:0110191 .
+DICOM:3006_00B4 ilxtr:hasIlxId ILX:0110191 .
 
-DICOM:3006_00B6 ilxtr:hasIlxId ilx:0381485 .
+DICOM:3006_00B6 ilxtr:hasIlxId ILX:0381485 .
 
-DICOM:3006_00B7 ilxtr:hasIlxId ilx:0381738 .
+DICOM:3006_00B7 ilxtr:hasIlxId ILX:0381738 .
 
-DICOM:3006_00B8 ilxtr:hasIlxId ilx:0382932 .
+DICOM:3006_00B8 ilxtr:hasIlxId ILX:0382932 .
 
-DICOM:3006_00C0 ilxtr:hasIlxId ilx:0104414 .
+DICOM:3006_00C0 ilxtr:hasIlxId ILX:0104414 .
 
-DICOM:3006_00C2 ilxtr:hasIlxId ilx:0109888 .
+DICOM:3006_00C2 ilxtr:hasIlxId ILX:0109888 .
 
-DICOM:3006_00C4 ilxtr:hasIlxId ilx:0104417 .
+DICOM:3006_00C4 ilxtr:hasIlxId ILX:0104417 .
 
-DICOM:3006_00C6 ilxtr:hasIlxId ilx:0104416 .
+DICOM:3006_00C6 ilxtr:hasIlxId ILX:0104416 .
 
-DICOM:3006_00C8 ilxtr:hasIlxId ilx:0104415 .
+DICOM:3006_00C8 ilxtr:hasIlxId ILX:0104415 .
 
-DICOM:3006_0002 ilxtr:hasIlxId ilx:0111121 .
+DICOM:3006_0002 ilxtr:hasIlxId ILX:0111121 .
 
-DICOM:3006_002A ilxtr:hasIlxId ilx:0110180 .
+DICOM:3006_002A ilxtr:hasIlxId ILX:0110180 .
 
-DICOM:3006_002C ilxtr:hasIlxId ilx:0110193 .
+DICOM:3006_002C ilxtr:hasIlxId ILX:0110193 .
 
-DICOM:3006_0004 ilxtr:hasIlxId ilx:0111122 .
+DICOM:3006_0004 ilxtr:hasIlxId ILX:0111122 .
 
-DICOM:3006_0006 ilxtr:hasIlxId ilx:0111120 .
+DICOM:3006_0006 ilxtr:hasIlxId ILX:0111120 .
 
-DICOM:3006_0008 ilxtr:hasIlxId ilx:0111119 .
+DICOM:3006_0008 ilxtr:hasIlxId ILX:0111119 .
 
-DICOM:3006_0009 ilxtr:hasIlxId ilx:0111124 .
+DICOM:3006_0009 ilxtr:hasIlxId ILX:0111124 .
 
-DICOM:3006_0010 ilxtr:hasIlxId ilx:0109760 .
+DICOM:3006_0010 ilxtr:hasIlxId ILX:0109760 .
 
-DICOM:3006_0012 ilxtr:hasIlxId ilx:0110258 .
+DICOM:3006_0012 ilxtr:hasIlxId ILX:0110258 .
 
-DICOM:3006_0014 ilxtr:hasIlxId ilx:0110257 .
+DICOM:3006_0014 ilxtr:hasIlxId ILX:0110257 .
 
-DICOM:3006_0016 ilxtr:hasIlxId ilx:0102522 .
+DICOM:3006_0016 ilxtr:hasIlxId ILX:0102522 .
 
-DICOM:3006_0018 ilxtr:hasIlxId ilx:0383015 .
+DICOM:3006_0018 ilxtr:hasIlxId ILX:0383015 .
 
-DICOM:3006_0020 ilxtr:hasIlxId ilx:0111123 .
+DICOM:3006_0020 ilxtr:hasIlxId ILX:0111123 .
 
-DICOM:3006_0022 ilxtr:hasIlxId ilx:0383191 .
+DICOM:3006_0022 ilxtr:hasIlxId ILX:0383191 .
 
-DICOM:3006_0024 ilxtr:hasIlxId ilx:0109761 .
+DICOM:3006_0024 ilxtr:hasIlxId ILX:0109761 .
 
-DICOM:3006_0026 ilxtr:hasIlxId ilx:0110185 .
+DICOM:3006_0026 ilxtr:hasIlxId ILX:0110185 .
 
-DICOM:3006_0028 ilxtr:hasIlxId ilx:0110179 .
+DICOM:3006_0028 ilxtr:hasIlxId ILX:0110179 .
 
-DICOM:3006_0030 ilxtr:hasIlxId ilx:0110259 .
+DICOM:3006_0030 ilxtr:hasIlxId ILX:0110259 .
 
-DICOM:3006_0033 ilxtr:hasIlxId ilx:0110263 .
+DICOM:3006_0033 ilxtr:hasIlxId ILX:0110263 .
 
-DICOM:3006_0036 ilxtr:hasIlxId ilx:0110181 .
+DICOM:3006_0036 ilxtr:hasIlxId ILX:0110181 .
 
-DICOM:3006_0038 ilxtr:hasIlxId ilx:0110182 .
+DICOM:3006_0038 ilxtr:hasIlxId ILX:0110182 .
 
-DICOM:3006_0039 ilxtr:hasIlxId ilx:0110178 .
+DICOM:3006_0039 ilxtr:hasIlxId ILX:0110178 .
 
-DICOM:3006_0040 ilxtr:hasIlxId ilx:0102525 .
+DICOM:3006_0040 ilxtr:hasIlxId ILX:0102525 .
 
-DICOM:3006_0042 ilxtr:hasIlxId ilx:0102521 .
+DICOM:3006_0042 ilxtr:hasIlxId ILX:0102521 .
 
-DICOM:3006_0044 ilxtr:hasIlxId ilx:0102526 .
+DICOM:3006_0044 ilxtr:hasIlxId ILX:0102526 .
 
-DICOM:3006_0045 ilxtr:hasIlxId ilx:0102524 .
+DICOM:3006_0045 ilxtr:hasIlxId ILX:0102524 .
 
-DICOM:3006_0046 ilxtr:hasIlxId ilx:0107814 .
+DICOM:3006_0046 ilxtr:hasIlxId ILX:0107814 .
 
-DICOM:3006_0048 ilxtr:hasIlxId ilx:0102523 .
+DICOM:3006_0048 ilxtr:hasIlxId ILX:0102523 .
 
-DICOM:3006_0049 ilxtr:hasIlxId ilx:0100978 .
+DICOM:3006_0049 ilxtr:hasIlxId ILX:0100978 .
 
-DICOM:3006_0050 ilxtr:hasIlxId ilx:0102520 .
+DICOM:3006_0050 ilxtr:hasIlxId ILX:0102520 .
 
-DICOM:3006_0080 ilxtr:hasIlxId ilx:0110262 .
+DICOM:3006_0080 ilxtr:hasIlxId ILX:0110262 .
 
-DICOM:3006_0082 ilxtr:hasIlxId ilx:0107874 .
+DICOM:3006_0082 ilxtr:hasIlxId ILX:0107874 .
 
-DICOM:3006_0084 ilxtr:hasIlxId ilx:0109785 .
+DICOM:3006_0084 ilxtr:hasIlxId ILX:0109785 .
 
-DICOM:3006_0085 ilxtr:hasIlxId ilx:0110188 .
+DICOM:3006_0085 ilxtr:hasIlxId ILX:0110188 .
 
-DICOM:3006_0086 ilxtr:hasIlxId ilx:0110260 .
+DICOM:3006_0086 ilxtr:hasIlxId ILX:0110260 .
 
-DICOM:3006_0088 ilxtr:hasIlxId ilx:0110187 .
+DICOM:3006_0088 ilxtr:hasIlxId ILX:0110187 .
 
-DICOM:3008_00A0 ilxtr:hasIlxId ilx:0101146 .
+DICOM:3008_00A0 ilxtr:hasIlxId ILX:0101146 .
 
-DICOM:3008_00B0 ilxtr:hasIlxId ilx:0109712 .
+DICOM:3008_00B0 ilxtr:hasIlxId ILX:0109712 .
 
-DICOM:3008_00C0 ilxtr:hasIlxId ilx:0109709 .
+DICOM:3008_00C0 ilxtr:hasIlxId ILX:0109709 .
 
-DICOM:3008_00D0 ilxtr:hasIlxId ilx:0109705 .
+DICOM:3008_00D0 ilxtr:hasIlxId ILX:0109705 .
 
-DICOM:3008_00E0 ilxtr:hasIlxId ilx:0111940 .
+DICOM:3008_00E0 ilxtr:hasIlxId ILX:0111940 .
 
-DICOM:3008_002A ilxtr:hasIlxId ilx:0111942 .
+DICOM:3008_002A ilxtr:hasIlxId ILX:0111942 .
 
-DICOM:3008_002B ilxtr:hasIlxId ilx:0111941 .
+DICOM:3008_002B ilxtr:hasIlxId ILX:0111941 .
 
-DICOM:3008_002C ilxtr:hasIlxId ilx:0111944 .
+DICOM:3008_002C ilxtr:hasIlxId ILX:0111944 .
 
-DICOM:3008_003A ilxtr:hasIlxId ilx:0110864 .
+DICOM:3008_003A ilxtr:hasIlxId ILX:0110864 .
 
-DICOM:3008_003B ilxtr:hasIlxId ilx:0103003 .
+DICOM:3008_003B ilxtr:hasIlxId ILX:0103003 .
 
-DICOM:3008_005A ilxtr:hasIlxId ilx:0107821 .
+DICOM:3008_005A ilxtr:hasIlxId ILX:0107821 .
 
-DICOM:3008_006A ilxtr:hasIlxId ilx:0381938 .
+DICOM:3008_006A ilxtr:hasIlxId ILX:0381938 .
 
-DICOM:3008_007A ilxtr:hasIlxId ilx:0103774 .
+DICOM:3008_007A ilxtr:hasIlxId ILX:0103774 .
 
-DICOM:3008_0010 ilxtr:hasIlxId ilx:0106595 .
+DICOM:3008_0010 ilxtr:hasIlxId ILX:0106595 .
 
-DICOM:3008_0012 ilxtr:hasIlxId ilx:0106593 .
+DICOM:3008_0012 ilxtr:hasIlxId ILX:0106593 .
 
-DICOM:3008_013A ilxtr:hasIlxId ilx:0110862 .
+DICOM:3008_013A ilxtr:hasIlxId ILX:0110862 .
 
-DICOM:3008_013C ilxtr:hasIlxId ilx:0103001 .
+DICOM:3008_013C ilxtr:hasIlxId ILX:0103001 .
 
-DICOM:3008_0014 ilxtr:hasIlxId ilx:0106596 .
+DICOM:3008_0014 ilxtr:hasIlxId ILX:0106596 .
 
-DICOM:3008_0016 ilxtr:hasIlxId ilx:0106597 .
+DICOM:3008_0016 ilxtr:hasIlxId ILX:0106597 .
 
-DICOM:3008_0020 ilxtr:hasIlxId ilx:0111936 .
+DICOM:3008_0020 ilxtr:hasIlxId ILX:0111936 .
 
-DICOM:3008_0022 ilxtr:hasIlxId ilx:0102680 .
+DICOM:3008_0022 ilxtr:hasIlxId ILX:0102680 .
 
-DICOM:3008_0024 ilxtr:hasIlxId ilx:0111927 .
+DICOM:3008_0024 ilxtr:hasIlxId ILX:0111927 .
 
-DICOM:3008_0025 ilxtr:hasIlxId ilx:0111928 .
+DICOM:3008_0025 ilxtr:hasIlxId ILX:0111928 .
 
-DICOM:3008_0030 ilxtr:hasIlxId ilx:0109800 .
+DICOM:3008_0030 ilxtr:hasIlxId ILX:0109800 .
 
-DICOM:3008_0032 ilxtr:hasIlxId ilx:0110861 .
+DICOM:3008_0032 ilxtr:hasIlxId ILX:0110861 .
 
-DICOM:3008_0033 ilxtr:hasIlxId ilx:0110863 .
+DICOM:3008_0033 ilxtr:hasIlxId ILX:0110863 .
 
-DICOM:3008_0036 ilxtr:hasIlxId ilx:0103000 .
+DICOM:3008_0036 ilxtr:hasIlxId ILX:0103000 .
 
-DICOM:3008_0037 ilxtr:hasIlxId ilx:0103002 .
+DICOM:3008_0037 ilxtr:hasIlxId ILX:0103002 .
 
-DICOM:3008_0040 ilxtr:hasIlxId ilx:0102539 .
+DICOM:3008_0040 ilxtr:hasIlxId ILX:0102539 .
 
-DICOM:3008_0042 ilxtr:hasIlxId ilx:0110859 .
+DICOM:3008_0042 ilxtr:hasIlxId ILX:0110859 .
 
-DICOM:3008_0044 ilxtr:hasIlxId ilx:0102998 .
+DICOM:3008_0044 ilxtr:hasIlxId ILX:0102998 .
 
-DICOM:3008_0048 ilxtr:hasIlxId ilx:0103524 .
+DICOM:3008_0048 ilxtr:hasIlxId ILX:0103524 .
 
-DICOM:3008_0050 ilxtr:hasIlxId ilx:0111939 .
+DICOM:3008_0050 ilxtr:hasIlxId ILX:0111939 .
 
-DICOM:3008_0052 ilxtr:hasIlxId ilx:0102663 .
+DICOM:3008_0052 ilxtr:hasIlxId ILX:0102663 .
 
-DICOM:3008_0054 ilxtr:hasIlxId ilx:0104263 .
+DICOM:3008_0054 ilxtr:hasIlxId ILX:0104263 .
 
-DICOM:3008_0056 ilxtr:hasIlxId ilx:0107110 .
+DICOM:3008_0056 ilxtr:hasIlxId ILX:0107110 .
 
-DICOM:3008_0060 ilxtr:hasIlxId ilx:0108307 .
+DICOM:3008_0060 ilxtr:hasIlxId ILX:0108307 .
 
-DICOM:3008_0061 ilxtr:hasIlxId ilx:0382139 .
+DICOM:3008_0061 ilxtr:hasIlxId ILX:0382139 .
 
-DICOM:3008_0062 ilxtr:hasIlxId ilx:0108305 .
+DICOM:3008_0062 ilxtr:hasIlxId ILX:0108305 .
 
-DICOM:3008_0063 ilxtr:hasIlxId ilx:0381854 .
+DICOM:3008_0063 ilxtr:hasIlxId ILX:0381854 .
 
-DICOM:3008_0064 ilxtr:hasIlxId ilx:0106594 .
+DICOM:3008_0064 ilxtr:hasIlxId ILX:0106594 .
 
-DICOM:3008_0065 ilxtr:hasIlxId ilx:0381656 .
+DICOM:3008_0065 ilxtr:hasIlxId ILX:0381656 .
 
-DICOM:3008_0066 ilxtr:hasIlxId ilx:0108306 .
+DICOM:3008_0066 ilxtr:hasIlxId ILX:0108306 .
 
-DICOM:3008_0067 ilxtr:hasIlxId ilx:0382773 .
+DICOM:3008_0067 ilxtr:hasIlxId ILX:0382773 .
 
-DICOM:3008_0068 ilxtr:hasIlxId ilx:0383084 .
+DICOM:3008_0068 ilxtr:hasIlxId ILX:0383084 .
 
-DICOM:3008_0070 ilxtr:hasIlxId ilx:0381750 .
+DICOM:3008_0070 ilxtr:hasIlxId ILX:0381750 .
 
-DICOM:3008_0072 ilxtr:hasIlxId ilx:0382995 .
+DICOM:3008_0072 ilxtr:hasIlxId ILX:0382995 .
 
-DICOM:3008_0074 ilxtr:hasIlxId ilx:0381791 .
+DICOM:3008_0074 ilxtr:hasIlxId ILX:0381791 .
 
-DICOM:3008_0076 ilxtr:hasIlxId ilx:0382867 .
+DICOM:3008_0076 ilxtr:hasIlxId ILX:0382867 .
 
-DICOM:3008_0078 ilxtr:hasIlxId ilx:0111024 .
+DICOM:3008_0078 ilxtr:hasIlxId ILX:0111024 .
 
-DICOM:3008_0080 ilxtr:hasIlxId ilx:0109771 .
+DICOM:3008_0080 ilxtr:hasIlxId ILX:0109771 .
 
-DICOM:3008_0082 ilxtr:hasIlxId ilx:0109770 .
+DICOM:3008_0082 ilxtr:hasIlxId ILX:0109770 .
 
-DICOM:3008_0090 ilxtr:hasIlxId ilx:0109746 .
+DICOM:3008_0090 ilxtr:hasIlxId ILX:0109746 .
 
-DICOM:3008_0092 ilxtr:hasIlxId ilx:0109745 .
+DICOM:3008_0092 ilxtr:hasIlxId ILX:0109745 .
 
-DICOM:3008_0100 ilxtr:hasIlxId ilx:0109711 .
+DICOM:3008_0100 ilxtr:hasIlxId ILX:0109711 .
 
-DICOM:3008_0105 ilxtr:hasIlxId ilx:0110801 .
+DICOM:3008_0105 ilxtr:hasIlxId ILX:0110801 .
 
-DICOM:3008_0110 ilxtr:hasIlxId ilx:0111935 .
+DICOM:3008_0110 ilxtr:hasIlxId ILX:0111935 .
 
-DICOM:3008_0116 ilxtr:hasIlxId ilx:0100855 .
+DICOM:3008_0116 ilxtr:hasIlxId ILX:0100855 .
 
-DICOM:3008_0120 ilxtr:hasIlxId ilx:0109706 .
+DICOM:3008_0120 ilxtr:hasIlxId ILX:0109706 .
 
-DICOM:3008_0122 ilxtr:hasIlxId ilx:0109742 .
+DICOM:3008_0122 ilxtr:hasIlxId ILX:0109742 .
 
-DICOM:3008_0130 ilxtr:hasIlxId ilx:0109707 .
+DICOM:3008_0130 ilxtr:hasIlxId ILX:0109707 .
 
-DICOM:3008_0132 ilxtr:hasIlxId ilx:0110858 .
+DICOM:3008_0132 ilxtr:hasIlxId ILX:0110858 .
 
-DICOM:3008_0134 ilxtr:hasIlxId ilx:0102997 .
+DICOM:3008_0134 ilxtr:hasIlxId ILX:0102997 .
 
-DICOM:3008_0136 ilxtr:hasIlxId ilx:0110860 .
+DICOM:3008_0136 ilxtr:hasIlxId ILX:0110860 .
 
-DICOM:3008_0138 ilxtr:hasIlxId ilx:0102999 .
+DICOM:3008_0138 ilxtr:hasIlxId ILX:0102999 .
 
-DICOM:3008_0140 ilxtr:hasIlxId ilx:0109710 .
+DICOM:3008_0140 ilxtr:hasIlxId ILX:0109710 .
 
-DICOM:3008_0142 ilxtr:hasIlxId ilx:0109792 .
+DICOM:3008_0142 ilxtr:hasIlxId ILX:0109792 .
 
-DICOM:3008_0150 ilxtr:hasIlxId ilx:0109708 .
+DICOM:3008_0150 ilxtr:hasIlxId ILX:0109708 .
 
-DICOM:3008_0152 ilxtr:hasIlxId ilx:0383126 .
+DICOM:3008_0152 ilxtr:hasIlxId ILX:0383126 .
 
-DICOM:3008_0160 ilxtr:hasIlxId ilx:0101420 .
+DICOM:3008_0160 ilxtr:hasIlxId ILX:0101420 .
 
-DICOM:3008_0162 ilxtr:hasIlxId ilx:0110307 .
+DICOM:3008_0162 ilxtr:hasIlxId ILX:0110307 .
 
-DICOM:3008_0164 ilxtr:hasIlxId ilx:0110308 .
+DICOM:3008_0164 ilxtr:hasIlxId ILX:0110308 .
 
-DICOM:3008_0166 ilxtr:hasIlxId ilx:0110309 .
+DICOM:3008_0166 ilxtr:hasIlxId ILX:0110309 .
 
-DICOM:3008_0168 ilxtr:hasIlxId ilx:0110310 .
+DICOM:3008_0168 ilxtr:hasIlxId ILX:0110310 .
 
-DICOM:3008_0171 ilxtr:hasIlxId ilx:0381955 .
+DICOM:3008_0171 ilxtr:hasIlxId ILX:0381955 .
 
-DICOM:3008_0172 ilxtr:hasIlxId ilx:0382994 .
+DICOM:3008_0172 ilxtr:hasIlxId ILX:0382994 .
 
-DICOM:3008_0173 ilxtr:hasIlxId ilx:0383038 .
+DICOM:3008_0173 ilxtr:hasIlxId ILX:0383038 .
 
-DICOM:3008_0200 ilxtr:hasIlxId ilx:0102683 .
+DICOM:3008_0200 ilxtr:hasIlxId ILX:0102683 .
 
-DICOM:3008_0202 ilxtr:hasIlxId ilx:0111938 .
+DICOM:3008_0202 ilxtr:hasIlxId ILX:0111938 .
 
-DICOM:3008_0220 ilxtr:hasIlxId ilx:0104390 .
+DICOM:3008_0220 ilxtr:hasIlxId ILX:0104390 .
 
-DICOM:3008_0223 ilxtr:hasIlxId ilx:0383187 .
+DICOM:3008_0223 ilxtr:hasIlxId ILX:0383187 .
 
-DICOM:3008_0224 ilxtr:hasIlxId ilx:0104391 .
+DICOM:3008_0224 ilxtr:hasIlxId ILX:0104391 .
 
-DICOM:3008_0230 ilxtr:hasIlxId ilx:0101156 .
+DICOM:3008_0230 ilxtr:hasIlxId ILX:0101156 .
 
-DICOM:3008_0240 ilxtr:hasIlxId ilx:0104394 .
+DICOM:3008_0240 ilxtr:hasIlxId ILX:0104394 .
 
-DICOM:3008_0250 ilxtr:hasIlxId ilx:0383174 .
+DICOM:3008_0250 ilxtr:hasIlxId ILX:0383174 .
 
-DICOM:3008_0251 ilxtr:hasIlxId ilx:0111943 .
+DICOM:3008_0251 ilxtr:hasIlxId ILX:0111943 .
 
-DICOM:4008_010A ilxtr:hasIlxId ilx:0105616 .
+DICOM:4008_010A ilxtr:hasIlxId ILX:0105616 .
 
-DICOM:4008_010B ilxtr:hasIlxId ilx:0105615 .
+DICOM:4008_010B ilxtr:hasIlxId ILX:0105615 .
 
-DICOM:4008_010C ilxtr:hasIlxId ilx:0105606 .
+DICOM:4008_010C ilxtr:hasIlxId ILX:0105606 .
 
-DICOM:4008_011A ilxtr:hasIlxId ilx:0103346 .
+DICOM:4008_011A ilxtr:hasIlxId ILX:0103346 .
 
-DICOM:4008_0040 ilxtr:hasIlxId ilx:0109982 .
+DICOM:4008_0040 ilxtr:hasIlxId ILX:0109982 .
 
-DICOM:4008_0042 ilxtr:hasIlxId ilx:0109983 .
+DICOM:4008_0042 ilxtr:hasIlxId ILX:0109983 .
 
-DICOM:4008_0050 ilxtr:hasIlxId ilx:0109769 .
+DICOM:4008_0050 ilxtr:hasIlxId ILX:0109769 .
 
-DICOM:4008_0100 ilxtr:hasIlxId ilx:0105611 .
+DICOM:4008_0100 ilxtr:hasIlxId ILX:0105611 .
 
-DICOM:4008_0101 ilxtr:hasIlxId ilx:0105612 .
+DICOM:4008_0101 ilxtr:hasIlxId ILX:0105612 .
 
-DICOM:4008_0102 ilxtr:hasIlxId ilx:0105613 .
+DICOM:4008_0102 ilxtr:hasIlxId ILX:0105613 .
 
-DICOM:4008_0103 ilxtr:hasIlxId ilx:0109736 .
+DICOM:4008_0103 ilxtr:hasIlxId ILX:0109736 .
 
-DICOM:4008_0108 ilxtr:hasIlxId ilx:0105617 .
+DICOM:4008_0108 ilxtr:hasIlxId ILX:0105617 .
 
-DICOM:4008_0109 ilxtr:hasIlxId ilx:0105618 .
+DICOM:4008_0109 ilxtr:hasIlxId ILX:0105618 .
 
-DICOM:4008_0111 ilxtr:hasIlxId ilx:0105605 .
+DICOM:4008_0111 ilxtr:hasIlxId ILX:0105605 .
 
-DICOM:4008_0112 ilxtr:hasIlxId ilx:0105603 .
+DICOM:4008_0112 ilxtr:hasIlxId ILX:0105603 .
 
-DICOM:4008_0113 ilxtr:hasIlxId ilx:0105604 .
+DICOM:4008_0113 ilxtr:hasIlxId ILX:0105604 .
 
-DICOM:4008_0114 ilxtr:hasIlxId ilx:0108862 .
+DICOM:4008_0114 ilxtr:hasIlxId ILX:0108862 .
 
-DICOM:4008_0115 ilxtr:hasIlxId ilx:0105608 .
+DICOM:4008_0115 ilxtr:hasIlxId ILX:0105608 .
 
-DICOM:4008_0117 ilxtr:hasIlxId ilx:0105607 .
+DICOM:4008_0117 ilxtr:hasIlxId ILX:0105607 .
 
-DICOM:4008_0118 ilxtr:hasIlxId ilx:0109981 .
+DICOM:4008_0118 ilxtr:hasIlxId ILX:0109981 .
 
-DICOM:4008_0119 ilxtr:hasIlxId ilx:0103347 .
+DICOM:4008_0119 ilxtr:hasIlxId ILX:0103347 .
 
-DICOM:4008_0200 ilxtr:hasIlxId ilx:0105609 .
+DICOM:4008_0200 ilxtr:hasIlxId ILX:0105609 .
 
-DICOM:4008_0202 ilxtr:hasIlxId ilx:0105610 .
+DICOM:4008_0202 ilxtr:hasIlxId ILX:0105610 .
 
-DICOM:4008_0210 ilxtr:hasIlxId ilx:0105619 .
+DICOM:4008_0210 ilxtr:hasIlxId ILX:0105619 .
 
-DICOM:4008_0212 ilxtr:hasIlxId ilx:0105614 .
+DICOM:4008_0212 ilxtr:hasIlxId ILX:0105614 .
 
-DICOM:4008_0300 ilxtr:hasIlxId ilx:0105304 .
+DICOM:4008_0300 ilxtr:hasIlxId ILX:0105304 .
 
-DICOM:4008_4000 ilxtr:hasIlxId ilx:0109980 .
+DICOM:4008_4000 ilxtr:hasIlxId ILX:0109980 .
 
-DICOM:5200_9229 ilxtr:hasIlxId ilx:0110597 .
+DICOM:5200_9229 ilxtr:hasIlxId ILX:0110597 .
 
-DICOM:5200_9230 ilxtr:hasIlxId ilx:0108677 .
+DICOM:5200_9230 ilxtr:hasIlxId ILX:0108677 .
 
-DICOM:5400_0100 ilxtr:hasIlxId ilx:0112590 .
+DICOM:5400_0100 ilxtr:hasIlxId ILX:0112590 .
 
-DICOM:5400_100A ilxtr:hasIlxId ilx:0112588 .
+DICOM:5400_100A ilxtr:hasIlxId ILX:0112588 .
 
-DICOM:5400_0110 ilxtr:hasIlxId ilx:0102036 .
+DICOM:5400_0110 ilxtr:hasIlxId ILX:0102036 .
 
-DICOM:5400_0112 ilxtr:hasIlxId ilx:0102035 .
+DICOM:5400_0112 ilxtr:hasIlxId ILX:0102035 .
 
-DICOM:5400_1004 ilxtr:hasIlxId ilx:0112583 .
+DICOM:5400_1004 ilxtr:hasIlxId ILX:0112583 .
 
-DICOM:5400_1006 ilxtr:hasIlxId ilx:0112589 .
+DICOM:5400_1006 ilxtr:hasIlxId ILX:0112589 .
 
-DICOM:5400_1010 ilxtr:hasIlxId ilx:0112586 .
+DICOM:5400_1010 ilxtr:hasIlxId ILX:0112586 .
 
-DICOM:5600_0010 ilxtr:hasIlxId ilx:0104256 .
+DICOM:5600_0010 ilxtr:hasIlxId ILX:0104256 .
 
-DICOM:5600_0020 ilxtr:hasIlxId ilx:0110884 .
+DICOM:5600_0020 ilxtr:hasIlxId ILX:0110884 .
 
-DICOM:FFFA_FFFA ilxtr:hasIlxId ilx:0382419 .
+DICOM:FFFA_FFFA ilxtr:hasIlxId ILX:0382419 .
 
 ### Serialized using the ttlser deterministic serializer v1.2.0

--- a/ttl/generated/DICOM-ILX-mapping.ttl
+++ b/ttl/generated/DICOM-ILX-mapping.ttl
@@ -1,0 +1,6615 @@
+@prefix DICOM: <http://uri.interlex.org/dicom/uris/terms/> .
+@prefix ilx: <http://uri.interlex.org/base/ilx_> .
+@prefix ilxtr: <http://uri.interlex.org/tgbugs/uris/readable/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://ontology.neuinfo.org/NIF/ttl/generated/DICOM-ILX-mapping.ttl> a owl:Ontology ;
+    rdfs:label "DICOM to ILX equivalents" ;
+    owl:versionInfo "2022-11-01" .
+
+### Annotations
+
+DICOM:0000_0001 ilxtr:hasIlxId ilx:0381696 .
+
+DICOM:0000_0002 ilxtr:hasIlxId ilx:0382179 .
+
+DICOM:0000_0003 ilxtr:hasIlxId ilx:0382134 .
+
+DICOM:0000_0004 ilxtr:hasIlxId ilx:0382147 .
+
+DICOM:0000_0005 ilxtr:hasIlxId ilx:0381975 .
+
+DICOM:0000_0006 ilxtr:hasIlxId ilx:0382712 .
+
+DICOM:0000_0007 ilxtr:hasIlxId ilx:0382125 .
+
+DICOM:0000_0008 ilxtr:hasIlxId ilx:0381682 .
+
+DICOM:0000_0009 ilxtr:hasIlxId ilx:0381831 .
+
+DICOM:0000_0010 ilxtr:hasIlxId ilx:0381753 .
+
+DICOM:0000_0011 ilxtr:hasIlxId ilx:0381801 .
+
+DICOM:0000_0012 ilxtr:hasIlxId ilx:0381679 .
+
+DICOM:0000_0013 ilxtr:hasIlxId ilx:0382943 .
+
+DICOM:0000_0014 ilxtr:hasIlxId ilx:0382784 .
+
+DICOM:0000_0015 ilxtr:hasIlxId ilx:0382357 .
+
+DICOM:0000_0016 ilxtr:hasIlxId ilx:0381905 .
+
+DICOM:0000_0017 ilxtr:hasIlxId ilx:0382523 .
+
+DICOM:0000_0018 ilxtr:hasIlxId ilx:0382759 .
+
+DICOM:0000_0019 ilxtr:hasIlxId ilx:0381540 .
+
+DICOM:0000_0020 ilxtr:hasIlxId ilx:0381746 .
+
+DICOM:0000_0021 ilxtr:hasIlxId ilx:0382387 .
+
+DICOM:0000_0022 ilxtr:hasIlxId ilx:0382003 .
+
+DICOM:0000_0023 ilxtr:hasIlxId ilx:0382598 .
+
+DICOM:0000_0024 ilxtr:hasIlxId ilx:0382535 .
+
+DICOM:0000_0025 ilxtr:hasIlxId ilx:0382150 .
+
+DICOM:0000_0026 ilxtr:hasIlxId ilx:0381973 .
+
+DICOM:0000_0027 ilxtr:hasIlxId ilx:0382627 .
+
+DICOM:0000_0028 ilxtr:hasIlxId ilx:0381758 .
+
+DICOM:0000_0029 ilxtr:hasIlxId ilx:0382043 .
+
+DICOM:0000_0031 ilxtr:hasIlxId ilx:0382925 .
+
+DICOM:0000_0032 ilxtr:hasIlxId ilx:0382607 .
+
+DICOM:0000_0033 ilxtr:hasIlxId ilx:0382772 .
+
+DICOM:0000_0034 ilxtr:hasIlxId ilx:0382122 .
+
+DICOM:0000_0035 ilxtr:hasIlxId ilx:0382724 .
+
+DICOM:0000_0036 ilxtr:hasIlxId ilx:0382399 .
+
+DICOM:0000_0037 ilxtr:hasIlxId ilx:0381945 .
+
+DICOM:0000_0040 ilxtr:hasIlxId ilx:0381848 .
+
+DICOM:0000_0041 ilxtr:hasIlxId ilx:0383140 .
+
+DICOM:0000_0042 ilxtr:hasIlxId ilx:0382657 .
+
+DICOM:0000_0043 ilxtr:hasIlxId ilx:0382128 .
+
+DICOM:0000_0044 ilxtr:hasIlxId ilx:0382979 .
+
+DICOM:0000_0045 ilxtr:hasIlxId ilx:0382313 .
+
+DICOM:0000_0046 ilxtr:hasIlxId ilx:0382929 .
+
+DICOM:0000_0047 ilxtr:hasIlxId ilx:0382606 .
+
+DICOM:0000_0049 ilxtr:hasIlxId ilx:0381841 .
+
+DICOM:0000_0051 ilxtr:hasIlxId ilx:0381829 .
+
+DICOM:0000_0052 ilxtr:hasIlxId ilx:0381451 .
+
+DICOM:0000_0053 ilxtr:hasIlxId ilx:0382085 .
+
+DICOM:0000_0054 ilxtr:hasIlxId ilx:0383169 .
+
+DICOM:0000_0055 ilxtr:hasIlxId ilx:0381866 .
+
+DICOM:0000_0056 ilxtr:hasIlxId ilx:0382883 .
+
+DICOM:0000_0057 ilxtr:hasIlxId ilx:0381935 .
+
+DICOM:0000_0058 ilxtr:hasIlxId ilx:0382972 .
+
+DICOM:0000_0060 ilxtr:hasIlxId ilx:0382488 .
+
+DICOM:0000_0061 ilxtr:hasIlxId ilx:0382397 .
+
+DICOM:0000_0062 ilxtr:hasIlxId ilx:0381559 .
+
+DICOM:0000_0063 ilxtr:hasIlxId ilx:0381476 .
+
+DICOM:0000_0064 ilxtr:hasIlxId ilx:0383008 .
+
+DICOM:0000_0065 ilxtr:hasIlxId ilx:0382351 .
+
+DICOM:0000_0066 ilxtr:hasIlxId ilx:0383016 .
+
+DICOM:0000_0067 ilxtr:hasIlxId ilx:0382751 .
+
+DICOM:0000_0068 ilxtr:hasIlxId ilx:0382788 .
+
+DICOM:0000_0069 ilxtr:hasIlxId ilx:0382518 .
+
+DICOM:0000_070 ilxtr:hasIlxId ilx:0382091 .
+
+DICOM:0000_0071 ilxtr:hasIlxId ilx:0381767 .
+
+DICOM:0000_0072 ilxtr:hasIlxId ilx:0381551 .
+
+DICOM:0000_0073 ilxtr:hasIlxId ilx:0382975 .
+
+DICOM:0000_0074 ilxtr:hasIlxId ilx:0382335 .
+
+DICOM:0000_0075 ilxtr:hasIlxId ilx:0382326 .
+
+DICOM:0000_0076 ilxtr:hasIlxId ilx:0382425 .
+
+DICOM:0000_0077 ilxtr:hasIlxId ilx:0381913 .
+
+DICOM:0000_0078 ilxtr:hasIlxId ilx:0382170 .
+
+DICOM:0000_0079 ilxtr:hasIlxId ilx:0383146 .
+
+DICOM:0000_0080 ilxtr:hasIlxId ilx:0382047 .
+
+DICOM:0000_0081 ilxtr:hasIlxId ilx:0381496 .
+
+DICOM:0000_0082 ilxtr:hasIlxId ilx:0381579 .
+
+DICOM:0000_0083 ilxtr:hasIlxId ilx:0382463 .
+
+DICOM:0000_0084 ilxtr:hasIlxId ilx:0382274 .
+
+DICOM:0000_0085 ilxtr:hasIlxId ilx:0381883 .
+
+DICOM:0000_0086 ilxtr:hasIlxId ilx:0382413 .
+
+DICOM:0000_0087 ilxtr:hasIlxId ilx:0382982 .
+
+DICOM:003A_001A ilxtr:hasIlxId ilx:0110333 .
+
+DICOM:003A_0004 ilxtr:hasIlxId ilx:0112587 .
+
+DICOM:003A_0005 ilxtr:hasIlxId ilx:0107850 .
+
+DICOM:003A_0010 ilxtr:hasIlxId ilx:0107851 .
+
+DICOM:003A_0020 ilxtr:hasIlxId ilx:0107194 .
+
+DICOM:003A_020A ilxtr:hasIlxId ilx:0110810 .
+
+DICOM:003A_020C ilxtr:hasIlxId ilx:0102031 .
+
+DICOM:003A_021A ilxtr:hasIlxId ilx:0112584 .
+
+DICOM:003A_0200 ilxtr:hasIlxId ilx:0102030 .
+
+DICOM:003A_0202 ilxtr:hasIlxId ilx:0112585 .
+
+DICOM:003A_0203 ilxtr:hasIlxId ilx:0102033 .
+
+DICOM:003A_0205 ilxtr:hasIlxId ilx:0102051 .
+
+DICOM:003A_0208 ilxtr:hasIlxId ilx:0381786 .
+
+DICOM:003A_0209 ilxtr:hasIlxId ilx:0102050 .
+
+DICOM:003A_0210 ilxtr:hasIlxId ilx:0102040 .
+
+DICOM:003A_0211 ilxtr:hasIlxId ilx:0102042 .
+
+DICOM:003A_0212 ilxtr:hasIlxId ilx:0102041 .
+
+DICOM:003A_0213 ilxtr:hasIlxId ilx:0102029 .
+
+DICOM:003A_0214 ilxtr:hasIlxId ilx:0102052 .
+
+DICOM:003A_0215 ilxtr:hasIlxId ilx:0102039 .
+
+DICOM:003A_0218 ilxtr:hasIlxId ilx:0102038 .
+
+DICOM:003A_0220 ilxtr:hasIlxId ilx:0104234 .
+
+DICOM:003A_0221 ilxtr:hasIlxId ilx:0104233 .
+
+DICOM:003A_0222 ilxtr:hasIlxId ilx:0107695 .
+
+DICOM:003A_0223 ilxtr:hasIlxId ilx:0107694 .
+
+DICOM:003A_0230 ilxtr:hasIlxId ilx:0383147 .
+
+DICOM:003A_0231 ilxtr:hasIlxId ilx:0383139 .
+
+DICOM:003A_0240 ilxtr:hasIlxId ilx:0382361 .
+
+DICOM:003A_0241 ilxtr:hasIlxId ilx:0381948 .
+
+DICOM:003A_0242 ilxtr:hasIlxId ilx:0382381 .
+
+DICOM:003A_0244 ilxtr:hasIlxId ilx:0383130 .
+
+DICOM:003A_0245 ilxtr:hasIlxId ilx:0381794 .
+
+DICOM:003A_0246 ilxtr:hasIlxId ilx:0383101 .
+
+DICOM:003A_0247 ilxtr:hasIlxId ilx:0382024 .
+
+DICOM:003A_0248 ilxtr:hasIlxId ilx:0381756 .
+
+DICOM:003A_0300 ilxtr:hasIlxId ilx:0381635 .
+
+DICOM:003A_0301 ilxtr:hasIlxId ilx:0381662 .
+
+DICOM:003A_0302 ilxtr:hasIlxId ilx:0381792 .
+
+DICOM:0004_151A ilxtr:hasIlxId ilx:0383026 .
+
+DICOM:0004_1130 ilxtr:hasIlxId ilx:0381487 .
+
+DICOM:0004_1141 ilxtr:hasIlxId ilx:0382981 .
+
+DICOM:0004_1142 ilxtr:hasIlxId ilx:0382643 .
+
+DICOM:0004_1200 ilxtr:hasIlxId ilx:0381877 .
+
+DICOM:0004_1202 ilxtr:hasIlxId ilx:0381941 .
+
+DICOM:0004_1212 ilxtr:hasIlxId ilx:0382700 .
+
+DICOM:0004_1220 ilxtr:hasIlxId ilx:0381648 .
+
+DICOM:0004_1400 ilxtr:hasIlxId ilx:0382710 .
+
+DICOM:0004_1410 ilxtr:hasIlxId ilx:0381795 .
+
+DICOM:0004_1420 ilxtr:hasIlxId ilx:0382039 .
+
+DICOM:0004_1430 ilxtr:hasIlxId ilx:0382450 .
+
+DICOM:0004_1432 ilxtr:hasIlxId ilx:0381681 .
+
+DICOM:0004_1500 ilxtr:hasIlxId ilx:0381552 .
+
+DICOM:0004_1511 ilxtr:hasIlxId ilx:0382905 .
+
+DICOM:0004_1512 ilxtr:hasIlxId ilx:0382854 .
+
+DICOM:4FFE_0001 ilxtr:hasIlxId ilx:0382861 .
+
+DICOM:7FE0_0008 ilxtr:hasIlxId ilx:0381956 .
+
+DICOM:7FE0_0009 ilxtr:hasIlxId ilx:0382986 .
+
+DICOM:7FE0_0010 ilxtr:hasIlxId ilx:0108950 .
+
+DICOM:0008_001A ilxtr:hasIlxId ilx:0109889 .
+
+DICOM:0008_001B ilxtr:hasIlxId ilx:0382924 .
+
+DICOM:0008_002A ilxtr:hasIlxId ilx:0100257 .
+
+DICOM:0008_0005 ilxtr:hasIlxId ilx:0110852 .
+
+DICOM:0008_0006 ilxtr:hasIlxId ilx:0382364 .
+
+DICOM:0008_0008 ilxtr:hasIlxId ilx:0105255 .
+
+DICOM:0008_009C ilxtr:hasIlxId ilx:0381512 .
+
+DICOM:0008_009D ilxtr:hasIlxId ilx:0382271 .
+
+DICOM:0008_010B ilxtr:hasIlxId ilx:0381943 .
+
+DICOM:0008_010C ilxtr:hasIlxId ilx:0102335 .
+
+DICOM:0008_010D ilxtr:hasIlxId ilx:0382117 .
+
+DICOM:0008_010F ilxtr:hasIlxId ilx:0383060 .
+
+DICOM:0008_0012 ilxtr:hasIlxId ilx:0105506 .
+
+DICOM:0008_0013 ilxtr:hasIlxId ilx:0105507 .
+
+DICOM:0008_0014 ilxtr:hasIlxId ilx:0105508 .
+
+DICOM:0008_0015 ilxtr:hasIlxId ilx:0381548 .
+
+DICOM:0008_0016 ilxtr:hasIlxId ilx:0110764 .
+
+DICOM:0008_0018 ilxtr:hasIlxId ilx:0110767 .
+
+DICOM:0008_0020 ilxtr:hasIlxId ilx:0111138 .
+
+DICOM:0008_0021 ilxtr:hasIlxId ilx:0110542 .
+
+DICOM:0008_0022 ilxtr:hasIlxId ilx:0100256 .
+
+DICOM:0008_0023 ilxtr:hasIlxId ilx:0102506 .
+
+DICOM:0008_0024 ilxtr:hasIlxId ilx:0108295 .
+
+DICOM:0008_0030 ilxtr:hasIlxId ilx:0111145 .
+
+DICOM:0008_030A ilxtr:hasIlxId ilx:0381493 .
+
+DICOM:0008_030B ilxtr:hasIlxId ilx:0382682 .
+
+DICOM:0008_030C ilxtr:hasIlxId ilx:0382277 .
+
+DICOM:0008_030D ilxtr:hasIlxId ilx:0381860 .
+
+DICOM:0008_030E ilxtr:hasIlxId ilx:0382717 .
+
+DICOM:0008_030F ilxtr:hasIlxId ilx:0382092 .
+
+DICOM:0008_0031 ilxtr:hasIlxId ilx:0110547 .
+
+DICOM:0008_0032 ilxtr:hasIlxId ilx:0100266 .
+
+DICOM:0008_0033 ilxtr:hasIlxId ilx:0102513 .
+
+DICOM:0008_0034 ilxtr:hasIlxId ilx:0108303 .
+
+DICOM:0008_0051 ilxtr:hasIlxId ilx:0382501 .
+
+DICOM:0008_0053 ilxtr:hasIlxId ilx:0383046 .
+
+DICOM:0008_0054 ilxtr:hasIlxId ilx:0110059 .
+
+DICOM:0008_0055 ilxtr:hasIlxId ilx:0383048 .
+
+DICOM:0008_0056 ilxtr:hasIlxId ilx:0105505 .
+
+DICOM:0008_0058 ilxtr:hasIlxId ilx:0104082 .
+
+DICOM:0008_0060 ilxtr:hasIlxId ilx:0107045 .
+
+DICOM:0008_0061 ilxtr:hasIlxId ilx:0107044 .
+
+DICOM:0008_0064 ilxtr:hasIlxId ilx:0102546 .
+
+DICOM:0008_0068 ilxtr:hasIlxId ilx:0109240 .
+
+DICOM:0008_0070 ilxtr:hasIlxId ilx:0106513 .
+
+DICOM:0008_0080 ilxtr:hasIlxId ilx:0105513 .
+
+DICOM:0008_0081 ilxtr:hasIlxId ilx:0105511 .
+
+DICOM:0008_0082 ilxtr:hasIlxId ilx:0105512 .
+
+DICOM:0008_0090 ilxtr:hasIlxId ilx:0109808 .
+
+DICOM:0008_0092 ilxtr:hasIlxId ilx:0109807 .
+
+DICOM:0008_0094 ilxtr:hasIlxId ilx:0109809 .
+
+DICOM:0008_0096 ilxtr:hasIlxId ilx:0109806 .
+
+DICOM:0008_0100 ilxtr:hasIlxId ilx:0102328 .
+
+DICOM:0008_0102 ilxtr:hasIlxId ilx:0102330 .
+
+DICOM:0008_0103 ilxtr:hasIlxId ilx:0102336 .
+
+DICOM:0008_103E ilxtr:hasIlxId ilx:0110543 .
+
+DICOM:0008_103F ilxtr:hasIlxId ilx:0382516 .
+
+DICOM:0008_0104 ilxtr:hasIlxId ilx:0102325 .
+
+DICOM:0008_0105 ilxtr:hasIlxId ilx:0382628 .
+
+DICOM:0008_0106 ilxtr:hasIlxId ilx:0382243 .
+
+DICOM:0008_0107 ilxtr:hasIlxId ilx:0382921 .
+
+DICOM:0008_0110 ilxtr:hasIlxId ilx:0102332 .
+
+DICOM:0008_0112 ilxtr:hasIlxId ilx:0102334 .
+
+DICOM:0008_113A ilxtr:hasIlxId ilx:0109804 .
+
+DICOM:0008_0114 ilxtr:hasIlxId ilx:0102331 .
+
+DICOM:0008_114A ilxtr:hasIlxId ilx:0109768 .
+
+DICOM:0008_114B ilxtr:hasIlxId ilx:0381940 .
+
+DICOM:0008_0115 ilxtr:hasIlxId ilx:0102333 .
+
+DICOM:0008_115A ilxtr:hasIlxId ilx:0110765 .
+
+DICOM:0008_0116 ilxtr:hasIlxId ilx:0109973 .
+
+DICOM:0008_0118 ilxtr:hasIlxId ilx:0382707 .
+
+DICOM:0008_0119 ilxtr:hasIlxId ilx:0382098 .
+
+DICOM:0008_0120 ilxtr:hasIlxId ilx:0381644 .
+
+DICOM:0008_0121 ilxtr:hasIlxId ilx:0383106 .
+
+DICOM:0008_0122 ilxtr:hasIlxId ilx:0382442 .
+
+DICOM:0008_0123 ilxtr:hasIlxId ilx:0383107 .
+
+DICOM:0008_0124 ilxtr:hasIlxId ilx:0381730 .
+
+DICOM:0008_0201 ilxtr:hasIlxId ilx:0111761 .
+
+DICOM:0008_212A ilxtr:hasIlxId ilx:0107849 .
+
+DICOM:0008_0220 ilxtr:hasIlxId ilx:0382081 .
+
+DICOM:0008_0221 ilxtr:hasIlxId ilx:0381804 .
+
+DICOM:0008_0222 ilxtr:hasIlxId ilx:0382727 .
+
+DICOM:0008_0300 ilxtr:hasIlxId ilx:0381692 .
+
+DICOM:0008_0301 ilxtr:hasIlxId ilx:0382299 .
+
+DICOM:0008_0302 ilxtr:hasIlxId ilx:0381958 .
+
+DICOM:0008_0303 ilxtr:hasIlxId ilx:0382527 .
+
+DICOM:0008_0304 ilxtr:hasIlxId ilx:0382311 .
+
+DICOM:0008_0305 ilxtr:hasIlxId ilx:0382570 .
+
+DICOM:0008_0306 ilxtr:hasIlxId ilx:0382622 .
+
+DICOM:0008_0307 ilxtr:hasIlxId ilx:0382207 .
+
+DICOM:0008_0308 ilxtr:hasIlxId ilx:0381727 .
+
+DICOM:0008_0309 ilxtr:hasIlxId ilx:0381880 .
+
+DICOM:0008_0310 ilxtr:hasIlxId ilx:0381606 .
+
+DICOM:0008_1010 ilxtr:hasIlxId ilx:0111027 .
+
+DICOM:0008_1030 ilxtr:hasIlxId ilx:0111139 .
+
+DICOM:0008_1032 ilxtr:hasIlxId ilx:0109380 .
+
+DICOM:0008_1040 ilxtr:hasIlxId ilx:0381511 .
+
+DICOM:0008_1048 ilxtr:hasIlxId ilx:0108863 .
+
+DICOM:0008_1049 ilxtr:hasIlxId ilx:0108864 .
+
+DICOM:0008_1050 ilxtr:hasIlxId ilx:0108709 .
+
+DICOM:0008_1052 ilxtr:hasIlxId ilx:0108708 .
+
+DICOM:0008_1060 ilxtr:hasIlxId ilx:0107294 .
+
+DICOM:0008_1062 ilxtr:hasIlxId ilx:0108865 .
+
+DICOM:0008_1070 ilxtr:hasIlxId ilx:0108056 .
+
+DICOM:0008_1072 ilxtr:hasIlxId ilx:0108055 .
+
+DICOM:0008_1080 ilxtr:hasIlxId ilx:0100336 .
+
+DICOM:0008_1084 ilxtr:hasIlxId ilx:0100335 .
+
+DICOM:0008_1090 ilxtr:hasIlxId ilx:0106514 .
+
+DICOM:0008_1100 ilxtr:hasIlxId ilx:0109784 .
+
+DICOM:0008_1110 ilxtr:hasIlxId ilx:0109797 .
+
+DICOM:0008_1111 ilxtr:hasIlxId ilx:0109777 .
+
+DICOM:0008_1115 ilxtr:hasIlxId ilx:0109788 .
+
+DICOM:0008_1120 ilxtr:hasIlxId ilx:0109775 .
+
+DICOM:0008_1125 ilxtr:hasIlxId ilx:0109802 .
+
+DICOM:0008_1130 ilxtr:hasIlxId ilx:0109773 .
+
+DICOM:0008_1134 ilxtr:hasIlxId ilx:0382804 .
+
+DICOM:0008_1140 ilxtr:hasIlxId ilx:0109767 .
+
+DICOM:0008_1145 ilxtr:hasIlxId ilx:0109750 .
+
+DICOM:0008_1150 ilxtr:hasIlxId ilx:0109789 .
+
+DICOM:0008_1155 ilxtr:hasIlxId ilx:0109790 .
+
+DICOM:0008_1160 ilxtr:hasIlxId ilx:0109758 .
+
+DICOM:0008_1161 ilxtr:hasIlxId ilx:0382881 .
+
+DICOM:0008_1162 ilxtr:hasIlxId ilx:0381712 .
+
+DICOM:0008_1163 ilxtr:hasIlxId ilx:0381724 .
+
+DICOM:0008_1164 ilxtr:hasIlxId ilx:0381520 .
+
+DICOM:0008_1167 ilxtr:hasIlxId ilx:0381553 .
+
+DICOM:0008_1195 ilxtr:hasIlxId ilx:0111860 .
+
+DICOM:0008_1197 ilxtr:hasIlxId ilx:0104083 .
+
+DICOM:0008_1199 ilxtr:hasIlxId ilx:0109791 .
+
+DICOM:0008_1200 ilxtr:hasIlxId ilx:0111131 .
+
+DICOM:0008_1250 ilxtr:hasIlxId ilx:0109891 .
+
+DICOM:0008_2111 ilxtr:hasIlxId ilx:0103098 .
+
+DICOM:0008_2112 ilxtr:hasIlxId ilx:0110793 .
+
+DICOM:0008_2120 ilxtr:hasIlxId ilx:0111013 .
+
+DICOM:0008_2122 ilxtr:hasIlxId ilx:0111014 .
+
+DICOM:0008_2124 ilxtr:hasIlxId ilx:0107839 .
+
+DICOM:0008_2127 ilxtr:hasIlxId ilx:0112475 .
+
+DICOM:0008_2128 ilxtr:hasIlxId ilx:0112476 .
+
+DICOM:0008_2129 ilxtr:hasIlxId ilx:0107819 .
+
+DICOM:0008_2130 ilxtr:hasIlxId ilx:0103990 .
+
+DICOM:0008_2132 ilxtr:hasIlxId ilx:0103993 .
+
+DICOM:0008_2133 ilxtr:hasIlxId ilx:0381870 .
+
+DICOM:0008_2134 ilxtr:hasIlxId ilx:0381624 .
+
+DICOM:0008_2135 ilxtr:hasIlxId ilx:0382612 .
+
+DICOM:0008_2142 ilxtr:hasIlxId ilx:0381812 .
+
+DICOM:0008_2143 ilxtr:hasIlxId ilx:0382057 .
+
+DICOM:0008_2218 ilxtr:hasIlxId ilx:0100609 .
+
+DICOM:0008_2220 ilxtr:hasIlxId ilx:0100608 .
+
+DICOM:0008_2228 ilxtr:hasIlxId ilx:0109262 .
+
+DICOM:0008_2229 ilxtr:hasIlxId ilx:0100610 .
+
+DICOM:0008_2230 ilxtr:hasIlxId ilx:0109261 .
+
+DICOM:0008_2240 ilxtr:hasIlxId ilx:0111869 .
+
+DICOM:0008_2242 ilxtr:hasIlxId ilx:0111868 .
+
+DICOM:0008_2244 ilxtr:hasIlxId ilx:0111867 .
+
+DICOM:0008_2246 ilxtr:hasIlxId ilx:0111866 .
+
+DICOM:0008_3010 ilxtr:hasIlxId ilx:0382337 .
+
+DICOM:0008_3011 ilxtr:hasIlxId ilx:0381586 .
+
+DICOM:0008_3012 ilxtr:hasIlxId ilx:0381929 .
+
+DICOM:0008_9007 ilxtr:hasIlxId ilx:0104423 .
+
+DICOM:0008_9092 ilxtr:hasIlxId ilx:0109765 .
+
+DICOM:0008_9121 ilxtr:hasIlxId ilx:0109780 .
+
+DICOM:0008_9123 ilxtr:hasIlxId ilx:0102628 .
+
+DICOM:0008_9124 ilxtr:hasIlxId ilx:0382783 .
+
+DICOM:0008_9154 ilxtr:hasIlxId ilx:0110792 .
+
+DICOM:0008_9205 ilxtr:hasIlxId ilx:0383081 .
+
+DICOM:0008_9206 ilxtr:hasIlxId ilx:0112563 .
+
+DICOM:0008_9207 ilxtr:hasIlxId ilx:0112560 .
+
+DICOM:0008_9208 ilxtr:hasIlxId ilx:0102432 .
+
+DICOM:0008_9209 ilxtr:hasIlxId ilx:0100255 .
+
+DICOM:0008_9215 ilxtr:hasIlxId ilx:0103097 .
+
+DICOM:0008_9237 ilxtr:hasIlxId ilx:0109764 .
+
+DICOM:0008_9458 ilxtr:hasIlxId ilx:0381833 .
+
+DICOM:0008_9459 ilxtr:hasIlxId ilx:0382805 .
+
+DICOM:0008_9460 ilxtr:hasIlxId ilx:0382633 .
+
+DICOM:0010_0010 ilxtr:hasIlxId ilx:0108612 .
+
+DICOM:0010_0020 ilxtr:hasIlxId ilx:0108589 .
+
+DICOM:0010_0021 ilxtr:hasIlxId ilx:0105756 .
+
+DICOM:0010_21A0 ilxtr:hasIlxId ilx:0110695 .
+
+DICOM:0010_21B0 ilxtr:hasIlxId ilx:0100311 .
+
+DICOM:0010_21C0 ilxtr:hasIlxId ilx:0109211 .
+
+DICOM:0010_21D0 ilxtr:hasIlxId ilx:0106030 .
+
+DICOM:0010_21F0 ilxtr:hasIlxId ilx:0108615 .
+
+DICOM:0010_0022 ilxtr:hasIlxId ilx:0381600 .
+
+DICOM:0010_0024 ilxtr:hasIlxId ilx:0382124 .
+
+DICOM:0010_0026 ilxtr:hasIlxId ilx:0382394 .
+
+DICOM:0010_0027 ilxtr:hasIlxId ilx:0382332 .
+
+DICOM:0010_0028 ilxtr:hasIlxId ilx:0381897 .
+
+DICOM:0010_0030 ilxtr:hasIlxId ilx:0108606 .
+
+DICOM:0010_0032 ilxtr:hasIlxId ilx:0108608 .
+
+DICOM:0010_0033 ilxtr:hasIlxId ilx:0382163 .
+
+DICOM:0010_0034 ilxtr:hasIlxId ilx:0382416 .
+
+DICOM:0010_0035 ilxtr:hasIlxId ilx:0382257 .
+
+DICOM:0010_0040 ilxtr:hasIlxId ilx:0108616 .
+
+DICOM:0010_0050 ilxtr:hasIlxId ilx:0108610 .
+
+DICOM:0010_0101 ilxtr:hasIlxId ilx:0108614 .
+
+DICOM:0010_0102 ilxtr:hasIlxId ilx:0108613 .
+
+DICOM:0010_0200 ilxtr:hasIlxId ilx:0381893 .
+
+DICOM:0010_0212 ilxtr:hasIlxId ilx:0382014 .
+
+DICOM:0010_0213 ilxtr:hasIlxId ilx:0382283 .
+
+DICOM:0010_0214 ilxtr:hasIlxId ilx:0381602 .
+
+DICOM:0010_0215 ilxtr:hasIlxId ilx:0382736 .
+
+DICOM:0010_0216 ilxtr:hasIlxId ilx:0382837 .
+
+DICOM:0010_0217 ilxtr:hasIlxId ilx:0382148 .
+
+DICOM:0010_0218 ilxtr:hasIlxId ilx:0381930 .
+
+DICOM:0010_0219 ilxtr:hasIlxId ilx:0382565 .
+
+DICOM:0010_0221 ilxtr:hasIlxId ilx:0381835 .
+
+DICOM:0010_0222 ilxtr:hasIlxId ilx:0382444 .
+
+DICOM:0010_0223 ilxtr:hasIlxId ilx:0382648 .
+
+DICOM:0010_0229 ilxtr:hasIlxId ilx:0382343 .
+
+DICOM:0010_1000 ilxtr:hasIlxId ilx:0108277 .
+
+DICOM:0010_1001 ilxtr:hasIlxId ilx:0108278 .
+
+DICOM:0010_1002 ilxtr:hasIlxId ilx:0383087 .
+
+DICOM:0010_1005 ilxtr:hasIlxId ilx:0108607 .
+
+DICOM:0010_1010 ilxtr:hasIlxId ilx:0108605 .
+
+DICOM:0010_1020 ilxtr:hasIlxId ilx:0108617 .
+
+DICOM:0010_1021 ilxtr:hasIlxId ilx:0382339 .
+
+DICOM:0010_1022 ilxtr:hasIlxId ilx:0381748 .
+
+DICOM:0010_1023 ilxtr:hasIlxId ilx:0382814 .
+
+DICOM:0010_1024 ilxtr:hasIlxId ilx:0381473 .
+
+DICOM:0010_1030 ilxtr:hasIlxId ilx:0108619 .
+
+DICOM:0010_1040 ilxtr:hasIlxId ilx:0108604 .
+
+DICOM:0010_1060 ilxtr:hasIlxId ilx:0108611 .
+
+DICOM:0010_1080 ilxtr:hasIlxId ilx:0106978 .
+
+DICOM:0010_1081 ilxtr:hasIlxId ilx:0101445 .
+
+DICOM:0010_1090 ilxtr:hasIlxId ilx:0106720 .
+
+DICOM:0010_1100 ilxtr:hasIlxId ilx:0382455 .
+
+DICOM:0010_2000 ilxtr:hasIlxId ilx:0106719 .
+
+DICOM:0010_2110 ilxtr:hasIlxId ilx:0102532 .
+
+DICOM:0010_2150 ilxtr:hasIlxId ilx:0102601 .
+
+DICOM:0010_2152 ilxtr:hasIlxId ilx:0109827 .
+
+DICOM:0010_2154 ilxtr:hasIlxId ilx:0108618 .
+
+DICOM:0010_2160 ilxtr:hasIlxId ilx:0103954 .
+
+DICOM:0010_2180 ilxtr:hasIlxId ilx:0107886 .
+
+DICOM:0010_2201 ilxtr:hasIlxId ilx:0381845 .
+
+DICOM:0010_2202 ilxtr:hasIlxId ilx:0382212 .
+
+DICOM:0010_2203 ilxtr:hasIlxId ilx:0381964 .
+
+DICOM:0010_2210 ilxtr:hasIlxId ilx:0381914 .
+
+DICOM:0010_2292 ilxtr:hasIlxId ilx:0382184 .
+
+DICOM:0010_2293 ilxtr:hasIlxId ilx:0382165 .
+
+DICOM:0010_2294 ilxtr:hasIlxId ilx:0381465 .
+
+DICOM:0010_2295 ilxtr:hasIlxId ilx:0381814 .
+
+DICOM:0010_2296 ilxtr:hasIlxId ilx:0382142 .
+
+DICOM:0010_2297 ilxtr:hasIlxId ilx:0383132 .
+
+DICOM:0010_2298 ilxtr:hasIlxId ilx:0382440 .
+
+DICOM:0010_2299 ilxtr:hasIlxId ilx:0383178 .
+
+DICOM:0010_4000 ilxtr:hasIlxId ilx:0108585 .
+
+DICOM:0012_0010 ilxtr:hasIlxId ilx:0382049 .
+
+DICOM:0012_0020 ilxtr:hasIlxId ilx:0382492 .
+
+DICOM:0012_0021 ilxtr:hasIlxId ilx:0381711 .
+
+DICOM:0012_0030 ilxtr:hasIlxId ilx:0382895 .
+
+DICOM:0012_0031 ilxtr:hasIlxId ilx:0381978 .
+
+DICOM:0012_0040 ilxtr:hasIlxId ilx:0381751 .
+
+DICOM:0012_0042 ilxtr:hasIlxId ilx:0382160 .
+
+DICOM:0012_0050 ilxtr:hasIlxId ilx:0381907 .
+
+DICOM:0012_0051 ilxtr:hasIlxId ilx:0382151 .
+
+DICOM:0012_0060 ilxtr:hasIlxId ilx:0382132 .
+
+DICOM:0012_0062 ilxtr:hasIlxId ilx:0382245 .
+
+DICOM:0012_0063 ilxtr:hasIlxId ilx:0383134 .
+
+DICOM:0012_0064 ilxtr:hasIlxId ilx:0382365 .
+
+DICOM:0012_0071 ilxtr:hasIlxId ilx:0382297 .
+
+DICOM:0012_0072 ilxtr:hasIlxId ilx:0381657 .
+
+DICOM:0012_0081 ilxtr:hasIlxId ilx:0382089 .
+
+DICOM:0012_0082 ilxtr:hasIlxId ilx:0381896 .
+
+DICOM:0012_0083 ilxtr:hasIlxId ilx:0382153 .
+
+DICOM:0012_0084 ilxtr:hasIlxId ilx:0382910 .
+
+DICOM:0012_0085 ilxtr:hasIlxId ilx:0381980 .
+
+DICOM:0012_0086 ilxtr:hasIlxId ilx:0381583 .
+
+DICOM:0012_0087 ilxtr:hasIlxId ilx:0382477 .
+
+DICOM:0018_002A ilxtr:hasIlxId ilx:0382566 .
+
+DICOM:0018_003A ilxtr:hasIlxId ilx:0105631 .
+
+DICOM:0018_0010 ilxtr:hasIlxId ilx:0382888 .
+
+DICOM:0018_11A0 ilxtr:hasIlxId ilx:0101376 .
+
+DICOM:0018_11A2 ilxtr:hasIlxId ilx:0102442 .
+
+DICOM:0018_11A4 ilxtr:hasIlxId ilx:0382116 .
+
+DICOM:0018_0012 ilxtr:hasIlxId ilx:0381503 .
+
+DICOM:0018_0013 ilxtr:hasIlxId ilx:0382447 .
+
+DICOM:0018_0014 ilxtr:hasIlxId ilx:0381672 .
+
+DICOM:0018_0015 ilxtr:hasIlxId ilx:0101375 .
+
+DICOM:0018_0020 ilxtr:hasIlxId ilx:0110369 .
+
+DICOM:0018_0021 ilxtr:hasIlxId ilx:0110526 .
+
+DICOM:0018_0022 ilxtr:hasIlxId ilx:0383145 .
+
+DICOM:0018_0023 ilxtr:hasIlxId ilx:0107145 .
+
+DICOM:0018_0024 ilxtr:hasIlxId ilx:0110523 .
+
+DICOM:0018_0025 ilxtr:hasIlxId ilx:0100622 .
+
+DICOM:0018_0026 ilxtr:hasIlxId ilx:0105634 .
+
+DICOM:0018_0027 ilxtr:hasIlxId ilx:0105637 .
+
+DICOM:0018_0028 ilxtr:hasIlxId ilx:0105633 .
+
+DICOM:0018_0029 ilxtr:hasIlxId ilx:0105632 .
+
+DICOM:0018_0031 ilxtr:hasIlxId ilx:0109625 .
+
+DICOM:0018_0034 ilxtr:hasIlxId ilx:0105635 .
+
+DICOM:0018_0035 ilxtr:hasIlxId ilx:0105636 .
+
+DICOM:0018_0036 ilxtr:hasIlxId ilx:0105638 .
+
+DICOM:0018_0038 ilxtr:hasIlxId ilx:0105639 .
+
+DICOM:0018_0039 ilxtr:hasIlxId ilx:0111678 .
+
+DICOM:0018_0040 ilxtr:hasIlxId ilx:0382195 .
+
+DICOM:0018_0042 ilxtr:hasIlxId ilx:0382911 .
+
+DICOM:0018_0050 ilxtr:hasIlxId ilx:0110673 .
+
+DICOM:0018_0060 ilxtr:hasIlxId ilx:0105932 .
+
+DICOM:0018_0070 ilxtr:hasIlxId ilx:0102602 .
+
+DICOM:0018_0071 ilxtr:hasIlxId ilx:0100264 .
+
+DICOM:0018_0072 ilxtr:hasIlxId ilx:0382806 .
+
+DICOM:0018_0073 ilxtr:hasIlxId ilx:0100262 .
+
+DICOM:0018_0074 ilxtr:hasIlxId ilx:0100263 .
+
+DICOM:0018_0075 ilxtr:hasIlxId ilx:0383188 .
+
+DICOM:0018_0080 ilxtr:hasIlxId ilx:0109921 .
+
+DICOM:0018_0081 ilxtr:hasIlxId ilx:0103661 .
+
+DICOM:0018_0082 ilxtr:hasIlxId ilx:0105678 .
+
+DICOM:0018_0083 ilxtr:hasIlxId ilx:0107806 .
+
+DICOM:0018_0084 ilxtr:hasIlxId ilx:0105262 .
+
+DICOM:0018_0085 ilxtr:hasIlxId ilx:0105256 .
+
+DICOM:0018_0086 ilxtr:hasIlxId ilx:0103658 .
+
+DICOM:0018_0087 ilxtr:hasIlxId ilx:0106456 .
+
+DICOM:0018_0088 ilxtr:hasIlxId ilx:0110817 .
+
+DICOM:0018_0089 ilxtr:hasIlxId ilx:0107832 .
+
+DICOM:0018_0090 ilxtr:hasIlxId ilx:0382592 .
+
+DICOM:0018_0091 ilxtr:hasIlxId ilx:0103662 .
+
+DICOM:0018_0093 ilxtr:hasIlxId ilx:0108680 .
+
+DICOM:0018_0094 ilxtr:hasIlxId ilx:0108679 .
+
+DICOM:0018_0095 ilxtr:hasIlxId ilx:0108943 .
+
+DICOM:0018_100A ilxtr:hasIlxId ilx:0381510 .
+
+DICOM:0018_101A ilxtr:hasIlxId ilx:0104895 .
+
+DICOM:0018_101B ilxtr:hasIlxId ilx:0104893 .
+
+DICOM:0018_106A ilxtr:hasIlxId ilx:0111419 .
+
+DICOM:0018_106C ilxtr:hasIlxId ilx:0111417 .
+
+DICOM:0018_106E ilxtr:hasIlxId ilx:0111970 .
+
+DICOM:0018_113A ilxtr:hasIlxId ilx:0383183 .
+
+DICOM:0018_115A ilxtr:hasIlxId ilx:0109613 .
+
+DICOM:0018_115E ilxtr:hasIlxId ilx:0105229 .
+
+DICOM:0018_601A ilxtr:hasIlxId ilx:0109825 .
+
+DICOM:0018_601C ilxtr:hasIlxId ilx:0109822 .
+
+DICOM:0018_601E ilxtr:hasIlxId ilx:0109823 .
+
+DICOM:0018_602A ilxtr:hasIlxId ilx:0109733 .
+
+DICOM:0018_602C ilxtr:hasIlxId ilx:0108854 .
+
+DICOM:0018_602E ilxtr:hasIlxId ilx:0108855 .
+
+DICOM:0018_603B ilxtr:hasIlxId ilx:0103407 .
+
+DICOM:0018_603D ilxtr:hasIlxId ilx:0111782 .
+
+DICOM:0018_603F ilxtr:hasIlxId ilx:0111784 .
+
+DICOM:0018_604A ilxtr:hasIlxId ilx:0108949 .
+
+DICOM:0018_604C ilxtr:hasIlxId ilx:0108947 .
+
+DICOM:0018_604E ilxtr:hasIlxId ilx:0108944 .
+
+DICOM:0018_605A ilxtr:hasIlxId ilx:0111460 .
+
+DICOM:0018_700A ilxtr:hasIlxId ilx:0103145 .
+
+DICOM:0018_700C ilxtr:hasIlxId ilx:0102842 .
+
+DICOM:0018_700E ilxtr:hasIlxId ilx:0111751 .
+
+DICOM:0018_701A ilxtr:hasIlxId ilx:0103138 .
+
+DICOM:0018_702A ilxtr:hasIlxId ilx:0103148 .
+
+DICOM:0018_702B ilxtr:hasIlxId ilx:0103149 .
+
+DICOM:0018_704C ilxtr:hasIlxId ilx:0104788 .
+
+DICOM:0018_925A ilxtr:hasIlxId ilx:0382821 .
+
+DICOM:0018_925B ilxtr:hasIlxId ilx:0382435 .
+
+DICOM:0018_925C ilxtr:hasIlxId ilx:0381985 .
+
+DICOM:0018_925D ilxtr:hasIlxId ilx:0382358 .
+
+DICOM:0018_925E ilxtr:hasIlxId ilx:0381849 .
+
+DICOM:0018_925F ilxtr:hasIlxId ilx:0382000 .
+
+DICOM:0018_980C ilxtr:hasIlxId ilx:0382363 .
+
+DICOM:0018_980D ilxtr:hasIlxId ilx:0381895 .
+
+DICOM:0018_980E ilxtr:hasIlxId ilx:0383168 .
+
+DICOM:0018_980F ilxtr:hasIlxId ilx:0382260 .
+
+DICOM:0018_990A ilxtr:hasIlxId ilx:0381828 .
+
+DICOM:0018_990B ilxtr:hasIlxId ilx:0382899 .
+
+DICOM:0018_990C ilxtr:hasIlxId ilx:0382374 .
+
+DICOM:0018_990D ilxtr:hasIlxId ilx:0382968 .
+
+DICOM:0018_990E ilxtr:hasIlxId ilx:0382355 .
+
+DICOM:0018_990F ilxtr:hasIlxId ilx:0382464 .
+
+DICOM:0018_991A ilxtr:hasIlxId ilx:0382915 .
+
+DICOM:0018_991B ilxtr:hasIlxId ilx:0382403 .
+
+DICOM:0018_991C ilxtr:hasIlxId ilx:0382964 .
+
+DICOM:0018_991D ilxtr:hasIlxId ilx:0381654 .
+
+DICOM:0018_991E ilxtr:hasIlxId ilx:0382699 .
+
+DICOM:0018_991F ilxtr:hasIlxId ilx:0381921 .
+
+DICOM:0018_993A ilxtr:hasIlxId ilx:0381460 .
+
+DICOM:0018_993B ilxtr:hasIlxId ilx:0381763 .
+
+DICOM:0018_993C ilxtr:hasIlxId ilx:0381639 .
+
+DICOM:0018_993D ilxtr:hasIlxId ilx:0383151 .
+
+DICOM:0018_993E ilxtr:hasIlxId ilx:0382099 .
+
+DICOM:0018_1000 ilxtr:hasIlxId ilx:0103170 .
+
+DICOM:0018_1002 ilxtr:hasIlxId ilx:0382596 .
+
+DICOM:0018_1003 ilxtr:hasIlxId ilx:0382114 .
+
+DICOM:0018_1004 ilxtr:hasIlxId ilx:0381687 .
+
+DICOM:0018_1005 ilxtr:hasIlxId ilx:0381504 .
+
+DICOM:0018_1006 ilxtr:hasIlxId ilx:0382931 .
+
+DICOM:0018_1007 ilxtr:hasIlxId ilx:0383052 .
+
+DICOM:0018_1008 ilxtr:hasIlxId ilx:0382948 .
+
+DICOM:0018_1009 ilxtr:hasIlxId ilx:0382553 .
+
+DICOM:0018_1010 ilxtr:hasIlxId ilx:0110434 .
+
+DICOM:0018_1011 ilxtr:hasIlxId ilx:0104892 .
+
+DICOM:0018_1012 ilxtr:hasIlxId ilx:0102843 .
+
+DICOM:0018_1014 ilxtr:hasIlxId ilx:0111752 .
+
+DICOM:0018_1016 ilxtr:hasIlxId ilx:0110435 .
+
+DICOM:0018_1017 ilxtr:hasIlxId ilx:0104894 .
+
+DICOM:0018_1018 ilxtr:hasIlxId ilx:0110436 .
+
+DICOM:0018_1019 ilxtr:hasIlxId ilx:0110437 .
+
+DICOM:0018_1020 ilxtr:hasIlxId ilx:0110725 .
+
+DICOM:0018_1022 ilxtr:hasIlxId ilx:0112471 .
+
+DICOM:0018_1023 ilxtr:hasIlxId ilx:0103255 .
+
+DICOM:0018_1030 ilxtr:hasIlxId ilx:0109467 .
+
+DICOM:0018_1040 ilxtr:hasIlxId ilx:0381684 .
+
+DICOM:0018_1041 ilxtr:hasIlxId ilx:0382180 .
+
+DICOM:0018_1042 ilxtr:hasIlxId ilx:0381731 .
+
+DICOM:0018_1043 ilxtr:hasIlxId ilx:0382836 .
+
+DICOM:0018_1044 ilxtr:hasIlxId ilx:0382495 .
+
+DICOM:0018_1045 ilxtr:hasIlxId ilx:0111433 .
+
+DICOM:0018_1046 ilxtr:hasIlxId ilx:0381571 .
+
+DICOM:0018_1047 ilxtr:hasIlxId ilx:0381950 .
+
+DICOM:0018_1048 ilxtr:hasIlxId ilx:0382992 .
+
+DICOM:0018_1049 ilxtr:hasIlxId ilx:0382800 .
+
+DICOM:0018_1050 ilxtr:hasIlxId ilx:0110831 .
+
+DICOM:0018_1060 ilxtr:hasIlxId ilx:0111972 .
+
+DICOM:0018_1061 ilxtr:hasIlxId ilx:0111971 .
+
+DICOM:0018_1062 ilxtr:hasIlxId ilx:0107646 .
+
+DICOM:0018_1063 ilxtr:hasIlxId ilx:0382785 .
+
+DICOM:0018_1064 ilxtr:hasIlxId ilx:0104425 .
+
+DICOM:0018_1065 ilxtr:hasIlxId ilx:0382617 .
+
+DICOM:0018_1066 ilxtr:hasIlxId ilx:0383090 .
+
+DICOM:0018_1067 ilxtr:hasIlxId ilx:0382542 .
+
+DICOM:0018_1068 ilxtr:hasIlxId ilx:0107195 .
+
+DICOM:0018_1069 ilxtr:hasIlxId ilx:0111973 .
+
+DICOM:0018_1070 ilxtr:hasIlxId ilx:0109628 .
+
+DICOM:0018_1071 ilxtr:hasIlxId ilx:0109632 .
+
+DICOM:0018_1072 ilxtr:hasIlxId ilx:0109630 .
+
+DICOM:0018_1073 ilxtr:hasIlxId ilx:0109631 .
+
+DICOM:0018_1074 ilxtr:hasIlxId ilx:0109624 .
+
+DICOM:0018_1075 ilxtr:hasIlxId ilx:0109622 .
+
+DICOM:0018_1076 ilxtr:hasIlxId ilx:0109623 .
+
+DICOM:0018_1077 ilxtr:hasIlxId ilx:0109629 .
+
+DICOM:0018_1079 ilxtr:hasIlxId ilx:0382522 .
+
+DICOM:0018_1080 ilxtr:hasIlxId ilx:0101158 .
+
+DICOM:0018_1081 ilxtr:hasIlxId ilx:0382860 .
+
+DICOM:0018_1082 ilxtr:hasIlxId ilx:0382230 .
+
+DICOM:0018_1083 ilxtr:hasIlxId ilx:0382990 .
+
+DICOM:0018_1084 ilxtr:hasIlxId ilx:0381702 .
+
+DICOM:0018_1085 ilxtr:hasIlxId ilx:0109551 .
+
+DICOM:0018_1086 ilxtr:hasIlxId ilx:0110662 .
+
+DICOM:0018_1088 ilxtr:hasIlxId ilx:0104915 .
+
+DICOM:0018_1090 ilxtr:hasIlxId ilx:0101665 .
+
+DICOM:0018_1094 ilxtr:hasIlxId ilx:0111975 .
+
+DICOM:0018_1100 ilxtr:hasIlxId ilx:0109703 .
+
+DICOM:0018_1110 ilxtr:hasIlxId ilx:0103339 .
+
+DICOM:0018_1111 ilxtr:hasIlxId ilx:0382691 .
+
+DICOM:0018_1114 ilxtr:hasIlxId ilx:0103934 .
+
+DICOM:0018_1120 ilxtr:hasIlxId ilx:0382540 .
+
+DICOM:0018_1121 ilxtr:hasIlxId ilx:0382721 .
+
+DICOM:0018_1130 ilxtr:hasIlxId ilx:0382234 .
+
+DICOM:0018_1131 ilxtr:hasIlxId ilx:0111477 .
+
+DICOM:0018_1134 ilxtr:hasIlxId ilx:0111459 .
+
+DICOM:0018_1135 ilxtr:hasIlxId ilx:0111479 .
+
+DICOM:0018_1136 ilxtr:hasIlxId ilx:0111457 .
+
+DICOM:0018_1137 ilxtr:hasIlxId ilx:0111458 .
+
+DICOM:0018_1138 ilxtr:hasIlxId ilx:0111456 .
+
+DICOM:0018_1140 ilxtr:hasIlxId ilx:0383020 .
+
+DICOM:0018_1142 ilxtr:hasIlxId ilx:0109601 .
+
+DICOM:0018_1143 ilxtr:hasIlxId ilx:0110363 .
+
+DICOM:0018_1144 ilxtr:hasIlxId ilx:0100628 .
+
+DICOM:0018_1145 ilxtr:hasIlxId ilx:0101880 .
+
+DICOM:0018_1147 ilxtr:hasIlxId ilx:0104213 .
+
+DICOM:0018_1149 ilxtr:hasIlxId ilx:0104209 .
+
+DICOM:0018_1150 ilxtr:hasIlxId ilx:0104031 .
+
+DICOM:0018_1151 ilxtr:hasIlxId ilx:0382976 .
+
+DICOM:0018_1152 ilxtr:hasIlxId ilx:0381739 .
+
+DICOM:0018_1153 ilxtr:hasIlxId ilx:0382317 .
+
+DICOM:0018_1154 ilxtr:hasIlxId ilx:0101029 .
+
+DICOM:0018_1155 ilxtr:hasIlxId ilx:0109616 .
+
+DICOM:0018_1156 ilxtr:hasIlxId ilx:0109714 .
+
+DICOM:0018_1160 ilxtr:hasIlxId ilx:0104240 .
+
+DICOM:0018_1161 ilxtr:hasIlxId ilx:0112119 .
+
+DICOM:0018_1162 ilxtr:hasIlxId ilx:0105535 .
+
+DICOM:0018_1164 ilxtr:hasIlxId ilx:0381954 .
+
+DICOM:0018_1166 ilxtr:hasIlxId ilx:0104782 .
+
+DICOM:0018_1170 ilxtr:hasIlxId ilx:0382080 .
+
+DICOM:0018_1180 ilxtr:hasIlxId ilx:0382467 .
+
+DICOM:0018_1181 ilxtr:hasIlxId ilx:0102379 .
+
+DICOM:0018_1182 ilxtr:hasIlxId ilx:0104340 .
+
+DICOM:0018_1183 ilxtr:hasIlxId ilx:0112675 .
+
+DICOM:0018_1184 ilxtr:hasIlxId ilx:0112697 .
+
+DICOM:0018_1190 ilxtr:hasIlxId ilx:0382241 .
+
+DICOM:0018_1191 ilxtr:hasIlxId ilx:0100651 .
+
+DICOM:0018_1200 ilxtr:hasIlxId ilx:0102841 .
+
+DICOM:0018_1201 ilxtr:hasIlxId ilx:0111750 .
+
+DICOM:0018_1210 ilxtr:hasIlxId ilx:0381798 .
+
+DICOM:0018_1242 ilxtr:hasIlxId ilx:0381928 .
+
+DICOM:0018_1243 ilxtr:hasIlxId ilx:0102598 .
+
+DICOM:0018_1244 ilxtr:hasIlxId ilx:0382841 .
+
+DICOM:0018_1250 ilxtr:hasIlxId ilx:0109686 .
+
+DICOM:0018_1251 ilxtr:hasIlxId ilx:0111892 .
+
+DICOM:0018_1260 ilxtr:hasIlxId ilx:0383039 .
+
+DICOM:0018_1261 ilxtr:hasIlxId ilx:0382989 .
+
+DICOM:0018_1271 ilxtr:hasIlxId ilx:0382984 .
+
+DICOM:0018_1272 ilxtr:hasIlxId ilx:0381842 .
+
+DICOM:0018_1300 ilxtr:hasIlxId ilx:0110365 .
+
+DICOM:0018_1301 ilxtr:hasIlxId ilx:0112634 .
+
+DICOM:0018_1302 ilxtr:hasIlxId ilx:0110364 .
+
+DICOM:0018_1310 ilxtr:hasIlxId ilx:0100260 .
+
+DICOM:0018_1312 ilxtr:hasIlxId ilx:0105312 .
+
+DICOM:0018_1314 ilxtr:hasIlxId ilx:0104285 .
+
+DICOM:0018_1315 ilxtr:hasIlxId ilx:0112256 .
+
+DICOM:0018_1316 ilxtr:hasIlxId ilx:0110339 .
+
+DICOM:0018_1318 ilxtr:hasIlxId ilx:0381825 .
+
+DICOM:0018_1320 ilxtr:hasIlxId ilx:0381879 .
+
+DICOM:0018_1400 ilxtr:hasIlxId ilx:0381663 .
+
+DICOM:0018_1401 ilxtr:hasIlxId ilx:0382096 .
+
+DICOM:0018_1402 ilxtr:hasIlxId ilx:0383110 .
+
+DICOM:0018_1403 ilxtr:hasIlxId ilx:0382735 .
+
+DICOM:0018_1404 ilxtr:hasIlxId ilx:0382196 .
+
+DICOM:0018_1405 ilxtr:hasIlxId ilx:0382886 .
+
+DICOM:0018_1411 ilxtr:hasIlxId ilx:0382673 .
+
+DICOM:0018_1412 ilxtr:hasIlxId ilx:0382680 .
+
+DICOM:0018_1413 ilxtr:hasIlxId ilx:0382690 .
+
+DICOM:0018_1450 ilxtr:hasIlxId ilx:0102391 .
+
+DICOM:0018_1460 ilxtr:hasIlxId ilx:0111805 .
+
+DICOM:0018_1470 ilxtr:hasIlxId ilx:0111803 .
+
+DICOM:0018_1480 ilxtr:hasIlxId ilx:0111806 .
+
+DICOM:0018_1490 ilxtr:hasIlxId ilx:0111807 .
+
+DICOM:0018_1491 ilxtr:hasIlxId ilx:0111804 .
+
+DICOM:0018_1495 ilxtr:hasIlxId ilx:0107847 .
+
+DICOM:0018_1500 ilxtr:hasIlxId ilx:0109052 .
+
+DICOM:0018_1508 ilxtr:hasIlxId ilx:0109057 .
+
+DICOM:0018_1510 ilxtr:hasIlxId ilx:0109053 .
+
+DICOM:0018_1511 ilxtr:hasIlxId ilx:0109055 .
+
+DICOM:0018_1520 ilxtr:hasIlxId ilx:0109054 .
+
+DICOM:0018_1521 ilxtr:hasIlxId ilx:0109056 .
+
+DICOM:0018_1530 ilxtr:hasIlxId ilx:0103151 .
+
+DICOM:0018_1531 ilxtr:hasIlxId ilx:0103153 .
+
+DICOM:0018_1600 ilxtr:hasIlxId ilx:0382997 .
+
+DICOM:0018_1602 ilxtr:hasIlxId ilx:0382708 .
+
+DICOM:0018_1604 ilxtr:hasIlxId ilx:0382745 .
+
+DICOM:0018_1606 ilxtr:hasIlxId ilx:0382331 .
+
+DICOM:0018_1608 ilxtr:hasIlxId ilx:0382487 .
+
+DICOM:0018_1610 ilxtr:hasIlxId ilx:0383007 .
+
+DICOM:0018_1612 ilxtr:hasIlxId ilx:0383171 .
+
+DICOM:0018_1620 ilxtr:hasIlxId ilx:0382927 .
+
+DICOM:0018_1622 ilxtr:hasIlxId ilx:0383054 .
+
+DICOM:0018_1623 ilxtr:hasIlxId ilx:0382390 .
+
+DICOM:0018_1624 ilxtr:hasIlxId ilx:0381708 .
+
+DICOM:0018_1700 ilxtr:hasIlxId ilx:0102378 .
+
+DICOM:0018_1702 ilxtr:hasIlxId ilx:0102375 .
+
+DICOM:0018_1704 ilxtr:hasIlxId ilx:0102377 .
+
+DICOM:0018_1706 ilxtr:hasIlxId ilx:0102380 .
+
+DICOM:0018_1708 ilxtr:hasIlxId ilx:0102376 .
+
+DICOM:0018_1710 ilxtr:hasIlxId ilx:0101879 .
+
+DICOM:0018_1712 ilxtr:hasIlxId ilx:0109634 .
+
+DICOM:0018_1720 ilxtr:hasIlxId ilx:0112426 .
+
+DICOM:0018_1800 ilxtr:hasIlxId ilx:0100267 .
+
+DICOM:0018_1801 ilxtr:hasIlxId ilx:0111758 .
+
+DICOM:0018_1802 ilxtr:hasIlxId ilx:0111747 .
+
+DICOM:0018_1803 ilxtr:hasIlxId ilx:0107709 .
+
+DICOM:0018_2001 ilxtr:hasIlxId ilx:0108360 .
+
+DICOM:0018_2002 ilxtr:hasIlxId ilx:0104409 .
+
+DICOM:0018_2003 ilxtr:hasIlxId ilx:0104419 .
+
+DICOM:0018_2004 ilxtr:hasIlxId ilx:0104422 .
+
+DICOM:0018_2005 ilxtr:hasIlxId ilx:0110669 .
+
+DICOM:0018_2006 ilxtr:hasIlxId ilx:0103325 .
+
+DICOM:0018_2010 ilxtr:hasIlxId ilx:0107648 .
+
+DICOM:0018_2020 ilxtr:hasIlxId ilx:0103258 .
+
+DICOM:0018_2030 ilxtr:hasIlxId ilx:0110232 .
+
+DICOM:0018_2041 ilxtr:hasIlxId ilx:0382930 .
+
+DICOM:0018_2042 ilxtr:hasIlxId ilx:0382055 .
+
+DICOM:0018_2043 ilxtr:hasIlxId ilx:0382276 .
+
+DICOM:0018_2044 ilxtr:hasIlxId ilx:0382064 .
+
+DICOM:0018_2045 ilxtr:hasIlxId ilx:0381876 .
+
+DICOM:0018_2046 ilxtr:hasIlxId ilx:0382287 .
+
+DICOM:0018_3100 ilxtr:hasIlxId ilx:0105764 .
+
+DICOM:0018_3101 ilxtr:hasIlxId ilx:0105766 .
+
+DICOM:0018_3102 ilxtr:hasIlxId ilx:0105765 .
+
+DICOM:0018_3103 ilxtr:hasIlxId ilx:0105767 .
+
+DICOM:0018_3104 ilxtr:hasIlxId ilx:0105768 .
+
+DICOM:0018_3105 ilxtr:hasIlxId ilx:0106186 .
+
+DICOM:0018_5000 ilxtr:hasIlxId ilx:0108286 .
+
+DICOM:0018_5010 ilxtr:hasIlxId ilx:0111865 .
+
+DICOM:0018_5012 ilxtr:hasIlxId ilx:0104341 .
+
+DICOM:0018_5020 ilxtr:hasIlxId ilx:0109386 .
+
+DICOM:0018_5022 ilxtr:hasIlxId ilx:0106604 .
+
+DICOM:0018_5024 ilxtr:hasIlxId ilx:0101388 .
+
+DICOM:0018_5026 ilxtr:hasIlxId ilx:0102611 .
+
+DICOM:0018_5027 ilxtr:hasIlxId ilx:0110715 .
+
+DICOM:0018_5028 ilxtr:hasIlxId ilx:0110716 .
+
+DICOM:0018_5029 ilxtr:hasIlxId ilx:0110717 .
+
+DICOM:0018_5050 ilxtr:hasIlxId ilx:0103096 .
+
+DICOM:0018_5100 ilxtr:hasIlxId ilx:0108593 .
+
+DICOM:0018_5101 ilxtr:hasIlxId ilx:0381963 .
+
+DICOM:0018_5104 ilxtr:hasIlxId ilx:0109410 .
+
+DICOM:0018_5210 ilxtr:hasIlxId ilx:0105253 .
+
+DICOM:0018_5212 ilxtr:hasIlxId ilx:0105254 .
+
+DICOM:0018_6000 ilxtr:hasIlxId ilx:0383028 .
+
+DICOM:0018_6011 ilxtr:hasIlxId ilx:0110524 .
+
+DICOM:0018_6012 ilxtr:hasIlxId ilx:0109828 .
+
+DICOM:0018_6014 ilxtr:hasIlxId ilx:0109820 .
+
+DICOM:0018_6016 ilxtr:hasIlxId ilx:0109821 .
+
+DICOM:0018_6018 ilxtr:hasIlxId ilx:0109824 .
+
+DICOM:0018_6020 ilxtr:hasIlxId ilx:0109734 .
+
+DICOM:0018_6022 ilxtr:hasIlxId ilx:0109735 .
+
+DICOM:0018_6024 ilxtr:hasIlxId ilx:0108860 .
+
+DICOM:0018_6026 ilxtr:hasIlxId ilx:0108861 .
+
+DICOM:0018_6028 ilxtr:hasIlxId ilx:0109732 .
+
+DICOM:0018_6030 ilxtr:hasIlxId ilx:0111858 .
+
+DICOM:0018_6031 ilxtr:hasIlxId ilx:0111870 .
+
+DICOM:0018_6032 ilxtr:hasIlxId ilx:0109513 .
+
+DICOM:0018_6034 ilxtr:hasIlxId ilx:0103405 .
+
+DICOM:0018_6036 ilxtr:hasIlxId ilx:0111035 .
+
+DICOM:0018_6039 ilxtr:hasIlxId ilx:0103406 .
+
+DICOM:0018_6041 ilxtr:hasIlxId ilx:0111783 .
+
+DICOM:0018_6043 ilxtr:hasIlxId ilx:0111785 .
+
+DICOM:0018_6044 ilxtr:hasIlxId ilx:0108946 .
+
+DICOM:0018_6046 ilxtr:hasIlxId ilx:0108945 .
+
+DICOM:0018_6048 ilxtr:hasIlxId ilx:0108948 .
+
+DICOM:0018_6050 ilxtr:hasIlxId ilx:0107842 .
+
+DICOM:0018_6052 ilxtr:hasIlxId ilx:0111462 .
+
+DICOM:0018_6054 ilxtr:hasIlxId ilx:0111463 .
+
+DICOM:0018_6056 ilxtr:hasIlxId ilx:0107843 .
+
+DICOM:0018_6058 ilxtr:hasIlxId ilx:0111461 .
+
+DICOM:0018_6060 ilxtr:hasIlxId ilx:0109589 .
+
+DICOM:0018_7000 ilxtr:hasIlxId ilx:0103139 .
+
+DICOM:0018_7001 ilxtr:hasIlxId ilx:0103154 .
+
+DICOM:0018_7004 ilxtr:hasIlxId ilx:0103156 .
+
+DICOM:0018_7005 ilxtr:hasIlxId ilx:0103140 .
+
+DICOM:0018_7006 ilxtr:hasIlxId ilx:0103141 .
+
+DICOM:0018_7008 ilxtr:hasIlxId ilx:0103150 .
+
+DICOM:0018_7010 ilxtr:hasIlxId ilx:0104032 .
+
+DICOM:0018_7011 ilxtr:hasIlxId ilx:0104033 .
+
+DICOM:0018_7012 ilxtr:hasIlxId ilx:0103155 .
+
+DICOM:0018_7014 ilxtr:hasIlxId ilx:0103137 .
+
+DICOM:0018_7016 ilxtr:hasIlxId ilx:0103133 .
+
+DICOM:0018_7020 ilxtr:hasIlxId ilx:0103142 .
+
+DICOM:0018_7022 ilxtr:hasIlxId ilx:0103144 .
+
+DICOM:0018_7024 ilxtr:hasIlxId ilx:0103136 .
+
+DICOM:0018_7026 ilxtr:hasIlxId ilx:0103134 .
+
+DICOM:0018_7028 ilxtr:hasIlxId ilx:0103135 .
+
+DICOM:0018_7030 ilxtr:hasIlxId ilx:0104211 .
+
+DICOM:0018_7032 ilxtr:hasIlxId ilx:0104212 .
+
+DICOM:0018_7034 ilxtr:hasIlxId ilx:0104210 .
+
+DICOM:0018_7036 ilxtr:hasIlxId ilx:0382656 .
+
+DICOM:0018_7038 ilxtr:hasIlxId ilx:0383133 .
+
+DICOM:0018_7040 ilxtr:hasIlxId ilx:0104783 .
+
+DICOM:0018_7041 ilxtr:hasIlxId ilx:0104792 .
+
+DICOM:0018_7042 ilxtr:hasIlxId ilx:0104793 .
+
+DICOM:0018_7044 ilxtr:hasIlxId ilx:0104791 .
+
+DICOM:0018_7046 ilxtr:hasIlxId ilx:0104784 .
+
+DICOM:0018_7048 ilxtr:hasIlxId ilx:0104790 .
+
+DICOM:0018_7050 ilxtr:hasIlxId ilx:0104235 .
+
+DICOM:0018_7052 ilxtr:hasIlxId ilx:0104239 .
+
+DICOM:0018_7054 ilxtr:hasIlxId ilx:0383176 .
+
+DICOM:0018_7056 ilxtr:hasIlxId ilx:0381617 .
+
+DICOM:0018_7058 ilxtr:hasIlxId ilx:0381719 .
+
+DICOM:0018_7060 ilxtr:hasIlxId ilx:0104025 .
+
+DICOM:0018_7062 ilxtr:hasIlxId ilx:0104026 .
+
+DICOM:0018_7064 ilxtr:hasIlxId ilx:0104029 .
+
+DICOM:0018_7065 ilxtr:hasIlxId ilx:0108842 .
+
+DICOM:0018_8150 ilxtr:hasIlxId ilx:0383180 .
+
+DICOM:0018_8151 ilxtr:hasIlxId ilx:0112685 .
+
+DICOM:0018_9004 ilxtr:hasIlxId ilx:0102510 .
+
+DICOM:0018_9005 ilxtr:hasIlxId ilx:0109515 .
+
+DICOM:0018_9006 ilxtr:hasIlxId ilx:0107150 .
+
+DICOM:0018_9008 ilxtr:hasIlxId ilx:0103660 .
+
+DICOM:0018_9009 ilxtr:hasIlxId ilx:0105677 .
+
+DICOM:0018_9010 ilxtr:hasIlxId ilx:0104290 .
+
+DICOM:0018_9011 ilxtr:hasIlxId ilx:0107191 .
+
+DICOM:0018_9012 ilxtr:hasIlxId ilx:0107179 .
+
+DICOM:0018_9014 ilxtr:hasIlxId ilx:0108786 .
+
+DICOM:0018_9015 ilxtr:hasIlxId ilx:0111749 .
+
+DICOM:0018_9016 ilxtr:hasIlxId ilx:0110989 .
+
+DICOM:0018_9017 ilxtr:hasIlxId ilx:0111033 .
+
+DICOM:0018_9018 ilxtr:hasIlxId ilx:0103659 .
+
+DICOM:0018_9019 ilxtr:hasIlxId ilx:0111504 .
+
+DICOM:0018_9020 ilxtr:hasIlxId ilx:0106467 .
+
+DICOM:0018_9021 ilxtr:hasIlxId ilx:0111445 .
+
+DICOM:0018_9022 ilxtr:hasIlxId ilx:0101358 .
+
+DICOM:0018_9024 ilxtr:hasIlxId ilx:0110354 .
+
+DICOM:0018_9025 ilxtr:hasIlxId ilx:0110876 .
+
+DICOM:0018_9026 ilxtr:hasIlxId ilx:0110875 .
+
+DICOM:0018_9027 ilxtr:hasIlxId ilx:0110829 .
+
+DICOM:0018_9028 ilxtr:hasIlxId ilx:0111509 .
+
+DICOM:0018_9029 ilxtr:hasIlxId ilx:0108308 .
+
+DICOM:0018_9030 ilxtr:hasIlxId ilx:0111506 .
+
+DICOM:0018_9032 ilxtr:hasIlxId ilx:0104609 .
+
+DICOM:0018_9033 ilxtr:hasIlxId ilx:0110459 .
+
+DICOM:0018_9034 ilxtr:hasIlxId ilx:0109715 .
+
+DICOM:0018_9035 ilxtr:hasIlxId ilx:0111508 .
+
+DICOM:0018_9036 ilxtr:hasIlxId ilx:0108549 .
+
+DICOM:0018_9037 ilxtr:hasIlxId ilx:0382405 .
+
+DICOM:0018_9041 ilxtr:hasIlxId ilx:0109685 .
+
+DICOM:0018_9042 ilxtr:hasIlxId ilx:0107153 .
+
+DICOM:0018_9043 ilxtr:hasIlxId ilx:0383186 .
+
+DICOM:0018_9044 ilxtr:hasIlxId ilx:0109571 .
+
+DICOM:0018_9045 ilxtr:hasIlxId ilx:0107174 .
+
+DICOM:0018_9046 ilxtr:hasIlxId ilx:0107173 .
+
+DICOM:0018_9047 ilxtr:hasIlxId ilx:0107175 .
+
+DICOM:0018_9048 ilxtr:hasIlxId ilx:0107176 .
+
+DICOM:0018_9049 ilxtr:hasIlxId ilx:0107158 .
+
+DICOM:0018_9050 ilxtr:hasIlxId ilx:0111891 .
+
+DICOM:0018_9051 ilxtr:hasIlxId ilx:0111893 .
+
+DICOM:0018_9052 ilxtr:hasIlxId ilx:0110874 .
+
+DICOM:0018_9053 ilxtr:hasIlxId ilx:0102060 .
+
+DICOM:0018_9054 ilxtr:hasIlxId ilx:0112562 .
+
+DICOM:0018_9058 ilxtr:hasIlxId ilx:0107142 .
+
+DICOM:0018_9059 ilxtr:hasIlxId ilx:0102855 .
+
+DICOM:0018_9060 ilxtr:hasIlxId ilx:0102854 .
+
+DICOM:0018_9061 ilxtr:hasIlxId ilx:0102857 .
+
+DICOM:0018_9062 ilxtr:hasIlxId ilx:0102858 .
+
+DICOM:0018_9063 ilxtr:hasIlxId ilx:0102856 .
+
+DICOM:0018_9064 ilxtr:hasIlxId ilx:0105805 .
+
+DICOM:0018_9065 ilxtr:hasIlxId ilx:0111748 .
+
+DICOM:0018_9066 ilxtr:hasIlxId ilx:0107853 .
+
+DICOM:0018_9067 ilxtr:hasIlxId ilx:0101116 .
+
+DICOM:0018_9069 ilxtr:hasIlxId ilx:0108448 .
+
+DICOM:0018_9070 ilxtr:hasIlxId ilx:0382893 .
+
+DICOM:0018_9073 ilxtr:hasIlxId ilx:0100259 .
+
+DICOM:0018_9074 ilxtr:hasIlxId ilx:0104401 .
+
+DICOM:0018_9075 ilxtr:hasIlxId ilx:0103235 .
+
+DICOM:0018_9076 ilxtr:hasIlxId ilx:0103236 .
+
+DICOM:0018_9077 ilxtr:hasIlxId ilx:0108444 .
+
+DICOM:0018_9078 ilxtr:hasIlxId ilx:0108445 .
+
+DICOM:0018_9079 ilxtr:hasIlxId ilx:0105679 .
+
+DICOM:0018_9080 ilxtr:hasIlxId ilx:0106827 .
+
+DICOM:0018_9081 ilxtr:hasIlxId ilx:0108548 .
+
+DICOM:0018_9082 ilxtr:hasIlxId ilx:0103680 .
+
+DICOM:0018_9083 ilxtr:hasIlxId ilx:0106826 .
+
+DICOM:0018_9084 ilxtr:hasIlxId ilx:0102061 .
+
+DICOM:0018_9085 ilxtr:hasIlxId ilx:0382483 .
+
+DICOM:0018_9087 ilxtr:hasIlxId ilx:0103233 .
+
+DICOM:0018_9089 ilxtr:hasIlxId ilx:0103237 .
+
+DICOM:0018_9090 ilxtr:hasIlxId ilx:0112276 .
+
+DICOM:0018_9091 ilxtr:hasIlxId ilx:0112278 .
+
+DICOM:0018_9092 ilxtr:hasIlxId ilx:0382289 .
+
+DICOM:0018_9093 ilxtr:hasIlxId ilx:0107828 .
+
+DICOM:0018_9094 ilxtr:hasIlxId ilx:0102605 .
+
+DICOM:0018_9095 ilxtr:hasIlxId ilx:0110883 .
+
+DICOM:0018_9098 ilxtr:hasIlxId ilx:0111894 .
+
+DICOM:0018_9100 ilxtr:hasIlxId ilx:0109961 .
+
+DICOM:0018_9101 ilxtr:hasIlxId ilx:0104444 .
+
+DICOM:0018_9103 ilxtr:hasIlxId ilx:0382083 .
+
+DICOM:0018_9104 ilxtr:hasIlxId ilx:0110665 .
+
+DICOM:0018_9105 ilxtr:hasIlxId ilx:0110664 .
+
+DICOM:0018_9106 ilxtr:hasIlxId ilx:0106933 .
+
+DICOM:0018_9107 ilxtr:hasIlxId ilx:0107154 .
+
+DICOM:0018_9112 ilxtr:hasIlxId ilx:0107157 .
+
+DICOM:0018_9114 ilxtr:hasIlxId ilx:0107148 .
+
+DICOM:0018_9115 ilxtr:hasIlxId ilx:0107152 .
+
+DICOM:0018_9117 ilxtr:hasIlxId ilx:0107147 .
+
+DICOM:0018_9118 ilxtr:hasIlxId ilx:0382135 .
+
+DICOM:0018_9119 ilxtr:hasIlxId ilx:0107146 .
+
+DICOM:0018_9125 ilxtr:hasIlxId ilx:0381892 .
+
+DICOM:0018_9126 ilxtr:hasIlxId ilx:0112561 .
+
+DICOM:0018_9127 ilxtr:hasIlxId ilx:0110880 .
+
+DICOM:0018_9147 ilxtr:hasIlxId ilx:0103232 .
+
+DICOM:0018_9151 ilxtr:hasIlxId ilx:0104420 .
+
+DICOM:0018_9152 ilxtr:hasIlxId ilx:0107151 .
+
+DICOM:0018_9155 ilxtr:hasIlxId ilx:0108449 .
+
+DICOM:0018_9159 ilxtr:hasIlxId ilx:0110881 .
+
+DICOM:0018_9168 ilxtr:hasIlxId ilx:0108450 .
+
+DICOM:0018_9169 ilxtr:hasIlxId ilx:0382864 .
+
+DICOM:0018_9170 ilxtr:hasIlxId ilx:0109967 .
+
+DICOM:0018_9171 ilxtr:hasIlxId ilx:0109968 .
+
+DICOM:0018_9172 ilxtr:hasIlxId ilx:0382072 .
+
+DICOM:0018_9173 ilxtr:hasIlxId ilx:0382698 .
+
+DICOM:0018_9174 ilxtr:hasIlxId ilx:0382461 .
+
+DICOM:0018_9175 ilxtr:hasIlxId ilx:0100853 .
+
+DICOM:0018_9176 ilxtr:hasIlxId ilx:0108052 .
+
+DICOM:0018_9177 ilxtr:hasIlxId ilx:0108053 .
+
+DICOM:0018_9178 ilxtr:hasIlxId ilx:0108051 .
+
+DICOM:0018_9179 ilxtr:hasIlxId ilx:0110849 .
+
+DICOM:0018_9180 ilxtr:hasIlxId ilx:0104735 .
+
+DICOM:0018_9181 ilxtr:hasIlxId ilx:0110851 .
+
+DICOM:0018_9182 ilxtr:hasIlxId ilx:0104734 .
+
+DICOM:0018_9183 ilxtr:hasIlxId ilx:0104291 .
+
+DICOM:0018_9184 ilxtr:hasIlxId ilx:0111510 .
+
+DICOM:0018_9185 ilxtr:hasIlxId ilx:0382482 .
+
+DICOM:0018_9186 ilxtr:hasIlxId ilx:0382253 .
+
+DICOM:0018_9197 ilxtr:hasIlxId ilx:0107159 .
+
+DICOM:0018_9198 ilxtr:hasIlxId ilx:0104255 .
+
+DICOM:0018_9199 ilxtr:hasIlxId ilx:0112581 .
+
+DICOM:0018_9200 ilxtr:hasIlxId ilx:0107155 .
+
+DICOM:0018_9214 ilxtr:hasIlxId ilx:0109966 .
+
+DICOM:0018_9217 ilxtr:hasIlxId ilx:0112277 .
+
+DICOM:0018_9218 ilxtr:hasIlxId ilx:0111507 .
+
+DICOM:0018_9219 ilxtr:hasIlxId ilx:0111505 .
+
+DICOM:0018_9220 ilxtr:hasIlxId ilx:0104402 .
+
+DICOM:0018_9226 ilxtr:hasIlxId ilx:0107149 .
+
+DICOM:0018_9227 ilxtr:hasIlxId ilx:0107156 .
+
+DICOM:0018_9231 ilxtr:hasIlxId ilx:0107143 .
+
+DICOM:0018_9232 ilxtr:hasIlxId ilx:0107144 .
+
+DICOM:0018_9234 ilxtr:hasIlxId ilx:0110882 .
+
+DICOM:0018_9236 ilxtr:hasIlxId ilx:0101663 .
+
+DICOM:0018_9239 ilxtr:hasIlxId ilx:0110850 .
+
+DICOM:0018_9240 ilxtr:hasIlxId ilx:0383175 .
+
+DICOM:0018_9241 ilxtr:hasIlxId ilx:0104733 .
+
+DICOM:0018_9250 ilxtr:hasIlxId ilx:0381499 .
+
+DICOM:0018_9251 ilxtr:hasIlxId ilx:0382344 .
+
+DICOM:0018_9252 ilxtr:hasIlxId ilx:0382831 .
+
+DICOM:0018_9253 ilxtr:hasIlxId ilx:0381516 .
+
+DICOM:0018_9254 ilxtr:hasIlxId ilx:0382224 .
+
+DICOM:0018_9255 ilxtr:hasIlxId ilx:0382215 .
+
+DICOM:0018_9256 ilxtr:hasIlxId ilx:0381615 .
+
+DICOM:0018_9257 ilxtr:hasIlxId ilx:0383035 .
+
+DICOM:0018_9258 ilxtr:hasIlxId ilx:0382704 .
+
+DICOM:0018_9259 ilxtr:hasIlxId ilx:0383065 .
+
+DICOM:0018_9260 ilxtr:hasIlxId ilx:0382372 .
+
+DICOM:0018_9295 ilxtr:hasIlxId ilx:0382659 .
+
+DICOM:0018_9296 ilxtr:hasIlxId ilx:0382302 .
+
+DICOM:0018_9297 ilxtr:hasIlxId ilx:0382789 .
+
+DICOM:0018_9298 ilxtr:hasIlxId ilx:0382825 .
+
+DICOM:0018_9301 ilxtr:hasIlxId ilx:0382923 .
+
+DICOM:0018_9302 ilxtr:hasIlxId ilx:0381525 .
+
+DICOM:0018_9303 ilxtr:hasIlxId ilx:0381521 .
+
+DICOM:0018_9304 ilxtr:hasIlxId ilx:0382175 .
+
+DICOM:0018_9305 ilxtr:hasIlxId ilx:0382484 .
+
+DICOM:0018_9306 ilxtr:hasIlxId ilx:0383153 .
+
+DICOM:0018_9307 ilxtr:hasIlxId ilx:0382079 .
+
+DICOM:0018_9308 ilxtr:hasIlxId ilx:0381534 .
+
+DICOM:0018_9309 ilxtr:hasIlxId ilx:0381649 .
+
+DICOM:0018_9310 ilxtr:hasIlxId ilx:0381561 .
+
+DICOM:0018_9311 ilxtr:hasIlxId ilx:0381732 .
+
+DICOM:0018_9312 ilxtr:hasIlxId ilx:0383076 .
+
+DICOM:0018_9313 ilxtr:hasIlxId ilx:0382530 .
+
+DICOM:0018_9314 ilxtr:hasIlxId ilx:0381771 .
+
+DICOM:0018_9315 ilxtr:hasIlxId ilx:0382829 .
+
+DICOM:0018_9316 ilxtr:hasIlxId ilx:0383068 .
+
+DICOM:0018_9317 ilxtr:hasIlxId ilx:0381523 .
+
+DICOM:0018_9318 ilxtr:hasIlxId ilx:0381655 .
+
+DICOM:0018_9319 ilxtr:hasIlxId ilx:0382060 .
+
+DICOM:0018_9320 ilxtr:hasIlxId ilx:0382188 .
+
+DICOM:0018_9321 ilxtr:hasIlxId ilx:0382600 .
+
+DICOM:0018_9322 ilxtr:hasIlxId ilx:0382456 .
+
+DICOM:0018_9323 ilxtr:hasIlxId ilx:0382887 .
+
+DICOM:0018_9324 ilxtr:hasIlxId ilx:0382437 .
+
+DICOM:0018_9325 ilxtr:hasIlxId ilx:0382251 .
+
+DICOM:0018_9326 ilxtr:hasIlxId ilx:0383098 .
+
+DICOM:0018_9327 ilxtr:hasIlxId ilx:0383017 .
+
+DICOM:0018_9328 ilxtr:hasIlxId ilx:0383189 .
+
+DICOM:0018_9329 ilxtr:hasIlxId ilx:0381471 .
+
+DICOM:0018_9330 ilxtr:hasIlxId ilx:0381589 .
+
+DICOM:0018_9332 ilxtr:hasIlxId ilx:0381765 .
+
+DICOM:0018_9333 ilxtr:hasIlxId ilx:0382233 .
+
+DICOM:0018_9334 ilxtr:hasIlxId ilx:0382246 .
+
+DICOM:0018_9335 ilxtr:hasIlxId ilx:0383023 .
+
+DICOM:0018_9337 ilxtr:hasIlxId ilx:0381915 .
+
+DICOM:0018_9338 ilxtr:hasIlxId ilx:0383040 .
+
+DICOM:0018_9340 ilxtr:hasIlxId ilx:0102530 .
+
+DICOM:0018_9341 ilxtr:hasIlxId ilx:0382514 .
+
+DICOM:0018_9342 ilxtr:hasIlxId ilx:0382465 .
+
+DICOM:0018_9343 ilxtr:hasIlxId ilx:0382384 .
+
+DICOM:0018_9344 ilxtr:hasIlxId ilx:0381669 .
+
+DICOM:0018_9345 ilxtr:hasIlxId ilx:0381910 .
+
+DICOM:0018_9346 ilxtr:hasIlxId ilx:0382155 .
+
+DICOM:0018_9351 ilxtr:hasIlxId ilx:0383079 .
+
+DICOM:0018_9352 ilxtr:hasIlxId ilx:0382006 .
+
+DICOM:0018_9353 ilxtr:hasIlxId ilx:0381909 .
+
+DICOM:0018_9360 ilxtr:hasIlxId ilx:0382697 .
+
+DICOM:0018_9401 ilxtr:hasIlxId ilx:0383156 .
+
+DICOM:0018_9402 ilxtr:hasIlxId ilx:0382577 .
+
+DICOM:0018_9403 ilxtr:hasIlxId ilx:0382506 .
+
+DICOM:0018_9404 ilxtr:hasIlxId ilx:0381840 .
+
+DICOM:0018_9405 ilxtr:hasIlxId ilx:0382430 .
+
+DICOM:0018_9406 ilxtr:hasIlxId ilx:0381991 .
+
+DICOM:0018_9407 ilxtr:hasIlxId ilx:0381813 .
+
+DICOM:0018_9412 ilxtr:hasIlxId ilx:0381594 .
+
+DICOM:0018_9417 ilxtr:hasIlxId ilx:0383036 .
+
+DICOM:0018_9420 ilxtr:hasIlxId ilx:0381463 .
+
+DICOM:0018_9423 ilxtr:hasIlxId ilx:0381707 .
+
+DICOM:0018_9425 ilxtr:hasIlxId ilx:0382723 .
+
+DICOM:0018_9426 ilxtr:hasIlxId ilx:0381650 .
+
+DICOM:0018_9427 ilxtr:hasIlxId ilx:0382526 .
+
+DICOM:0018_9428 ilxtr:hasIlxId ilx:0382458 .
+
+DICOM:0018_9429 ilxtr:hasIlxId ilx:0382507 .
+
+DICOM:0018_9430 ilxtr:hasIlxId ilx:0382936 .
+
+DICOM:0018_9432 ilxtr:hasIlxId ilx:0381536 .
+
+DICOM:0018_9433 ilxtr:hasIlxId ilx:0381626 .
+
+DICOM:0018_9434 ilxtr:hasIlxId ilx:0383002 .
+
+DICOM:0018_9435 ilxtr:hasIlxId ilx:0382263 .
+
+DICOM:0018_9436 ilxtr:hasIlxId ilx:0382819 .
+
+DICOM:0018_9437 ilxtr:hasIlxId ilx:0382780 .
+
+DICOM:0018_9438 ilxtr:hasIlxId ilx:0381677 .
+
+DICOM:0018_9439 ilxtr:hasIlxId ilx:0382046 .
+
+DICOM:0018_9440 ilxtr:hasIlxId ilx:0382869 .
+
+DICOM:0018_9441 ilxtr:hasIlxId ilx:0383089 .
+
+DICOM:0018_9442 ilxtr:hasIlxId ilx:0382945 .
+
+DICOM:0018_9447 ilxtr:hasIlxId ilx:0382398 .
+
+DICOM:0018_9449 ilxtr:hasIlxId ilx:0382919 .
+
+DICOM:0018_9451 ilxtr:hasIlxId ilx:0382113 .
+
+DICOM:0018_9452 ilxtr:hasIlxId ilx:0382486 .
+
+DICOM:0018_9455 ilxtr:hasIlxId ilx:0381613 .
+
+DICOM:0018_9456 ilxtr:hasIlxId ilx:0382065 .
+
+DICOM:0018_9457 ilxtr:hasIlxId ilx:0382554 .
+
+DICOM:0018_9461 ilxtr:hasIlxId ilx:0382859 .
+
+DICOM:0018_9462 ilxtr:hasIlxId ilx:0382668 .
+
+DICOM:0018_9463 ilxtr:hasIlxId ilx:0382445 .
+
+DICOM:0018_9464 ilxtr:hasIlxId ilx:0382198 .
+
+DICOM:0018_9465 ilxtr:hasIlxId ilx:0383073 .
+
+DICOM:0018_9466 ilxtr:hasIlxId ilx:0382292 .
+
+DICOM:0018_9467 ilxtr:hasIlxId ilx:0382491 .
+
+DICOM:0018_9468 ilxtr:hasIlxId ilx:0382970 .
+
+DICOM:0018_9469 ilxtr:hasIlxId ilx:0381949 .
+
+DICOM:0018_9470 ilxtr:hasIlxId ilx:0383057 .
+
+DICOM:0018_9471 ilxtr:hasIlxId ilx:0382983 .
+
+DICOM:0018_9472 ilxtr:hasIlxId ilx:0382037 .
+
+DICOM:0018_9473 ilxtr:hasIlxId ilx:0382427 .
+
+DICOM:0018_9474 ilxtr:hasIlxId ilx:0383158 .
+
+DICOM:0018_9476 ilxtr:hasIlxId ilx:0381637 .
+
+DICOM:0018_9477 ilxtr:hasIlxId ilx:0383025 .
+
+DICOM:0018_9504 ilxtr:hasIlxId ilx:0382334 .
+
+DICOM:0018_9506 ilxtr:hasIlxId ilx:0381698 .
+
+DICOM:0018_9507 ilxtr:hasIlxId ilx:0383155 .
+
+DICOM:0018_9508 ilxtr:hasIlxId ilx:0382763 .
+
+DICOM:0018_9509 ilxtr:hasIlxId ilx:0383122 .
+
+DICOM:0018_9510 ilxtr:hasIlxId ilx:0383024 .
+
+DICOM:0018_9511 ilxtr:hasIlxId ilx:0381811 .
+
+DICOM:0018_9514 ilxtr:hasIlxId ilx:0382411 .
+
+DICOM:0018_9515 ilxtr:hasIlxId ilx:0382438 .
+
+DICOM:0018_9516 ilxtr:hasIlxId ilx:0382256 .
+
+DICOM:0018_9517 ilxtr:hasIlxId ilx:0382226 .
+
+DICOM:0018_9518 ilxtr:hasIlxId ilx:0382041 .
+
+DICOM:0018_9519 ilxtr:hasIlxId ilx:0382189 .
+
+DICOM:0018_9524 ilxtr:hasIlxId ilx:0382977 .
+
+DICOM:0018_9525 ilxtr:hasIlxId ilx:0382167 .
+
+DICOM:0018_9526 ilxtr:hasIlxId ilx:0381961 .
+
+DICOM:0018_9527 ilxtr:hasIlxId ilx:0382027 .
+
+DICOM:0018_9528 ilxtr:hasIlxId ilx:0381770 .
+
+DICOM:0018_9530 ilxtr:hasIlxId ilx:0382032 .
+
+DICOM:0018_9531 ilxtr:hasIlxId ilx:0381537 .
+
+DICOM:0018_9538 ilxtr:hasIlxId ilx:0382376 .
+
+DICOM:0018_9541 ilxtr:hasIlxId ilx:0381821 .
+
+DICOM:0018_9542 ilxtr:hasIlxId ilx:0382131 .
+
+DICOM:0018_9543 ilxtr:hasIlxId ilx:0382021 .
+
+DICOM:0018_9544 ilxtr:hasIlxId ilx:0381673 .
+
+DICOM:0018_9545 ilxtr:hasIlxId ilx:0381994 .
+
+DICOM:0018_9546 ilxtr:hasIlxId ilx:0381904 .
+
+DICOM:0018_9547 ilxtr:hasIlxId ilx:0382309 .
+
+DICOM:0018_9548 ilxtr:hasIlxId ilx:0382813 .
+
+DICOM:0018_9549 ilxtr:hasIlxId ilx:0382694 .
+
+DICOM:0018_9550 ilxtr:hasIlxId ilx:0382529 .
+
+DICOM:0018_9551 ilxtr:hasIlxId ilx:0382848 .
+
+DICOM:0018_9552 ilxtr:hasIlxId ilx:0381588 .
+
+DICOM:0018_9553 ilxtr:hasIlxId ilx:0382109 .
+
+DICOM:0018_9554 ilxtr:hasIlxId ilx:0382101 .
+
+DICOM:0018_9555 ilxtr:hasIlxId ilx:0381999 .
+
+DICOM:0018_9556 ilxtr:hasIlxId ilx:0381728 .
+
+DICOM:0018_9557 ilxtr:hasIlxId ilx:0382909 .
+
+DICOM:0018_9558 ilxtr:hasIlxId ilx:0381526 .
+
+DICOM:0018_9559 ilxtr:hasIlxId ilx:0382336 .
+
+DICOM:0018_9601 ilxtr:hasIlxId ilx:0382301 .
+
+DICOM:0018_9602 ilxtr:hasIlxId ilx:0382228 .
+
+DICOM:0018_9603 ilxtr:hasIlxId ilx:0382996 .
+
+DICOM:0018_9604 ilxtr:hasIlxId ilx:0382324 .
+
+DICOM:0018_9605 ilxtr:hasIlxId ilx:0382779 .
+
+DICOM:0018_9606 ilxtr:hasIlxId ilx:0382913 .
+
+DICOM:0018_9607 ilxtr:hasIlxId ilx:0382949 .
+
+DICOM:0018_9621 ilxtr:hasIlxId ilx:0382290 .
+
+DICOM:0018_9622 ilxtr:hasIlxId ilx:0382720 .
+
+DICOM:0018_9623 ilxtr:hasIlxId ilx:0381760 .
+
+DICOM:0018_9624 ilxtr:hasIlxId ilx:0381596 .
+
+DICOM:0018_9701 ilxtr:hasIlxId ilx:0381694 .
+
+DICOM:0018_9715 ilxtr:hasIlxId ilx:0381806 .
+
+DICOM:0018_9716 ilxtr:hasIlxId ilx:0381685 .
+
+DICOM:0018_9717 ilxtr:hasIlxId ilx:0381982 .
+
+DICOM:0018_9718 ilxtr:hasIlxId ilx:0381983 .
+
+DICOM:0018_9719 ilxtr:hasIlxId ilx:0382559 .
+
+DICOM:0018_9720 ilxtr:hasIlxId ilx:0382850 .
+
+DICOM:0018_9721 ilxtr:hasIlxId ilx:0382801 .
+
+DICOM:0018_9722 ilxtr:hasIlxId ilx:0382349 .
+
+DICOM:0018_9723 ilxtr:hasIlxId ilx:0382093 .
+
+DICOM:0018_9724 ilxtr:hasIlxId ilx:0382418 .
+
+DICOM:0018_9725 ilxtr:hasIlxId ilx:0381576 .
+
+DICOM:0018_9726 ilxtr:hasIlxId ilx:0381554 .
+
+DICOM:0018_9727 ilxtr:hasIlxId ilx:0382640 .
+
+DICOM:0018_9729 ilxtr:hasIlxId ilx:0382459 .
+
+DICOM:0018_9732 ilxtr:hasIlxId ilx:0381467 .
+
+DICOM:0018_9733 ilxtr:hasIlxId ilx:0382327 .
+
+DICOM:0018_9734 ilxtr:hasIlxId ilx:0382951 .
+
+DICOM:0018_9735 ilxtr:hasIlxId ilx:0382687 .
+
+DICOM:0018_9736 ilxtr:hasIlxId ilx:0382007 .
+
+DICOM:0018_9737 ilxtr:hasIlxId ilx:0382107 .
+
+DICOM:0018_9738 ilxtr:hasIlxId ilx:0382205 .
+
+DICOM:0018_9739 ilxtr:hasIlxId ilx:0382192 .
+
+DICOM:0018_9740 ilxtr:hasIlxId ilx:0381597 .
+
+DICOM:0018_9749 ilxtr:hasIlxId ilx:0382218 .
+
+DICOM:0018_9751 ilxtr:hasIlxId ilx:0382912 .
+
+DICOM:0018_9755 ilxtr:hasIlxId ilx:0382136 .
+
+DICOM:0018_9756 ilxtr:hasIlxId ilx:0381775 .
+
+DICOM:0018_9758 ilxtr:hasIlxId ilx:0382056 .
+
+DICOM:0018_9759 ilxtr:hasIlxId ilx:0381565 .
+
+DICOM:0018_9760 ilxtr:hasIlxId ilx:0383093 .
+
+DICOM:0018_9761 ilxtr:hasIlxId ilx:0381718 .
+
+DICOM:0018_9762 ilxtr:hasIlxId ilx:0381582 .
+
+DICOM:0018_9763 ilxtr:hasIlxId ilx:0382452 .
+
+DICOM:0018_9764 ilxtr:hasIlxId ilx:0382249 .
+
+DICOM:0018_9765 ilxtr:hasIlxId ilx:0381942 .
+
+DICOM:0018_9766 ilxtr:hasIlxId ilx:0381505 .
+
+DICOM:0018_9767 ilxtr:hasIlxId ilx:0383055 .
+
+DICOM:0018_9768 ilxtr:hasIlxId ilx:0382558 .
+
+DICOM:0018_9769 ilxtr:hasIlxId ilx:0382296 .
+
+DICOM:0018_9770 ilxtr:hasIlxId ilx:0381524 .
+
+DICOM:0018_9771 ilxtr:hasIlxId ilx:0382896 .
+
+DICOM:0018_9772 ilxtr:hasIlxId ilx:0382005 .
+
+DICOM:0018_9801 ilxtr:hasIlxId ilx:0382265 .
+
+DICOM:0018_9803 ilxtr:hasIlxId ilx:0382544 .
+
+DICOM:0018_9804 ilxtr:hasIlxId ilx:0382203 .
+
+DICOM:0018_9805 ilxtr:hasIlxId ilx:0383006 .
+
+DICOM:0018_9806 ilxtr:hasIlxId ilx:0381574 .
+
+DICOM:0018_9808 ilxtr:hasIlxId ilx:0382162 .
+
+DICOM:0018_9809 ilxtr:hasIlxId ilx:0381661 .
+
+DICOM:0018_9900 ilxtr:hasIlxId ilx:0382310 .
+
+DICOM:0018_9901 ilxtr:hasIlxId ilx:0382531 .
+
+DICOM:0018_9902 ilxtr:hasIlxId ilx:0382674 .
+
+DICOM:0018_9903 ilxtr:hasIlxId ilx:0382573 .
+
+DICOM:0018_9904 ilxtr:hasIlxId ilx:0381688 .
+
+DICOM:0018_9905 ilxtr:hasIlxId ilx:0382865 .
+
+DICOM:0018_9906 ilxtr:hasIlxId ilx:0382008 .
+
+DICOM:0018_9907 ilxtr:hasIlxId ilx:0382178 .
+
+DICOM:0018_9908 ilxtr:hasIlxId ilx:0381927 .
+
+DICOM:0018_9909 ilxtr:hasIlxId ilx:0383125 .
+
+DICOM:0018_9910 ilxtr:hasIlxId ilx:0381547 .
+
+DICOM:0018_9911 ilxtr:hasIlxId ilx:0381590 .
+
+DICOM:0018_9912 ilxtr:hasIlxId ilx:0381618 .
+
+DICOM:0018_9913 ilxtr:hasIlxId ilx:0382591 .
+
+DICOM:0018_9914 ilxtr:hasIlxId ilx:0383043 .
+
+DICOM:0018_9915 ilxtr:hasIlxId ilx:0382548 .
+
+DICOM:0018_9916 ilxtr:hasIlxId ilx:0382123 .
+
+DICOM:0018_9917 ilxtr:hasIlxId ilx:0381671 .
+
+DICOM:0018_9918 ilxtr:hasIlxId ilx:0382472 .
+
+DICOM:0018_9919 ilxtr:hasIlxId ilx:0382605 .
+
+DICOM:0018_9920 ilxtr:hasIlxId ilx:0381735 .
+
+DICOM:0018_9921 ilxtr:hasIlxId ilx:0381528 .
+
+DICOM:0018_9922 ilxtr:hasIlxId ilx:0382204 .
+
+DICOM:0018_9923 ilxtr:hasIlxId ilx:0382961 .
+
+DICOM:0018_9924 ilxtr:hasIlxId ilx:0382366 .
+
+DICOM:0018_9930 ilxtr:hasIlxId ilx:0381810 .
+
+DICOM:0018_9931 ilxtr:hasIlxId ilx:0381634 .
+
+DICOM:0018_9932 ilxtr:hasIlxId ilx:0383128 .
+
+DICOM:0018_9933 ilxtr:hasIlxId ilx:0383173 .
+
+DICOM:0018_9934 ilxtr:hasIlxId ilx:0382603 .
+
+DICOM:0018_9935 ilxtr:hasIlxId ilx:0381651 .
+
+DICOM:0018_9936 ilxtr:hasIlxId ilx:0381846 .
+
+DICOM:0018_9937 ilxtr:hasIlxId ilx:0381863 .
+
+DICOM:0018_9938 ilxtr:hasIlxId ilx:0382222 .
+
+DICOM:0018_9939 ilxtr:hasIlxId ilx:0383114 .
+
+DICOM:0018_9941 ilxtr:hasIlxId ilx:0381987 .
+
+DICOM:0018_9942 ilxtr:hasIlxId ilx:0382106 .
+
+DICOM:0018_9943 ilxtr:hasIlxId ilx:0381807 .
+
+DICOM:0018_9944 ilxtr:hasIlxId ilx:0382634 .
+
+DICOM:0018_9945 ilxtr:hasIlxId ilx:0382025 .
+
+DICOM:0018_9946 ilxtr:hasIlxId ilx:0381953 .
+
+DICOM:0018_9947 ilxtr:hasIlxId ilx:0382568 .
+
+DICOM:0018_A001 ilxtr:hasIlxId ilx:0102535 .
+
+DICOM:0018_A002 ilxtr:hasIlxId ilx:0102536 .
+
+DICOM:0018_A003 ilxtr:hasIlxId ilx:0102537 .
+
+DICOM:0020_000D ilxtr:hasIlxId ilx:0111142 .
+
+DICOM:0020_000E ilxtr:hasIlxId ilx:0110545 .
+
+DICOM:0020_0010 ilxtr:hasIlxId ilx:0111140 .
+
+DICOM:0020_0011 ilxtr:hasIlxId ilx:0110546 .
+
+DICOM:0020_0012 ilxtr:hasIlxId ilx:0100261 .
+
+DICOM:0020_0013 ilxtr:hasIlxId ilx:0105509 .
+
+DICOM:0020_0020 ilxtr:hasIlxId ilx:0108590 .
+
+DICOM:0020_0022 ilxtr:hasIlxId ilx:0108298 .
+
+DICOM:0020_0032 ilxtr:hasIlxId ilx:0105246 .
+
+DICOM:0020_0037 ilxtr:hasIlxId ilx:0105240 .
+
+DICOM:0020_0052 ilxtr:hasIlxId ilx:0104418 .
+
+DICOM:0020_0060 ilxtr:hasIlxId ilx:0106135 .
+
+DICOM:0020_0062 ilxtr:hasIlxId ilx:0105239 .
+
+DICOM:0020_0100 ilxtr:hasIlxId ilx:0111596 .
+
+DICOM:0020_103F ilxtr:hasIlxId ilx:0382409 .
+
+DICOM:0020_0105 ilxtr:hasIlxId ilx:0107844 .
+
+DICOM:0020_0110 ilxtr:hasIlxId ilx:0111600 .
+
+DICOM:0020_0200 ilxtr:hasIlxId ilx:0111418 .
+
+DICOM:0020_0242 ilxtr:hasIlxId ilx:0382497 .
+
+DICOM:0020_930D ilxtr:hasIlxId ilx:0382538 .
+
+DICOM:0020_930E ilxtr:hasIlxId ilx:0382877 .
+
+DICOM:0020_930F ilxtr:hasIlxId ilx:0382728 .
+
+DICOM:0020_1000 ilxtr:hasIlxId ilx:0110544 .
+
+DICOM:0020_1002 ilxtr:hasIlxId ilx:0105257 .
+
+DICOM:0020_1004 ilxtr:hasIlxId ilx:0100268 .
+
+DICOM:0020_1040 ilxtr:hasIlxId ilx:0109051 .
+
+DICOM:0020_1041 ilxtr:hasIlxId ilx:0110668 .
+
+DICOM:0020_1200 ilxtr:hasIlxId ilx:0107831 .
+
+DICOM:0020_1202 ilxtr:hasIlxId ilx:0107830 .
+
+DICOM:0020_1204 ilxtr:hasIlxId ilx:0107829 .
+
+DICOM:0020_1208 ilxtr:hasIlxId ilx:0107840 .
+
+DICOM:0020_1209 ilxtr:hasIlxId ilx:0107837 .
+
+DICOM:0020_4000 ilxtr:hasIlxId ilx:0105232 .
+
+DICOM:0020_9056 ilxtr:hasIlxId ilx:0111009 .
+
+DICOM:0020_9057 ilxtr:hasIlxId ilx:0105315 .
+
+DICOM:0020_9071 ilxtr:hasIlxId ilx:0104404 .
+
+DICOM:0020_9072 ilxtr:hasIlxId ilx:0104410 .
+
+DICOM:0020_9111 ilxtr:hasIlxId ilx:0104406 .
+
+DICOM:0020_9113 ilxtr:hasIlxId ilx:0108970 .
+
+DICOM:0020_9116 ilxtr:hasIlxId ilx:0108969 .
+
+DICOM:0020_9128 ilxtr:hasIlxId ilx:0111597 .
+
+DICOM:0020_9153 ilxtr:hasIlxId ilx:0381782 .
+
+DICOM:0020_9154 ilxtr:hasIlxId ilx:0382776 .
+
+DICOM:0020_9155 ilxtr:hasIlxId ilx:0381539 .
+
+DICOM:0020_9156 ilxtr:hasIlxId ilx:0104403 .
+
+DICOM:0020_9157 ilxtr:hasIlxId ilx:0103273 .
+
+DICOM:0020_9158 ilxtr:hasIlxId ilx:0104405 .
+
+DICOM:0020_9161 ilxtr:hasIlxId ilx:0102450 .
+
+DICOM:0020_9162 ilxtr:hasIlxId ilx:0105310 .
+
+DICOM:0020_9163 ilxtr:hasIlxId ilx:0105311 .
+
+DICOM:0020_9164 ilxtr:hasIlxId ilx:0103275 .
+
+DICOM:0020_9165 ilxtr:hasIlxId ilx:0103270 .
+
+DICOM:0020_9167 ilxtr:hasIlxId ilx:0104468 .
+
+DICOM:0020_9172 ilxtr:hasIlxId ilx:0381923 .
+
+DICOM:0020_9213 ilxtr:hasIlxId ilx:0103271 .
+
+DICOM:0020_9221 ilxtr:hasIlxId ilx:0103274 .
+
+DICOM:0020_9222 ilxtr:hasIlxId ilx:0103272 .
+
+DICOM:0020_9228 ilxtr:hasIlxId ilx:0102449 .
+
+DICOM:0020_9238 ilxtr:hasIlxId ilx:0104469 .
+
+DICOM:0020_9241 ilxtr:hasIlxId ilx:0382480 .
+
+DICOM:0020_9245 ilxtr:hasIlxId ilx:0381500 .
+
+DICOM:0020_9246 ilxtr:hasIlxId ilx:0381874 .
+
+DICOM:0020_9247 ilxtr:hasIlxId ilx:0381491 .
+
+DICOM:0020_9248 ilxtr:hasIlxId ilx:0382754 .
+
+DICOM:0020_9249 ilxtr:hasIlxId ilx:0383164 .
+
+DICOM:0020_9250 ilxtr:hasIlxId ilx:0382520 .
+
+DICOM:0020_9251 ilxtr:hasIlxId ilx:0382729 .
+
+DICOM:0020_9252 ilxtr:hasIlxId ilx:0382242 .
+
+DICOM:0020_9253 ilxtr:hasIlxId ilx:0382844 .
+
+DICOM:0020_9254 ilxtr:hasIlxId ilx:0381885 .
+
+DICOM:0020_9255 ilxtr:hasIlxId ilx:0381675 .
+
+DICOM:0020_9256 ilxtr:hasIlxId ilx:0382319 .
+
+DICOM:0020_9257 ilxtr:hasIlxId ilx:0382229 .
+
+DICOM:0020_9301 ilxtr:hasIlxId ilx:0381538 .
+
+DICOM:0020_9302 ilxtr:hasIlxId ilx:0381599 .
+
+DICOM:0020_9310 ilxtr:hasIlxId ilx:0381461 .
+
+DICOM:0020_9311 ilxtr:hasIlxId ilx:0382306 .
+
+DICOM:0020_9421 ilxtr:hasIlxId ilx:0383117 .
+
+DICOM:0020_9450 ilxtr:hasIlxId ilx:0381889 .
+
+DICOM:0020_9453 ilxtr:hasIlxId ilx:0382105 .
+
+DICOM:0020_9518 ilxtr:hasIlxId ilx:0381689 .
+
+DICOM:0020_9529 ilxtr:hasIlxId ilx:0381570 .
+
+DICOM:0020_9536 ilxtr:hasIlxId ilx:0381903 .
+
+DICOM:0022_000A ilxtr:hasIlxId ilx:0103759 .
+
+DICOM:0022_000B ilxtr:hasIlxId ilx:0105640 .
+
+DICOM:0022_000C ilxtr:hasIlxId ilx:0105106 .
+
+DICOM:0022_000D ilxtr:hasIlxId ilx:0109540 .
+
+DICOM:0022_000E ilxtr:hasIlxId ilx:0102985 .
+
+DICOM:0022_0001 ilxtr:hasIlxId ilx:0106243 .
+
+DICOM:0022_001A ilxtr:hasIlxId ilx:0102032 .
+
+DICOM:0022_001B ilxtr:hasIlxId ilx:0109817 .
+
+DICOM:0022_001C ilxtr:hasIlxId ilx:0107262 .
+
+DICOM:0022_001D ilxtr:hasIlxId ilx:0109902 .
+
+DICOM:0022_0002 ilxtr:hasIlxId ilx:0106242 .
+
+DICOM:0022_0003 ilxtr:hasIlxId ilx:0105243 .
+
+DICOM:0022_0004 ilxtr:hasIlxId ilx:0105242 .
+
+DICOM:0022_004E ilxtr:hasIlxId ilx:0382536 .
+
+DICOM:0022_0005 ilxtr:hasIlxId ilx:0108587 .
+
+DICOM:0022_0006 ilxtr:hasIlxId ilx:0108586 .
+
+DICOM:0022_0007 ilxtr:hasIlxId ilx:0110889 .
+
+DICOM:0022_0008 ilxtr:hasIlxId ilx:0102742 .
+
+DICOM:0022_0009 ilxtr:hasIlxId ilx:0102741 .
+
+DICOM:0022_0010 ilxtr:hasIlxId ilx:0111043 .
+
+DICOM:0022_0011 ilxtr:hasIlxId ilx:0111044 .
+
+DICOM:0022_0012 ilxtr:hasIlxId ilx:0111045 .
+
+DICOM:0022_0013 ilxtr:hasIlxId ilx:0111048 .
+
+DICOM:0022_0014 ilxtr:hasIlxId ilx:0111047 .
+
+DICOM:0022_0015 ilxtr:hasIlxId ilx:0100258 .
+
+DICOM:0022_0016 ilxtr:hasIlxId ilx:0105223 .
+
+DICOM:0022_0017 ilxtr:hasIlxId ilx:0106244 .
+
+DICOM:0022_0018 ilxtr:hasIlxId ilx:0105244 .
+
+DICOM:0022_0019 ilxtr:hasIlxId ilx:0106169 .
+
+DICOM:0022_0020 ilxtr:hasIlxId ilx:0111046 .
+
+DICOM:0022_0021 ilxtr:hasIlxId ilx:0106157 .
+
+DICOM:0022_0022 ilxtr:hasIlxId ilx:0110146 .
+
+DICOM:0022_0028 ilxtr:hasIlxId ilx:0381862 .
+
+DICOM:0022_0030 ilxtr:hasIlxId ilx:0381969 .
+
+DICOM:0022_0031 ilxtr:hasIlxId ilx:0382576 .
+
+DICOM:0022_0032 ilxtr:hasIlxId ilx:0382874 .
+
+DICOM:0022_0035 ilxtr:hasIlxId ilx:0382069 .
+
+DICOM:0022_0036 ilxtr:hasIlxId ilx:0382498 .
+
+DICOM:0022_0037 ilxtr:hasIlxId ilx:0382904 .
+
+DICOM:0022_0038 ilxtr:hasIlxId ilx:0382490 .
+
+DICOM:0022_0039 ilxtr:hasIlxId ilx:0382369 .
+
+DICOM:0022_0041 ilxtr:hasIlxId ilx:0381826 .
+
+DICOM:0022_0042 ilxtr:hasIlxId ilx:0381472 .
+
+DICOM:0022_0048 ilxtr:hasIlxId ilx:0382626 .
+
+DICOM:0022_0049 ilxtr:hasIlxId ilx:0381488 .
+
+DICOM:0022_0055 ilxtr:hasIlxId ilx:0383100 .
+
+DICOM:0022_0056 ilxtr:hasIlxId ilx:0383019 .
+
+DICOM:0022_0057 ilxtr:hasIlxId ilx:0381450 .
+
+DICOM:0022_0058 ilxtr:hasIlxId ilx:0381864 .
+
+DICOM:0022_1007 ilxtr:hasIlxId ilx:0382146 .
+
+DICOM:0022_1008 ilxtr:hasIlxId ilx:0381482 .
+
+DICOM:0022_1009 ilxtr:hasIlxId ilx:0382661 .
+
+DICOM:0022_1010 ilxtr:hasIlxId ilx:0382082 .
+
+DICOM:0022_1012 ilxtr:hasIlxId ilx:0383012 .
+
+DICOM:0022_1019 ilxtr:hasIlxId ilx:0382521 .
+
+DICOM:0022_1024 ilxtr:hasIlxId ilx:0383108 .
+
+DICOM:0022_1025 ilxtr:hasIlxId ilx:0383022 .
+
+DICOM:0022_1028 ilxtr:hasIlxId ilx:0383070 .
+
+DICOM:0022_1029 ilxtr:hasIlxId ilx:0382581 .
+
+DICOM:0022_1033 ilxtr:hasIlxId ilx:0382479 .
+
+DICOM:0022_1035 ilxtr:hasIlxId ilx:0382546 .
+
+DICOM:0022_1037 ilxtr:hasIlxId ilx:0382201 .
+
+DICOM:0022_1039 ilxtr:hasIlxId ilx:0382891 .
+
+DICOM:0022_1040 ilxtr:hasIlxId ilx:0382031 .
+
+DICOM:0022_1044 ilxtr:hasIlxId ilx:0382254 .
+
+DICOM:0022_1050 ilxtr:hasIlxId ilx:0382944 .
+
+DICOM:0022_1053 ilxtr:hasIlxId ilx:0381888 .
+
+DICOM:0022_1054 ilxtr:hasIlxId ilx:0382726 .
+
+DICOM:0022_1059 ilxtr:hasIlxId ilx:0382504 .
+
+DICOM:0022_1065 ilxtr:hasIlxId ilx:0381823 .
+
+DICOM:0022_1066 ilxtr:hasIlxId ilx:0381867 .
+
+DICOM:0022_1090 ilxtr:hasIlxId ilx:0383096 .
+
+DICOM:0022_1092 ilxtr:hasIlxId ilx:0382303 .
+
+DICOM:0022_1093 ilxtr:hasIlxId ilx:0382675 .
+
+DICOM:0022_1095 ilxtr:hasIlxId ilx:0381453 .
+
+DICOM:0022_1096 ilxtr:hasIlxId ilx:0381865 .
+
+DICOM:0022_1097 ilxtr:hasIlxId ilx:0382176 .
+
+DICOM:0022_1101 ilxtr:hasIlxId ilx:0382481 .
+
+DICOM:0022_1103 ilxtr:hasIlxId ilx:0381858 .
+
+DICOM:0022_1121 ilxtr:hasIlxId ilx:0383170 .
+
+DICOM:0022_1122 ilxtr:hasIlxId ilx:0382686 .
+
+DICOM:0022_1125 ilxtr:hasIlxId ilx:0382941 .
+
+DICOM:0022_1127 ilxtr:hasIlxId ilx:0382457 .
+
+DICOM:0022_1128 ilxtr:hasIlxId ilx:0382644 .
+
+DICOM:0022_1130 ilxtr:hasIlxId ilx:0382286 .
+
+DICOM:0022_1131 ilxtr:hasIlxId ilx:0382851 .
+
+DICOM:0022_1132 ilxtr:hasIlxId ilx:0381670 .
+
+DICOM:0022_1133 ilxtr:hasIlxId ilx:0382489 .
+
+DICOM:0022_1134 ilxtr:hasIlxId ilx:0382898 .
+
+DICOM:0022_1135 ilxtr:hasIlxId ilx:0381886 .
+
+DICOM:0022_1140 ilxtr:hasIlxId ilx:0383113 .
+
+DICOM:0022_1150 ilxtr:hasIlxId ilx:0381457 .
+
+DICOM:0022_1155 ilxtr:hasIlxId ilx:0381787 .
+
+DICOM:0022_1159 ilxtr:hasIlxId ilx:0382853 .
+
+DICOM:0022_1210 ilxtr:hasIlxId ilx:0381577 .
+
+DICOM:0022_1211 ilxtr:hasIlxId ilx:0382528 .
+
+DICOM:0022_1212 ilxtr:hasIlxId ilx:0382145 .
+
+DICOM:0022_1220 ilxtr:hasIlxId ilx:0381916 .
+
+DICOM:0022_1225 ilxtr:hasIlxId ilx:0381587 .
+
+DICOM:0022_1230 ilxtr:hasIlxId ilx:0383069 .
+
+DICOM:0022_1250 ilxtr:hasIlxId ilx:0381967 .
+
+DICOM:0022_1255 ilxtr:hasIlxId ilx:0381697 .
+
+DICOM:0022_1257 ilxtr:hasIlxId ilx:0382571 .
+
+DICOM:0022_1262 ilxtr:hasIlxId ilx:0381640 .
+
+DICOM:0022_1300 ilxtr:hasIlxId ilx:0383167 .
+
+DICOM:0022_1310 ilxtr:hasIlxId ilx:0382084 .
+
+DICOM:0022_1330 ilxtr:hasIlxId ilx:0382034 .
+
+DICOM:0022_1415 ilxtr:hasIlxId ilx:0382769 .
+
+DICOM:0022_1420 ilxtr:hasIlxId ilx:0382193 .
+
+DICOM:0022_1423 ilxtr:hasIlxId ilx:0381699 .
+
+DICOM:0022_1436 ilxtr:hasIlxId ilx:0382711 .
+
+DICOM:0022_1443 ilxtr:hasIlxId ilx:0381530 .
+
+DICOM:0022_1445 ilxtr:hasIlxId ilx:0382650 .
+
+DICOM:0022_1450 ilxtr:hasIlxId ilx:0382768 .
+
+DICOM:0022_1452 ilxtr:hasIlxId ilx:0382786 .
+
+DICOM:0022_1454 ilxtr:hasIlxId ilx:0381580 .
+
+DICOM:0022_1458 ilxtr:hasIlxId ilx:0381827 .
+
+DICOM:0022_1460 ilxtr:hasIlxId ilx:0382171 .
+
+DICOM:0022_1463 ilxtr:hasIlxId ilx:0381573 .
+
+DICOM:0022_1465 ilxtr:hasIlxId ilx:0382873 .
+
+DICOM:0022_1466 ilxtr:hasIlxId ilx:0382816 .
+
+DICOM:0022_1467 ilxtr:hasIlxId ilx:0382740 .
+
+DICOM:0022_1468 ilxtr:hasIlxId ilx:0382159 .
+
+DICOM:0022_1470 ilxtr:hasIlxId ilx:0381759 .
+
+DICOM:0022_1472 ilxtr:hasIlxId ilx:0382446 .
+
+DICOM:0022_1512 ilxtr:hasIlxId ilx:0381641 .
+
+DICOM:0022_1513 ilxtr:hasIlxId ilx:0383086 .
+
+DICOM:0022_1515 ilxtr:hasIlxId ilx:0382985 .
+
+DICOM:0022_1517 ilxtr:hasIlxId ilx:0382849 .
+
+DICOM:0022_1518 ilxtr:hasIlxId ilx:0381971 .
+
+DICOM:0022_1525 ilxtr:hasIlxId ilx:0383119 .
+
+DICOM:0022_1526 ilxtr:hasIlxId ilx:0381645 .
+
+DICOM:0022_1527 ilxtr:hasIlxId ilx:0381850 .
+
+DICOM:0022_1528 ilxtr:hasIlxId ilx:0381998 .
+
+DICOM:0022_1529 ilxtr:hasIlxId ilx:0382350 .
+
+DICOM:0022_1530 ilxtr:hasIlxId ilx:0382664 .
+
+DICOM:0024_0010 ilxtr:hasIlxId ilx:0381710 .
+
+DICOM:0024_0011 ilxtr:hasIlxId ilx:0381489 .
+
+DICOM:0024_0012 ilxtr:hasIlxId ilx:0382342 .
+
+DICOM:0024_0016 ilxtr:hasIlxId ilx:0382519 .
+
+DICOM:0024_0018 ilxtr:hasIlxId ilx:0381543 .
+
+DICOM:0024_0020 ilxtr:hasIlxId ilx:0382833 .
+
+DICOM:0024_0021 ilxtr:hasIlxId ilx:0381959 .
+
+DICOM:0024_0024 ilxtr:hasIlxId ilx:0382701 .
+
+DICOM:0024_0025 ilxtr:hasIlxId ilx:0383011 .
+
+DICOM:0024_0028 ilxtr:hasIlxId ilx:0382183 .
+
+DICOM:0024_0032 ilxtr:hasIlxId ilx:0382022 .
+
+DICOM:0024_0033 ilxtr:hasIlxId ilx:0382225 .
+
+DICOM:0024_0034 ilxtr:hasIlxId ilx:0381723 .
+
+DICOM:0024_0035 ilxtr:hasIlxId ilx:0382321 .
+
+DICOM:0024_0036 ilxtr:hasIlxId ilx:0382015 .
+
+DICOM:0024_0037 ilxtr:hasIlxId ilx:0381531 .
+
+DICOM:0024_0038 ilxtr:hasIlxId ilx:0382214 .
+
+DICOM:0024_0039 ilxtr:hasIlxId ilx:0381857 .
+
+DICOM:0024_0040 ilxtr:hasIlxId ilx:0382404 .
+
+DICOM:0024_0042 ilxtr:hasIlxId ilx:0381977 .
+
+DICOM:0024_0044 ilxtr:hasIlxId ilx:0382918 .
+
+DICOM:0024_0045 ilxtr:hasIlxId ilx:0382010 .
+
+DICOM:0024_0046 ilxtr:hasIlxId ilx:0382062 .
+
+DICOM:0024_0048 ilxtr:hasIlxId ilx:0381800 .
+
+DICOM:0024_0050 ilxtr:hasIlxId ilx:0381830 .
+
+DICOM:0024_0051 ilxtr:hasIlxId ilx:0381992 .
+
+DICOM:0024_0052 ilxtr:hasIlxId ilx:0381619 .
+
+DICOM:0024_0053 ilxtr:hasIlxId ilx:0382038 .
+
+DICOM:0024_0054 ilxtr:hasIlxId ilx:0382884 .
+
+DICOM:0024_0055 ilxtr:hasIlxId ilx:0382341 .
+
+DICOM:0024_0056 ilxtr:hasIlxId ilx:0382933 .
+
+DICOM:0024_0057 ilxtr:hasIlxId ilx:0381936 .
+
+DICOM:0024_0058 ilxtr:hasIlxId ilx:0383166 .
+
+DICOM:0024_0059 ilxtr:hasIlxId ilx:0381643 .
+
+DICOM:0024_0060 ilxtr:hasIlxId ilx:0382294 .
+
+DICOM:0024_0061 ilxtr:hasIlxId ilx:0382211 .
+
+DICOM:0024_0062 ilxtr:hasIlxId ilx:0381772 .
+
+DICOM:0024_0063 ilxtr:hasIlxId ilx:0383105 .
+
+DICOM:0024_0064 ilxtr:hasIlxId ilx:0382401 .
+
+DICOM:0024_0065 ilxtr:hasIlxId ilx:0381882 .
+
+DICOM:0024_0066 ilxtr:hasIlxId ilx:0382330 .
+
+DICOM:0024_0067 ilxtr:hasIlxId ilx:0382667 .
+
+DICOM:0024_0068 ilxtr:hasIlxId ilx:0382239 .
+
+DICOM:0024_0069 ilxtr:hasIlxId ilx:0382737 .
+
+DICOM:0024_0070 ilxtr:hasIlxId ilx:0381847 .
+
+DICOM:0024_0071 ilxtr:hasIlxId ilx:0382953 .
+
+DICOM:0024_0072 ilxtr:hasIlxId ilx:0382556 .
+
+DICOM:0024_0073 ilxtr:hasIlxId ilx:0382304 .
+
+DICOM:0024_0074 ilxtr:hasIlxId ilx:0383051 .
+
+DICOM:0024_0075 ilxtr:hasIlxId ilx:0381749 .
+
+DICOM:0024_0076 ilxtr:hasIlxId ilx:0381995 .
+
+DICOM:0024_0077 ilxtr:hasIlxId ilx:0382493 .
+
+DICOM:0024_0078 ilxtr:hasIlxId ilx:0381660 .
+
+DICOM:0024_0079 ilxtr:hasIlxId ilx:0381542 .
+
+DICOM:0024_0080 ilxtr:hasIlxId ilx:0382172 .
+
+DICOM:0024_0081 ilxtr:hasIlxId ilx:0381988 .
+
+DICOM:0024_0083 ilxtr:hasIlxId ilx:0382830 .
+
+DICOM:0024_0085 ilxtr:hasIlxId ilx:0382999 .
+
+DICOM:0024_0086 ilxtr:hasIlxId ilx:0382307 .
+
+DICOM:0024_0087 ilxtr:hasIlxId ilx:0381861 .
+
+DICOM:0024_0088 ilxtr:hasIlxId ilx:0382158 .
+
+DICOM:0024_0089 ilxtr:hasIlxId ilx:0382920 .
+
+DICOM:0024_0090 ilxtr:hasIlxId ilx:0381611 .
+
+DICOM:0024_0091 ilxtr:hasIlxId ilx:0381532 .
+
+DICOM:0024_0092 ilxtr:hasIlxId ilx:0381628 .
+
+DICOM:0024_0093 ilxtr:hasIlxId ilx:0381603 .
+
+DICOM:0024_0094 ilxtr:hasIlxId ilx:0381901 .
+
+DICOM:0024_0095 ilxtr:hasIlxId ilx:0382382 .
+
+DICOM:0024_0096 ilxtr:hasIlxId ilx:0382009 .
+
+DICOM:0024_0097 ilxtr:hasIlxId ilx:0382076 .
+
+DICOM:0024_0098 ilxtr:hasIlxId ilx:0381902 .
+
+DICOM:0024_0100 ilxtr:hasIlxId ilx:0382197 .
+
+DICOM:0024_0102 ilxtr:hasIlxId ilx:0381873 .
+
+DICOM:0024_0103 ilxtr:hasIlxId ilx:0382549 .
+
+DICOM:0024_0104 ilxtr:hasIlxId ilx:0382807 .
+
+DICOM:0024_0105 ilxtr:hasIlxId ilx:0381693 .
+
+DICOM:0024_0106 ilxtr:hasIlxId ilx:0382206 .
+
+DICOM:0024_0107 ilxtr:hasIlxId ilx:0381509 .
+
+DICOM:0024_0108 ilxtr:hasIlxId ilx:0381674 .
+
+DICOM:0024_0110 ilxtr:hasIlxId ilx:0382693 .
+
+DICOM:0024_0112 ilxtr:hasIlxId ilx:0382149 .
+
+DICOM:0024_0113 ilxtr:hasIlxId ilx:0381819 .
+
+DICOM:0024_0114 ilxtr:hasIlxId ilx:0382272 .
+
+DICOM:0024_0115 ilxtr:hasIlxId ilx:0382094 .
+
+DICOM:0024_0117 ilxtr:hasIlxId ilx:0382270 .
+
+DICOM:0024_0118 ilxtr:hasIlxId ilx:0382104 .
+
+DICOM:0024_0120 ilxtr:hasIlxId ilx:0382998 .
+
+DICOM:0024_0122 ilxtr:hasIlxId ilx:0382822 .
+
+DICOM:0024_0124 ilxtr:hasIlxId ilx:0382423 .
+
+DICOM:0024_0126 ilxtr:hasIlxId ilx:0383077 .
+
+DICOM:0024_0202 ilxtr:hasIlxId ilx:0383059 .
+
+DICOM:0024_0306 ilxtr:hasIlxId ilx:0382646 .
+
+DICOM:0024_0307 ilxtr:hasIlxId ilx:0381502 .
+
+DICOM:0024_0308 ilxtr:hasIlxId ilx:0382555 .
+
+DICOM:0024_0309 ilxtr:hasIlxId ilx:0383018 .
+
+DICOM:0024_0317 ilxtr:hasIlxId ilx:0382052 .
+
+DICOM:0024_0320 ilxtr:hasIlxId ilx:0381462 .
+
+DICOM:0024_0325 ilxtr:hasIlxId ilx:0382190 .
+
+DICOM:0024_0338 ilxtr:hasIlxId ilx:0381754 .
+
+DICOM:0024_0341 ilxtr:hasIlxId ilx:0382030 .
+
+DICOM:0024_0344 ilxtr:hasIlxId ilx:0382744 .
+
+DICOM:0028_000A ilxtr:hasIlxId ilx:0104407 .
+
+DICOM:0028_0A02 ilxtr:hasIlxId ilx:0381839 .
+
+DICOM:0028_0A04 ilxtr:hasIlxId ilx:0382389 .
+
+DICOM:0028_0002 ilxtr:hasIlxId ilx:0110331 .
+
+DICOM:0028_0003 ilxtr:hasIlxId ilx:0383177 .
+
+DICOM:0028_0004 ilxtr:hasIlxId ilx:0108836 .
+
+DICOM:0028_0006 ilxtr:hasIlxId ilx:0108965 .
+
+DICOM:0028_7FE0 ilxtr:hasIlxId ilx:0382053 .
+
+DICOM:0028_0008 ilxtr:hasIlxId ilx:0107823 .
+
+DICOM:0028_0009 ilxtr:hasIlxId ilx:0104408 .
+
+DICOM:0028_0010 ilxtr:hasIlxId ilx:0110238 .
+
+DICOM:0028_0011 ilxtr:hasIlxId ilx:0102393 .
+
+DICOM:0028_0014 ilxtr:hasIlxId ilx:0112151 .
+
+DICOM:0028_0030 ilxtr:hasIlxId ilx:0108956 .
+
+DICOM:0028_0031 ilxtr:hasIlxId ilx:0112751 .
+
+DICOM:0028_0032 ilxtr:hasIlxId ilx:0112750 .
+
+DICOM:0028_0034 ilxtr:hasIlxId ilx:0108942 .
+
+DICOM:0028_0051 ilxtr:hasIlxId ilx:0102564 .
+
+DICOM:0028_0100 ilxtr:hasIlxId ilx:0101321 .
+
+DICOM:0028_0101 ilxtr:hasIlxId ilx:0101322 .
+
+DICOM:0028_0102 ilxtr:hasIlxId ilx:0104992 .
+
+DICOM:0028_0103 ilxtr:hasIlxId ilx:0108955 .
+
+DICOM:0028_0106 ilxtr:hasIlxId ilx:0110690 .
+
+DICOM:0028_0107 ilxtr:hasIlxId ilx:0105995 .
+
+DICOM:0028_0108 ilxtr:hasIlxId ilx:0110691 .
+
+DICOM:0028_0109 ilxtr:hasIlxId ilx:0105997 .
+
+DICOM:0028_0120 ilxtr:hasIlxId ilx:0108954 .
+
+DICOM:0028_0121 ilxtr:hasIlxId ilx:0381722 .
+
+DICOM:0028_0122 ilxtr:hasIlxId ilx:0382823 .
+
+DICOM:0028_0123 ilxtr:hasIlxId ilx:0382126 .
+
+DICOM:0028_0124 ilxtr:hasIlxId ilx:0381695 .
+
+DICOM:0028_0125 ilxtr:hasIlxId ilx:0381875 .
+
+DICOM:0028_135A ilxtr:hasIlxId ilx:0381716 .
+
+DICOM:0028_140B ilxtr:hasIlxId ilx:0383061 .
+
+DICOM:0028_140C ilxtr:hasIlxId ilx:0382967 .
+
+DICOM:0028_140D ilxtr:hasIlxId ilx:0382799 .
+
+DICOM:0028_140E ilxtr:hasIlxId ilx:0382473 .
+
+DICOM:0028_140F ilxtr:hasIlxId ilx:0382407 .
+
+DICOM:0028_0300 ilxtr:hasIlxId ilx:0109575 .
+
+DICOM:0028_0301 ilxtr:hasIlxId ilx:0101500 .
+
+DICOM:0028_0302 ilxtr:hasIlxId ilx:0382377 .
+
+DICOM:0028_0303 ilxtr:hasIlxId ilx:0382154 .
+
+DICOM:0028_0304 ilxtr:hasIlxId ilx:0382665 .
+
+DICOM:0028_1040 ilxtr:hasIlxId ilx:0108951 .
+
+DICOM:0028_1041 ilxtr:hasIlxId ilx:0108952 .
+
+DICOM:0028_1050 ilxtr:hasIlxId ilx:0112646 .
+
+DICOM:0028_1051 ilxtr:hasIlxId ilx:0112648 .
+
+DICOM:0028_1052 ilxtr:hasIlxId ilx:0109949 .
+
+DICOM:0028_1053 ilxtr:hasIlxId ilx:0109950 .
+
+DICOM:0028_1054 ilxtr:hasIlxId ilx:0109951 .
+
+DICOM:0028_1055 ilxtr:hasIlxId ilx:0112647 .
+
+DICOM:0028_1056 ilxtr:hasIlxId ilx:0382809 .
+
+DICOM:0028_1090 ilxtr:hasIlxId ilx:0109699 .
+
+DICOM:0028_1101 ilxtr:hasIlxId ilx:0109725 .
+
+DICOM:0028_1102 ilxtr:hasIlxId ilx:0104778 .
+
+DICOM:0028_1103 ilxtr:hasIlxId ilx:0101366 .
+
+DICOM:0028_1104 ilxtr:hasIlxId ilx:0382608 .
+
+DICOM:0028_1199 ilxtr:hasIlxId ilx:0108374 .
+
+DICOM:0028_1201 ilxtr:hasIlxId ilx:0109724 .
+
+DICOM:0028_1202 ilxtr:hasIlxId ilx:0104777 .
+
+DICOM:0028_1203 ilxtr:hasIlxId ilx:0101365 .
+
+DICOM:0028_1204 ilxtr:hasIlxId ilx:0381646 .
+
+DICOM:0028_1221 ilxtr:hasIlxId ilx:0110460 .
+
+DICOM:0028_1222 ilxtr:hasIlxId ilx:0110458 .
+
+DICOM:0028_1223 ilxtr:hasIlxId ilx:0110457 .
+
+DICOM:0028_1224 ilxtr:hasIlxId ilx:0381506 .
+
+DICOM:0028_1300 ilxtr:hasIlxId ilx:0105302 .
+
+DICOM:0028_1350 ilxtr:hasIlxId ilx:0108551 .
+
+DICOM:0028_1351 ilxtr:hasIlxId ilx:0108552 .
+
+DICOM:0028_1352 ilxtr:hasIlxId ilx:0381933 .
+
+DICOM:0028_1401 ilxtr:hasIlxId ilx:0382762 .
+
+DICOM:0028_1402 ilxtr:hasIlxId ilx:0381498 .
+
+DICOM:0028_1403 ilxtr:hasIlxId ilx:0382429 .
+
+DICOM:0028_1404 ilxtr:hasIlxId ilx:0381598 .
+
+DICOM:0028_1405 ilxtr:hasIlxId ilx:0382942 .
+
+DICOM:0028_1406 ilxtr:hasIlxId ilx:0383071 .
+
+DICOM:0028_1407 ilxtr:hasIlxId ilx:0382391 .
+
+DICOM:0028_1408 ilxtr:hasIlxId ilx:0382383 .
+
+DICOM:0028_1410 ilxtr:hasIlxId ilx:0381470 .
+
+DICOM:0028_2000 ilxtr:hasIlxId ilx:0381592 .
+
+DICOM:0028_2002 ilxtr:hasIlxId ilx:0382102 .
+
+DICOM:0028_2110 ilxtr:hasIlxId ilx:0106369 .
+
+DICOM:0028_2112 ilxtr:hasIlxId ilx:0106371 .
+
+DICOM:0028_2114 ilxtr:hasIlxId ilx:0106370 .
+
+DICOM:0028_3000 ilxtr:hasIlxId ilx:0107046 .
+
+DICOM:0028_3002 ilxtr:hasIlxId ilx:0106412 .
+
+DICOM:0028_3003 ilxtr:hasIlxId ilx:0106413 .
+
+DICOM:0028_3004 ilxtr:hasIlxId ilx:0107047 .
+
+DICOM:0028_3006 ilxtr:hasIlxId ilx:0106411 .
+
+DICOM:0028_3010 ilxtr:hasIlxId ilx:0112537 .
+
+DICOM:0028_3110 ilxtr:hasIlxId ilx:0110718 .
+
+DICOM:0028_6010 ilxtr:hasIlxId ilx:0109926 .
+
+DICOM:0028_6020 ilxtr:hasIlxId ilx:0104411 .
+
+DICOM:0028_6022 ilxtr:hasIlxId ilx:0104412 .
+
+DICOM:0028_6023 ilxtr:hasIlxId ilx:0104413 .
+
+DICOM:0028_6040 ilxtr:hasIlxId ilx:0109588 .
+
+DICOM:0028_6100 ilxtr:hasIlxId ilx:0106542 .
+
+DICOM:0028_6101 ilxtr:hasIlxId ilx:0106540 .
+
+DICOM:0028_6102 ilxtr:hasIlxId ilx:0100852 .
+
+DICOM:0028_6110 ilxtr:hasIlxId ilx:0106539 .
+
+DICOM:0028_6112 ilxtr:hasIlxId ilx:0102534 .
+
+DICOM:0028_6114 ilxtr:hasIlxId ilx:0382075 .
+
+DICOM:0028_6120 ilxtr:hasIlxId ilx:0111740 .
+
+DICOM:0028_6190 ilxtr:hasIlxId ilx:0106541 .
+
+DICOM:0028_9001 ilxtr:hasIlxId ilx:0102828 .
+
+DICOM:0028_9002 ilxtr:hasIlxId ilx:0102827 .
+
+DICOM:0028_9003 ilxtr:hasIlxId ilx:0383185 .
+
+DICOM:0028_9099 ilxtr:hasIlxId ilx:0105996 .
+
+DICOM:0028_9108 ilxtr:hasIlxId ilx:0110620 .
+
+DICOM:0028_9110 ilxtr:hasIlxId ilx:0108953 .
+
+DICOM:0028_9132 ilxtr:hasIlxId ilx:0104424 .
+
+DICOM:0028_9145 ilxtr:hasIlxId ilx:0108958 .
+
+DICOM:0028_9235 ilxtr:hasIlxId ilx:0110621 .
+
+DICOM:0028_9411 ilxtr:hasIlxId ilx:0382166 .
+
+DICOM:0028_9415 ilxtr:hasIlxId ilx:0382202 .
+
+DICOM:0028_9416 ilxtr:hasIlxId ilx:0383143 .
+
+DICOM:0028_9422 ilxtr:hasIlxId ilx:0381562 .
+
+DICOM:0028_9443 ilxtr:hasIlxId ilx:0382001 .
+
+DICOM:0028_9444 ilxtr:hasIlxId ilx:0381843 .
+
+DICOM:0028_9445 ilxtr:hasIlxId ilx:0382375 .
+
+DICOM:0028_9446 ilxtr:hasIlxId ilx:0382639 .
+
+DICOM:0028_9454 ilxtr:hasIlxId ilx:0382604 .
+
+DICOM:0028_9474 ilxtr:hasIlxId ilx:0381934 .
+
+DICOM:0028_9478 ilxtr:hasIlxId ilx:0382133 .
+
+DICOM:0028_9501 ilxtr:hasIlxId ilx:0382273 .
+
+DICOM:0028_9502 ilxtr:hasIlxId ilx:0382862 .
+
+DICOM:0028_9503 ilxtr:hasIlxId ilx:0381550 .
+
+DICOM:0028_9505 ilxtr:hasIlxId ilx:0382059 .
+
+DICOM:0028_9506 ilxtr:hasIlxId ilx:0382194 .
+
+DICOM:0028_9507 ilxtr:hasIlxId ilx:0383124 .
+
+DICOM:0028_9520 ilxtr:hasIlxId ilx:0382778 .
+
+DICOM:0028_9537 ilxtr:hasIlxId ilx:0382262 .
+
+DICOM:0032_0032 ilxtr:hasIlxId ilx:0111146 .
+
+DICOM:0032_0033 ilxtr:hasIlxId ilx:0111147 .
+
+DICOM:0032_0034 ilxtr:hasIlxId ilx:0111143 .
+
+DICOM:0032_0035 ilxtr:hasIlxId ilx:0111144 .
+
+DICOM:0032_1000 ilxtr:hasIlxId ilx:0110401 .
+
+DICOM:0032_1001 ilxtr:hasIlxId ilx:0110402 .
+
+DICOM:0032_1010 ilxtr:hasIlxId ilx:0110403 .
+
+DICOM:0032_1011 ilxtr:hasIlxId ilx:0110404 .
+
+DICOM:0032_1020 ilxtr:hasIlxId ilx:0110400 .
+
+DICOM:0032_1021 ilxtr:hasIlxId ilx:0110399 .
+
+DICOM:0032_1030 ilxtr:hasIlxId ilx:0109679 .
+
+DICOM:0032_1031 ilxtr:hasIlxId ilx:0109945 .
+
+DICOM:0032_1032 ilxtr:hasIlxId ilx:0109944 .
+
+DICOM:0032_1033 ilxtr:hasIlxId ilx:0109946 .
+
+DICOM:0032_1034 ilxtr:hasIlxId ilx:0381563 .
+
+DICOM:0032_1040 ilxtr:hasIlxId ilx:0111133 .
+
+DICOM:0032_1041 ilxtr:hasIlxId ilx:0111134 .
+
+DICOM:0032_1050 ilxtr:hasIlxId ilx:0111135 .
+
+DICOM:0032_1051 ilxtr:hasIlxId ilx:0111136 .
+
+DICOM:0032_1055 ilxtr:hasIlxId ilx:0111137 .
+
+DICOM:0032_1060 ilxtr:hasIlxId ilx:0109937 .
+
+DICOM:0032_1064 ilxtr:hasIlxId ilx:0111141 .
+
+DICOM:0032_1070 ilxtr:hasIlxId ilx:0109932 .
+
+DICOM:0038_0004 ilxtr:hasIlxId ilx:0109774 .
+
+DICOM:0038_0008 ilxtr:hasIlxId ilx:0112504 .
+
+DICOM:0038_0010 ilxtr:hasIlxId ilx:0100333 .
+
+DICOM:0038_0011 ilxtr:hasIlxId ilx:0105755 .
+
+DICOM:0038_0014 ilxtr:hasIlxId ilx:0382966 .
+
+DICOM:0038_0020 ilxtr:hasIlxId ilx:0100334 .
+
+DICOM:0038_0021 ilxtr:hasIlxId ilx:0100337 .
+
+DICOM:0038_0030 ilxtr:hasIlxId ilx:0103300 .
+
+DICOM:0038_0032 ilxtr:hasIlxId ilx:0103303 .
+
+DICOM:0038_0040 ilxtr:hasIlxId ilx:0103302 .
+
+DICOM:0038_0044 ilxtr:hasIlxId ilx:0103301 .
+
+DICOM:0038_0050 ilxtr:hasIlxId ilx:0110846 .
+
+DICOM:0038_0060 ilxtr:hasIlxId ilx:0382595 .
+
+DICOM:0038_0062 ilxtr:hasIlxId ilx:0381686 .
+
+DICOM:0038_0064 ilxtr:hasIlxId ilx:0381468 .
+
+DICOM:0038_0101 ilxtr:hasIlxId ilx:0382750 .
+
+DICOM:0038_0102 ilxtr:hasIlxId ilx:0381966 .
+
+DICOM:0038_0300 ilxtr:hasIlxId ilx:0102681 .
+
+DICOM:0038_0400 ilxtr:hasIlxId ilx:0108609 .
+
+DICOM:0038_0500 ilxtr:hasIlxId ilx:0108598 .
+
+DICOM:0038_4000 ilxtr:hasIlxId ilx:0112503 .
+
+DICOM:0040_000A ilxtr:hasIlxId ilx:0111012 .
+
+DICOM:0040_000B ilxtr:hasIlxId ilx:0110378 .
+
+DICOM:0040_0001 ilxtr:hasIlxId ilx:0110393 .
+
+DICOM:0040_0002 ilxtr:hasIlxId ilx:0110387 .
+
+DICOM:0040_0003 ilxtr:hasIlxId ilx:0110389 .
+
+DICOM:0040_003A ilxtr:hasIlxId ilx:0383115 .
+
+DICOM:0040_0004 ilxtr:hasIlxId ilx:0110381 .
+
+DICOM:0040_0005 ilxtr:hasIlxId ilx:0110382 .
+
+DICOM:0040_0006 ilxtr:hasIlxId ilx:0110379 .
+
+DICOM:0040_06FA ilxtr:hasIlxId ilx:0110676 .
+
+DICOM:0040_0007 ilxtr:hasIlxId ilx:0110380 .
+
+DICOM:0040_0008 ilxtr:hasIlxId ilx:0110392 .
+
+DICOM:0040_08D8 ilxtr:hasIlxId ilx:0108957 .
+
+DICOM:0040_08DA ilxtr:hasIlxId ilx:0102552 .
+
+DICOM:0040_08EA ilxtr:hasIlxId ilx:0382291 .
+
+DICOM:0040_0009 ilxtr:hasIlxId ilx:0110383 .
+
+DICOM:0040_0010 ilxtr:hasIlxId ilx:0110396 .
+
+DICOM:0040_0011 ilxtr:hasIlxId ilx:0110384 .
+
+DICOM:0040_0012 ilxtr:hasIlxId ilx:0109182 .
+
+DICOM:0040_0020 ilxtr:hasIlxId ilx:0110390 .
+
+DICOM:0040_0026 ilxtr:hasIlxId ilx:0382597 .
+
+DICOM:0040_0027 ilxtr:hasIlxId ilx:0382587 .
+
+DICOM:0040_030E ilxtr:hasIlxId ilx:0104027 .
+
+DICOM:0040_0031 ilxtr:hasIlxId ilx:0381920 .
+
+DICOM:0040_0032 ilxtr:hasIlxId ilx:0382048 .
+
+DICOM:0040_0033 ilxtr:hasIlxId ilx:0382663 .
+
+DICOM:0040_0035 ilxtr:hasIlxId ilx:0382557 .
+
+DICOM:0040_0036 ilxtr:hasIlxId ilx:0381515 .
+
+DICOM:0040_0039 ilxtr:hasIlxId ilx:0382706 .
+
+DICOM:0040_050A ilxtr:hasIlxId ilx:0110865 .
+
+DICOM:0040_051A ilxtr:hasIlxId ilx:0381737 .
+
+DICOM:0040_059A ilxtr:hasIlxId ilx:0110871 .
+
+DICOM:0040_071A ilxtr:hasIlxId ilx:0105230 .
+
+DICOM:0040_072A ilxtr:hasIlxId ilx:0112676 .
+
+DICOM:0040_073A ilxtr:hasIlxId ilx:0112698 .
+
+DICOM:0040_074A ilxtr:hasIlxId ilx:0112720 .
+
+DICOM:0040_0100 ilxtr:hasIlxId ilx:0110386 .
+
+DICOM:0040_100A ilxtr:hasIlxId ilx:0109678 .
+
+DICOM:0040_0220 ilxtr:hasIlxId ilx:0109772 .
+
+DICOM:0040_0241 ilxtr:hasIlxId ilx:0108702 .
+
+DICOM:0040_0242 ilxtr:hasIlxId ilx:0108705 .
+
+DICOM:0040_0243 ilxtr:hasIlxId ilx:0108688 .
+
+DICOM:0040_0244 ilxtr:hasIlxId ilx:0108695 .
+
+DICOM:0040_0245 ilxtr:hasIlxId ilx:0108696 .
+
+DICOM:0040_0250 ilxtr:hasIlxId ilx:0108692 .
+
+DICOM:0040_0251 ilxtr:hasIlxId ilx:0108693 .
+
+DICOM:0040_0252 ilxtr:hasIlxId ilx:0108697 .
+
+DICOM:0040_0253 ilxtr:hasIlxId ilx:0108694 .
+
+DICOM:0040_0254 ilxtr:hasIlxId ilx:0108690 .
+
+DICOM:0040_0255 ilxtr:hasIlxId ilx:0108698 .
+
+DICOM:0040_0260 ilxtr:hasIlxId ilx:0383184 .
+
+DICOM:0040_0261 ilxtr:hasIlxId ilx:0383137 .
+
+DICOM:0040_0270 ilxtr:hasIlxId ilx:0110398 .
+
+DICOM:0040_0275 ilxtr:hasIlxId ilx:0109930 .
+
+DICOM:0040_0280 ilxtr:hasIlxId ilx:0102399 .
+
+DICOM:0040_0281 ilxtr:hasIlxId ilx:0108691 .
+
+DICOM:0040_0300 ilxtr:hasIlxId ilx:0111831 .
+
+DICOM:0040_0301 ilxtr:hasIlxId ilx:0111828 .
+
+DICOM:0040_0302 ilxtr:hasIlxId ilx:0103871 .
+
+DICOM:0040_0303 ilxtr:hasIlxId ilx:0104024 .
+
+DICOM:0040_0306 ilxtr:hasIlxId ilx:0103340 .
+
+DICOM:0040_0310 ilxtr:hasIlxId ilx:0102398 .
+
+DICOM:0040_0312 ilxtr:hasIlxId ilx:0112684 .
+
+DICOM:0040_0314 ilxtr:hasIlxId ilx:0104876 .
+
+DICOM:0040_0316 ilxtr:hasIlxId ilx:0108130 .
+
+DICOM:0040_0318 ilxtr:hasIlxId ilx:0108131 .
+
+DICOM:0040_0340 ilxtr:hasIlxId ilx:0108701 .
+
+DICOM:0040_0400 ilxtr:hasIlxId ilx:0102400 .
+
+DICOM:0040_0440 ilxtr:hasIlxId ilx:0109466 .
+
+DICOM:0040_0441 ilxtr:hasIlxId ilx:0102508 .
+
+DICOM:0040_0512 ilxtr:hasIlxId ilx:0382191 .
+
+DICOM:0040_0513 ilxtr:hasIlxId ilx:0382513 .
+
+DICOM:0040_0515 ilxtr:hasIlxId ilx:0381490 .
+
+DICOM:0040_0518 ilxtr:hasIlxId ilx:0381717 .
+
+DICOM:0040_0520 ilxtr:hasIlxId ilx:0382903 .
+
+DICOM:0040_0550 ilxtr:hasIlxId ilx:0110870 .
+
+DICOM:0040_0551 ilxtr:hasIlxId ilx:0110867 .
+
+DICOM:0040_0554 ilxtr:hasIlxId ilx:0382839 .
+
+DICOM:0040_0555 ilxtr:hasIlxId ilx:0381667 .
+
+DICOM:0040_0556 ilxtr:hasIlxId ilx:0382794 .
+
+DICOM:0040_0560 ilxtr:hasIlxId ilx:0382808 .
+
+DICOM:0040_0562 ilxtr:hasIlxId ilx:0381741 .
+
+DICOM:0040_0600 ilxtr:hasIlxId ilx:0382322 .
+
+DICOM:0040_0602 ilxtr:hasIlxId ilx:0382308 .
+
+DICOM:0040_0610 ilxtr:hasIlxId ilx:0382562 .
+
+DICOM:0040_0612 ilxtr:hasIlxId ilx:0381492 .
+
+DICOM:0040_0620 ilxtr:hasIlxId ilx:0382068 .
+
+DICOM:0040_1001 ilxtr:hasIlxId ilx:0109938 .
+
+DICOM:0040_1002 ilxtr:hasIlxId ilx:0109680 .
+
+DICOM:0040_1003 ilxtr:hasIlxId ilx:0109940 .
+
+DICOM:0040_1004 ilxtr:hasIlxId ilx:0108602 .
+
+DICOM:0040_1005 ilxtr:hasIlxId ilx:0109939 .
+
+DICOM:0040_1008 ilxtr:hasIlxId ilx:0102469 .
+
+DICOM:0040_1009 ilxtr:hasIlxId ilx:0109925 .
+
+DICOM:0040_1010 ilxtr:hasIlxId ilx:0107296 .
+
+DICOM:0040_1011 ilxtr:hasIlxId ilx:0105534 .
+
+DICOM:0040_1012 ilxtr:hasIlxId ilx:0382152 .
+
+DICOM:0040_1101 ilxtr:hasIlxId ilx:0108769 .
+
+DICOM:0040_1102 ilxtr:hasIlxId ilx:0108770 .
+
+DICOM:0040_1103 ilxtr:hasIlxId ilx:0108771 .
+
+DICOM:0040_1104 ilxtr:hasIlxId ilx:0381996 .
+
+DICOM:0040_1400 ilxtr:hasIlxId ilx:0109936 .
+
+DICOM:0040_2004 ilxtr:hasIlxId ilx:0105753 .
+
+DICOM:0040_2005 ilxtr:hasIlxId ilx:0105754 .
+
+DICOM:0040_2008 ilxtr:hasIlxId ilx:0108118 .
+
+DICOM:0040_2009 ilxtr:hasIlxId ilx:0108119 .
+
+DICOM:0040_2010 ilxtr:hasIlxId ilx:0108117 .
+
+DICOM:0040_2016 ilxtr:hasIlxId ilx:0382248 .
+
+DICOM:0040_2017 ilxtr:hasIlxId ilx:0382843 .
+
+DICOM:0040_2400 ilxtr:hasIlxId ilx:0105269 .
+
+DICOM:0040_3001 ilxtr:hasIlxId ilx:0102470 .
+
+DICOM:0040_4001 ilxtr:hasIlxId ilx:0104587 .
+
+DICOM:0040_4002 ilxtr:hasIlxId ilx:0104585 .
+
+DICOM:0040_4003 ilxtr:hasIlxId ilx:0104586 .
+
+DICOM:0040_4004 ilxtr:hasIlxId ilx:0110391 .
+
+DICOM:0040_4005 ilxtr:hasIlxId ilx:0110388 .
+
+DICOM:0040_4006 ilxtr:hasIlxId ilx:0107188 .
+
+DICOM:0040_4007 ilxtr:hasIlxId ilx:0108699 .
+
+DICOM:0040_4009 ilxtr:hasIlxId ilx:0105116 .
+
+DICOM:0040_4010 ilxtr:hasIlxId ilx:0110385 .
+
+DICOM:0040_4011 ilxtr:hasIlxId ilx:0104016 .
+
+DICOM:0040_4015 ilxtr:hasIlxId ilx:0109979 .
+
+DICOM:0040_4016 ilxtr:hasIlxId ilx:0109762 .
+
+DICOM:0040_4018 ilxtr:hasIlxId ilx:0110405 .
+
+DICOM:0040_4019 ilxtr:hasIlxId ilx:0108707 .
+
+DICOM:0040_4020 ilxtr:hasIlxId ilx:0105496 .
+
+DICOM:0040_4021 ilxtr:hasIlxId ilx:0105497 .
+
+DICOM:0040_4022 ilxtr:hasIlxId ilx:0109909 .
+
+DICOM:0040_4023 ilxtr:hasIlxId ilx:0109763 .
+
+DICOM:0040_4025 ilxtr:hasIlxId ilx:0110397 .
+
+DICOM:0040_4026 ilxtr:hasIlxId ilx:0110394 .
+
+DICOM:0040_4027 ilxtr:hasIlxId ilx:0110395 .
+
+DICOM:0040_4028 ilxtr:hasIlxId ilx:0108706 .
+
+DICOM:0040_4029 ilxtr:hasIlxId ilx:0108703 .
+
+DICOM:0040_4030 ilxtr:hasIlxId ilx:0108704 .
+
+DICOM:0040_4031 ilxtr:hasIlxId ilx:0109943 .
+
+DICOM:0040_4032 ilxtr:hasIlxId ilx:0107654 .
+
+DICOM:0040_4033 ilxtr:hasIlxId ilx:0108285 .
+
+DICOM:0040_4034 ilxtr:hasIlxId ilx:0110377 .
+
+DICOM:0040_4035 ilxtr:hasIlxId ilx:0100295 .
+
+DICOM:0040_4036 ilxtr:hasIlxId ilx:0105118 .
+
+DICOM:0040_4037 ilxtr:hasIlxId ilx:0105117 .
+
+DICOM:0040_4071 ilxtr:hasIlxId ilx:0383116 .
+
+DICOM:0040_4072 ilxtr:hasIlxId ilx:0381774 .
+
+DICOM:0040_4073 ilxtr:hasIlxId ilx:0382652 .
+
+DICOM:0040_4074 ilxtr:hasIlxId ilx:0382593 .
+
+DICOM:0040_8302 ilxtr:hasIlxId ilx:0103872 .
+
+DICOM:0040_9092 ilxtr:hasIlxId ilx:0381818 .
+
+DICOM:0040_9094 ilxtr:hasIlxId ilx:0382545 .
+
+DICOM:0040_9096 ilxtr:hasIlxId ilx:0109675 .
+
+DICOM:0040_9098 ilxtr:hasIlxId ilx:0382653 .
+
+DICOM:0040_9210 ilxtr:hasIlxId ilx:0106414 .
+
+DICOM:0040_9211 ilxtr:hasIlxId ilx:0109673 .
+
+DICOM:0040_9212 ilxtr:hasIlxId ilx:0109674 .
+
+DICOM:0040_9213 ilxtr:hasIlxId ilx:0381627 .
+
+DICOM:0040_9214 ilxtr:hasIlxId ilx:0382810 .
+
+DICOM:0040_9216 ilxtr:hasIlxId ilx:0109671 .
+
+DICOM:0040_9220 ilxtr:hasIlxId ilx:0383104 .
+
+DICOM:0040_9224 ilxtr:hasIlxId ilx:0109672 .
+
+DICOM:0040_9225 ilxtr:hasIlxId ilx:0109676 .
+
+DICOM:0040_A0B0 ilxtr:hasIlxId ilx:0109803 .
+
+DICOM:0040_A07A ilxtr:hasIlxId ilx:0382250 .
+
+DICOM:0040_A07C ilxtr:hasIlxId ilx:0382791 .
+
+DICOM:0040_A010 ilxtr:hasIlxId ilx:0109900 .
+
+DICOM:0040_A13A ilxtr:hasIlxId ilx:0109751 .
+
+DICOM:0040_A027 ilxtr:hasIlxId ilx:0112391 .
+
+DICOM:0040_A030 ilxtr:hasIlxId ilx:0112386 .
+
+DICOM:0040_A30A ilxtr:hasIlxId ilx:0382619 .
+
+DICOM:0040_A032 ilxtr:hasIlxId ilx:0107873 .
+
+DICOM:0040_A040 ilxtr:hasIlxId ilx:0382583 .
+
+DICOM:0040_A043 ilxtr:hasIlxId ilx:0381632 .
+
+DICOM:0040_A050 ilxtr:hasIlxId ilx:0102516 .
+
+DICOM:0040_A073 ilxtr:hasIlxId ilx:0112390 .
+
+DICOM:0040_A075 ilxtr:hasIlxId ilx:0112389 .
+
+DICOM:0040_A078 ilxtr:hasIlxId ilx:0382688 .
+
+DICOM:0040_A080 ilxtr:hasIlxId ilx:0382875 .
+
+DICOM:0040_A082 ilxtr:hasIlxId ilx:0382144 .
+
+DICOM:0040_A084 ilxtr:hasIlxId ilx:0382755 .
+
+DICOM:0040_A088 ilxtr:hasIlxId ilx:0112388 .
+
+DICOM:0040_A120 ilxtr:hasIlxId ilx:0102844 .
+
+DICOM:0040_A121 ilxtr:hasIlxId ilx:0383109 .
+
+DICOM:0040_A123 ilxtr:hasIlxId ilx:0382955 .
+
+DICOM:0040_A124 ilxtr:hasIlxId ilx:0112146 .
+
+DICOM:0040_A130 ilxtr:hasIlxId ilx:0111598 .
+
+DICOM:0040_A132 ilxtr:hasIlxId ilx:0109787 .
+
+DICOM:0040_A136 ilxtr:hasIlxId ilx:0383179 .
+
+DICOM:0040_A138 ilxtr:hasIlxId ilx:0109798 .
+
+DICOM:0040_A160 ilxtr:hasIlxId ilx:0382340 .
+
+DICOM:0040_A161 ilxtr:hasIlxId ilx:0382213 .
+
+DICOM:0040_A162 ilxtr:hasIlxId ilx:0382181 .
+
+DICOM:0040_A163 ilxtr:hasIlxId ilx:0381912 .
+
+DICOM:0040_A168 ilxtr:hasIlxId ilx:0381519 .
+
+DICOM:0040_A170 ilxtr:hasIlxId ilx:0109547 .
+
+DICOM:0040_A171 ilxtr:hasIlxId ilx:0382567 .
+
+DICOM:0040_A180 ilxtr:hasIlxId ilx:0100649 .
+
+DICOM:0040_A195 ilxtr:hasIlxId ilx:0107058 .
+
+DICOM:0040_A300 ilxtr:hasIlxId ilx:0106598 .
+
+DICOM:0040_A301 ilxtr:hasIlxId ilx:0107855 .
+
+DICOM:0040_A360 ilxtr:hasIlxId ilx:0109202 .
+
+DICOM:0040_A370 ilxtr:hasIlxId ilx:0109783 .
+
+DICOM:0040_A372 ilxtr:hasIlxId ilx:0108689 .
+
+DICOM:0040_A375 ilxtr:hasIlxId ilx:0102682 .
+
+DICOM:0040_A385 ilxtr:hasIlxId ilx:0108773 .
+
+DICOM:0040_A390 ilxtr:hasIlxId ilx:0382470 .
+
+DICOM:0040_A491 ilxtr:hasIlxId ilx:0102429 .
+
+DICOM:0040_A492 ilxtr:hasIlxId ilx:0102430 .
+
+DICOM:0040_A493 ilxtr:hasIlxId ilx:0112387 .
+
+DICOM:0040_A496 ilxtr:hasIlxId ilx:0383112 .
+
+DICOM:0040_A504 ilxtr:hasIlxId ilx:0102512 .
+
+DICOM:0040_A525 ilxtr:hasIlxId ilx:0105211 .
+
+DICOM:0040_A730 ilxtr:hasIlxId ilx:0102511 .
+
+DICOM:0040_B020 ilxtr:hasIlxId ilx:0382362 .
+
+DICOM:0040_DB00 ilxtr:hasIlxId ilx:0111575 .
+
+DICOM:0040_DB73 ilxtr:hasIlxId ilx:0109748 .
+
+DICOM:0040_E001 ilxtr:hasIlxId ilx:0382802 .
+
+DICOM:0040_E008 ilxtr:hasIlxId ilx:0382885 .
+
+DICOM:0040_E010 ilxtr:hasIlxId ilx:0383154 .
+
+DICOM:0040_E011 ilxtr:hasIlxId ilx:0382601 .
+
+DICOM:0040_E020 ilxtr:hasIlxId ilx:0382908 .
+
+DICOM:0040_E021 ilxtr:hasIlxId ilx:0382164 .
+
+DICOM:0040_E022 ilxtr:hasIlxId ilx:0382946 .
+
+DICOM:0040_E023 ilxtr:hasIlxId ilx:0382798 .
+
+DICOM:0040_E024 ilxtr:hasIlxId ilx:0382360 .
+
+DICOM:0040_E025 ilxtr:hasIlxId ilx:0382588 .
+
+DICOM:0040_E030 ilxtr:hasIlxId ilx:0382173 .
+
+DICOM:0040_E031 ilxtr:hasIlxId ilx:0383157 .
+
+DICOM:0042_0010 ilxtr:hasIlxId ilx:0381878 .
+
+DICOM:0042_0011 ilxtr:hasIlxId ilx:0381899 .
+
+DICOM:0042_0012 ilxtr:hasIlxId ilx:0382269 .
+
+DICOM:0042_0013 ilxtr:hasIlxId ilx:0382216 .
+
+DICOM:0042_0014 ilxtr:hasIlxId ilx:0382718 .
+
+DICOM:0046_0012 ilxtr:hasIlxId ilx:0382478 .
+
+DICOM:0046_0014 ilxtr:hasIlxId ilx:0381824 .
+
+DICOM:0046_0015 ilxtr:hasIlxId ilx:0382950 .
+
+DICOM:0046_0016 ilxtr:hasIlxId ilx:0381834 .
+
+DICOM:0046_0018 ilxtr:hasIlxId ilx:0383010 .
+
+DICOM:0046_0028 ilxtr:hasIlxId ilx:0381783 .
+
+DICOM:0046_0030 ilxtr:hasIlxId ilx:0381972 .
+
+DICOM:0046_0032 ilxtr:hasIlxId ilx:0381721 .
+
+DICOM:0046_0034 ilxtr:hasIlxId ilx:0382730 .
+
+DICOM:0046_0036 ilxtr:hasIlxId ilx:0382890 .
+
+DICOM:0046_0038 ilxtr:hasIlxId ilx:0382050 .
+
+DICOM:0046_0040 ilxtr:hasIlxId ilx:0381529 .
+
+DICOM:0046_0042 ilxtr:hasIlxId ilx:0381517 .
+
+DICOM:0046_0044 ilxtr:hasIlxId ilx:0383142 .
+
+DICOM:0046_0046 ilxtr:hasIlxId ilx:0381997 .
+
+DICOM:0046_0050 ilxtr:hasIlxId ilx:0383064 .
+
+DICOM:0046_0052 ilxtr:hasIlxId ilx:0382414 .
+
+DICOM:0046_0060 ilxtr:hasIlxId ilx:0381564 .
+
+DICOM:0046_0062 ilxtr:hasIlxId ilx:0382969 .
+
+DICOM:0046_0063 ilxtr:hasIlxId ilx:0382471 .
+
+DICOM:0046_0064 ilxtr:hasIlxId ilx:0382293 .
+
+DICOM:0046_0070 ilxtr:hasIlxId ilx:0382187 .
+
+DICOM:0046_0071 ilxtr:hasIlxId ilx:0382742 .
+
+DICOM:0046_0074 ilxtr:hasIlxId ilx:0382761 .
+
+DICOM:0046_0075 ilxtr:hasIlxId ilx:0381495 .
+
+DICOM:0046_0076 ilxtr:hasIlxId ilx:0382748 .
+
+DICOM:0046_0077 ilxtr:hasIlxId ilx:0381480 .
+
+DICOM:0046_0080 ilxtr:hasIlxId ilx:0381725 .
+
+DICOM:0046_0092 ilxtr:hasIlxId ilx:0382868 .
+
+DICOM:0046_0094 ilxtr:hasIlxId ilx:0382889 .
+
+DICOM:0046_0095 ilxtr:hasIlxId ilx:0382386 .
+
+DICOM:0046_0097 ilxtr:hasIlxId ilx:0381976 .
+
+DICOM:0046_0098 ilxtr:hasIlxId ilx:0381578 .
+
+DICOM:0046_0100 ilxtr:hasIlxId ilx:0381466 .
+
+DICOM:0046_0101 ilxtr:hasIlxId ilx:0381608 .
+
+DICOM:0046_0102 ilxtr:hasIlxId ilx:0381773 .
+
+DICOM:0046_0104 ilxtr:hasIlxId ilx:0381668 .
+
+DICOM:0046_0106 ilxtr:hasIlxId ilx:0382421 .
+
+DICOM:0046_0121 ilxtr:hasIlxId ilx:0382564 .
+
+DICOM:0046_0122 ilxtr:hasIlxId ilx:0383021 .
+
+DICOM:0046_0123 ilxtr:hasIlxId ilx:0381638 .
+
+DICOM:0046_0124 ilxtr:hasIlxId ilx:0382741 .
+
+DICOM:0046_0125 ilxtr:hasIlxId ilx:0382088 .
+
+DICOM:0046_0135 ilxtr:hasIlxId ilx:0382209 .
+
+DICOM:0046_0137 ilxtr:hasIlxId ilx:0382632 .
+
+DICOM:0046_0139 ilxtr:hasIlxId ilx:0382432 .
+
+DICOM:0046_0145 ilxtr:hasIlxId ilx:0382036 .
+
+DICOM:0046_0146 ilxtr:hasIlxId ilx:0381522 .
+
+DICOM:0046_0147 ilxtr:hasIlxId ilx:0381881 .
+
+DICOM:0046_0201 ilxtr:hasIlxId ilx:0382937 .
+
+DICOM:0046_0202 ilxtr:hasIlxId ilx:0382300 .
+
+DICOM:0046_0203 ilxtr:hasIlxId ilx:0381541 .
+
+DICOM:0046_0204 ilxtr:hasIlxId ilx:0383162 .
+
+DICOM:0046_0205 ilxtr:hasIlxId ilx:0381986 .
+
+DICOM:0046_0207 ilxtr:hasIlxId ilx:0382855 .
+
+DICOM:0046_0208 ilxtr:hasIlxId ilx:0382354 .
+
+DICOM:0046_0210 ilxtr:hasIlxId ilx:0381744 .
+
+DICOM:0046_0211 ilxtr:hasIlxId ilx:0383165 .
+
+DICOM:0046_0212 ilxtr:hasIlxId ilx:0383131 .
+
+DICOM:0046_0213 ilxtr:hasIlxId ilx:0382231 .
+
+DICOM:0046_0215 ilxtr:hasIlxId ilx:0382618 .
+
+DICOM:0046_0218 ilxtr:hasIlxId ilx:0381459 .
+
+DICOM:0046_0220 ilxtr:hasIlxId ilx:0383034 .
+
+DICOM:0046_0224 ilxtr:hasIlxId ilx:0381952 .
+
+DICOM:0046_0227 ilxtr:hasIlxId ilx:0382502 .
+
+DICOM:0046_0230 ilxtr:hasIlxId ilx:0382177 .
+
+DICOM:0046_0232 ilxtr:hasIlxId ilx:0382582 .
+
+DICOM:0046_0234 ilxtr:hasIlxId ilx:0382143 .
+
+DICOM:0046_0236 ilxtr:hasIlxId ilx:0382980 .
+
+DICOM:0046_0238 ilxtr:hasIlxId ilx:0381777 .
+
+DICOM:0046_0242 ilxtr:hasIlxId ilx:0382393 .
+
+DICOM:0046_0244 ilxtr:hasIlxId ilx:0382902 .
+
+DICOM:0046_0247 ilxtr:hasIlxId ilx:0382525 .
+
+DICOM:0046_0248 ilxtr:hasIlxId ilx:0381815 .
+
+DICOM:0046_0249 ilxtr:hasIlxId ilx:0382020 .
+
+DICOM:0046_0250 ilxtr:hasIlxId ilx:0381911 .
+
+DICOM:0046_0251 ilxtr:hasIlxId ilx:0383118 .
+
+DICOM:0046_0252 ilxtr:hasIlxId ilx:0381868 .
+
+DICOM:0046_0253 ilxtr:hasIlxId ilx:0383049 .
+
+DICOM:0048_0001 ilxtr:hasIlxId ilx:0382642 .
+
+DICOM:0048_0002 ilxtr:hasIlxId ilx:0381545 .
+
+DICOM:0048_0003 ilxtr:hasIlxId ilx:0382338 .
+
+DICOM:0048_0006 ilxtr:hasIlxId ilx:0382649 .
+
+DICOM:0048_0007 ilxtr:hasIlxId ilx:0382651 .
+
+DICOM:0048_0008 ilxtr:hasIlxId ilx:0381546 .
+
+DICOM:0048_0010 ilxtr:hasIlxId ilx:0382709 .
+
+DICOM:0048_0011 ilxtr:hasIlxId ilx:0383080 .
+
+DICOM:0048_0012 ilxtr:hasIlxId ilx:0381785 .
+
+DICOM:0048_0013 ilxtr:hasIlxId ilx:0382747 .
+
+DICOM:0048_0014 ilxtr:hasIlxId ilx:0382054 .
+
+DICOM:0048_0015 ilxtr:hasIlxId ilx:0383005 .
+
+DICOM:0048_021A ilxtr:hasIlxId ilx:0381454 .
+
+DICOM:0048_021E ilxtr:hasIlxId ilx:0382138 .
+
+DICOM:0048_021F ilxtr:hasIlxId ilx:0382907 .
+
+DICOM:0048_0100 ilxtr:hasIlxId ilx:0382842 .
+
+DICOM:0048_0102 ilxtr:hasIlxId ilx:0383030 .
+
+DICOM:0048_0105 ilxtr:hasIlxId ilx:0381494 .
+
+DICOM:0048_0106 ilxtr:hasIlxId ilx:0383161 .
+
+DICOM:0048_0107 ilxtr:hasIlxId ilx:0382660 .
+
+DICOM:0048_0108 ilxtr:hasIlxId ilx:0382820 .
+
+DICOM:0048_0110 ilxtr:hasIlxId ilx:0381478 .
+
+DICOM:0048_0111 ilxtr:hasIlxId ilx:0382817 .
+
+DICOM:0048_0112 ilxtr:hasIlxId ilx:0382137 .
+
+DICOM:0048_0113 ilxtr:hasIlxId ilx:0382087 .
+
+DICOM:0048_0120 ilxtr:hasIlxId ilx:0382782 .
+
+DICOM:0048_0200 ilxtr:hasIlxId ilx:0381636 .
+
+DICOM:0048_0201 ilxtr:hasIlxId ilx:0381808 .
+
+DICOM:0048_0202 ilxtr:hasIlxId ilx:0382371 .
+
+DICOM:0048_0207 ilxtr:hasIlxId ilx:0381906 .
+
+DICOM:0048_0301 ilxtr:hasIlxId ilx:0382066 .
+
+DICOM:0050_001A ilxtr:hasIlxId ilx:0382100 .
+
+DICOM:0050_001B ilxtr:hasIlxId ilx:0381924 .
+
+DICOM:0050_001C ilxtr:hasIlxId ilx:0381745 .
+
+DICOM:0050_001D ilxtr:hasIlxId ilx:0381726 .
+
+DICOM:0050_001E ilxtr:hasIlxId ilx:0382469 .
+
+DICOM:0050_0004 ilxtr:hasIlxId ilx:0101581 .
+
+DICOM:0050_0010 ilxtr:hasIlxId ilx:0381709 .
+
+DICOM:0050_0012 ilxtr:hasIlxId ilx:0382261 .
+
+DICOM:0050_0013 ilxtr:hasIlxId ilx:0382935 .
+
+DICOM:0050_0014 ilxtr:hasIlxId ilx:0382284 .
+
+DICOM:0050_0015 ilxtr:hasIlxId ilx:0382731 .
+
+DICOM:0050_0016 ilxtr:hasIlxId ilx:0382400 .
+
+DICOM:0050_0017 ilxtr:hasIlxId ilx:0383037 .
+
+DICOM:0050_0018 ilxtr:hasIlxId ilx:0382475 .
+
+DICOM:0050_0019 ilxtr:hasIlxId ilx:0382033 .
+
+DICOM:0050_0020 ilxtr:hasIlxId ilx:0382208 .
+
+DICOM:50xx_0005 ilxtr:hasIlxId ilx:0102687 .
+
+DICOM:50xx_0020 ilxtr:hasIlxId ilx:0112117 .
+
+DICOM:50xx_0030 ilxtr:hasIlxId ilx:0101038 .
+
+DICOM:50xx_1001 ilxtr:hasIlxId ilx:0102686 .
+
+DICOM:0052_0001 ilxtr:hasIlxId ilx:0382609 .
+
+DICOM:0052_0002 ilxtr:hasIlxId ilx:0383045 .
+
+DICOM:0052_0003 ilxtr:hasIlxId ilx:0382871 .
+
+DICOM:0052_003A ilxtr:hasIlxId ilx:0382560 .
+
+DICOM:0052_0004 ilxtr:hasIlxId ilx:0381568 .
+
+DICOM:0052_0006 ilxtr:hasIlxId ilx:0382422 .
+
+DICOM:0052_0007 ilxtr:hasIlxId ilx:0382312 .
+
+DICOM:0052_0008 ilxtr:hasIlxId ilx:0382451 .
+
+DICOM:0052_0009 ilxtr:hasIlxId ilx:0382803 .
+
+DICOM:0052_0011 ilxtr:hasIlxId ilx:0381869 .
+
+DICOM:0052_0012 ilxtr:hasIlxId ilx:0382719 .
+
+DICOM:0052_0013 ilxtr:hasIlxId ilx:0382974 .
+
+DICOM:0052_0014 ilxtr:hasIlxId ilx:0382436 .
+
+DICOM:0052_0016 ilxtr:hasIlxId ilx:0381894 .
+
+DICOM:0052_0025 ilxtr:hasIlxId ilx:0381486 .
+
+DICOM:0052_0026 ilxtr:hasIlxId ilx:0383058 .
+
+DICOM:0052_0027 ilxtr:hasIlxId ilx:0382916 .
+
+DICOM:0052_0028 ilxtr:hasIlxId ilx:0383091 .
+
+DICOM:0052_0029 ilxtr:hasIlxId ilx:0381778 .
+
+DICOM:0052_0030 ilxtr:hasIlxId ilx:0382347 .
+
+DICOM:0052_0031 ilxtr:hasIlxId ilx:0382585 .
+
+DICOM:0052_0033 ilxtr:hasIlxId ilx:0382835 .
+
+DICOM:0052_0034 ilxtr:hasIlxId ilx:0382511 .
+
+DICOM:0052_0036 ilxtr:hasIlxId ilx:0382543 .
+
+DICOM:0052_0038 ilxtr:hasIlxId ilx:0382827 .
+
+DICOM:0052_0039 ilxtr:hasIlxId ilx:0382631 .
+
+DICOM:0054_0010 ilxtr:hasIlxId ilx:0103820 .
+
+DICOM:0054_0011 ilxtr:hasIlxId ilx:0107818 .
+
+DICOM:0054_0012 ilxtr:hasIlxId ilx:0103814 .
+
+DICOM:0054_0013 ilxtr:hasIlxId ilx:0103818 .
+
+DICOM:0054_0014 ilxtr:hasIlxId ilx:0103815 .
+
+DICOM:0054_0015 ilxtr:hasIlxId ilx:0103819 .
+
+DICOM:0054_0016 ilxtr:hasIlxId ilx:0109627 .
+
+DICOM:0054_0017 ilxtr:hasIlxId ilx:0109956 .
+
+DICOM:0054_0018 ilxtr:hasIlxId ilx:0103816 .
+
+DICOM:0054_0020 ilxtr:hasIlxId ilx:0103157 .
+
+DICOM:0054_0021 ilxtr:hasIlxId ilx:0107816 .
+
+DICOM:0054_0022 ilxtr:hasIlxId ilx:0103146 .
+
+DICOM:0054_0030 ilxtr:hasIlxId ilx:0108792 .
+
+DICOM:0054_0031 ilxtr:hasIlxId ilx:0107833 .
+
+DICOM:0054_0032 ilxtr:hasIlxId ilx:0108790 .
+
+DICOM:0054_0033 ilxtr:hasIlxId ilx:0107825 .
+
+DICOM:0054_0036 ilxtr:hasIlxId ilx:0108788 .
+
+DICOM:0054_0038 ilxtr:hasIlxId ilx:0108623 .
+
+DICOM:0054_0039 ilxtr:hasIlxId ilx:0108789 .
+
+DICOM:0054_0050 ilxtr:hasIlxId ilx:0110233 .
+
+DICOM:0054_0051 ilxtr:hasIlxId ilx:0107836 .
+
+DICOM:0054_0052 ilxtr:hasIlxId ilx:0110231 .
+
+DICOM:0054_0053 ilxtr:hasIlxId ilx:0107826 .
+
+DICOM:0054_0060 ilxtr:hasIlxId ilx:0109590 .
+
+DICOM:0054_0061 ilxtr:hasIlxId ilx:0107835 .
+
+DICOM:0054_0062 ilxtr:hasIlxId ilx:0104568 .
+
+DICOM:0054_0063 ilxtr:hasIlxId ilx:0102822 .
+
+DICOM:0054_0070 ilxtr:hasIlxId ilx:0111757 .
+
+DICOM:0054_0071 ilxtr:hasIlxId ilx:0107846 .
+
+DICOM:0054_0072 ilxtr:hasIlxId ilx:0111755 .
+
+DICOM:0054_0073 ilxtr:hasIlxId ilx:0111756 .
+
+DICOM:0054_0080 ilxtr:hasIlxId ilx:0110674 .
+
+DICOM:0054_0081 ilxtr:hasIlxId ilx:0107838 .
+
+DICOM:0054_0090 ilxtr:hasIlxId ilx:0100631 .
+
+DICOM:0054_0100 ilxtr:hasIlxId ilx:0111754 .
+
+DICOM:0054_0101 ilxtr:hasIlxId ilx:0107845 .
+
+DICOM:0054_0200 ilxtr:hasIlxId ilx:0111022 .
+
+DICOM:0054_0202 ilxtr:hasIlxId ilx:0112118 .
+
+DICOM:0054_0210 ilxtr:hasIlxId ilx:0111974 .
+
+DICOM:0054_0211 ilxtr:hasIlxId ilx:0107848 .
+
+DICOM:0054_0220 ilxtr:hasIlxId ilx:0112473 .
+
+DICOM:0054_0222 ilxtr:hasIlxId ilx:0112474 .
+
+DICOM:0054_0300 ilxtr:hasIlxId ilx:0109621 .
+
+DICOM:0054_0302 ilxtr:hasIlxId ilx:0100332 .
+
+DICOM:0054_0304 ilxtr:hasIlxId ilx:0109626 .
+
+DICOM:0054_0306 ilxtr:hasIlxId ilx:0101580 .
+
+DICOM:0054_0308 ilxtr:hasIlxId ilx:0103817 .
+
+DICOM:0054_0400 ilxtr:hasIlxId ilx:0105236 .
+
+DICOM:0054_0410 ilxtr:hasIlxId ilx:0108591 .
+
+DICOM:0054_0412 ilxtr:hasIlxId ilx:0108592 .
+
+DICOM:0054_0414 ilxtr:hasIlxId ilx:0108588 .
+
+DICOM:0054_0500 ilxtr:hasIlxId ilx:0110671 .
+
+DICOM:0054_0501 ilxtr:hasIlxId ilx:0381549 .
+
+DICOM:0054_1000 ilxtr:hasIlxId ilx:0110548 .
+
+DICOM:0054_1001 ilxtr:hasIlxId ilx:0112181 .
+
+DICOM:0054_1002 ilxtr:hasIlxId ilx:0102604 .
+
+DICOM:0054_1004 ilxtr:hasIlxId ilx:0109929 .
+
+DICOM:0054_1006 ilxtr:hasIlxId ilx:0382590 .
+
+DICOM:0054_1100 ilxtr:hasIlxId ilx:0109642 .
+
+DICOM:0054_1101 ilxtr:hasIlxId ilx:0100986 .
+
+DICOM:0054_1102 ilxtr:hasIlxId ilx:0102868 .
+
+DICOM:0054_1103 ilxtr:hasIlxId ilx:0383190 .
+
+DICOM:0054_1104 ilxtr:hasIlxId ilx:0103147 .
+
+DICOM:0054_1105 ilxtr:hasIlxId ilx:0110371 .
+
+DICOM:0054_1200 ilxtr:hasIlxId ilx:0101033 .
+
+DICOM:0054_1201 ilxtr:hasIlxId ilx:0101035 .
+
+DICOM:0054_1202 ilxtr:hasIlxId ilx:0111904 .
+
+DICOM:0054_1203 ilxtr:hasIlxId ilx:0103143 .
+
+DICOM:0054_1210 ilxtr:hasIlxId ilx:0102347 .
+
+DICOM:0054_1220 ilxtr:hasIlxId ilx:0110439 .
+
+DICOM:0054_1300 ilxtr:hasIlxId ilx:0104421 .
+
+DICOM:0054_1310 ilxtr:hasIlxId ilx:0109285 .
+
+DICOM:0054_1311 ilxtr:hasIlxId ilx:0110438 .
+
+DICOM:0054_1320 ilxtr:hasIlxId ilx:0110672 .
+
+DICOM:0054_1321 ilxtr:hasIlxId ilx:0102869 .
+
+DICOM:0054_1322 ilxtr:hasIlxId ilx:0103521 .
+
+DICOM:0054_1323 ilxtr:hasIlxId ilx:0110372 .
+
+DICOM:0054_1324 ilxtr:hasIlxId ilx:0102861 .
+
+DICOM:0054_1330 ilxtr:hasIlxId ilx:0105237 .
+
+DICOM:0054_1400 ilxtr:hasIlxId ilx:0102603 .
+
+DICOM:0054_1401 ilxtr:hasIlxId ilx:0102860 .
+
+DICOM:0060_3000 ilxtr:hasIlxId ilx:0105078 .
+
+DICOM:0060_3002 ilxtr:hasIlxId ilx:0105077 .
+
+DICOM:0060_3004 ilxtr:hasIlxId ilx:0105075 .
+
+DICOM:0060_3006 ilxtr:hasIlxId ilx:0105076 .
+
+DICOM:0060_3008 ilxtr:hasIlxId ilx:0105072 .
+
+DICOM:0060_3010 ilxtr:hasIlxId ilx:0105074 .
+
+DICOM:0060_3020 ilxtr:hasIlxId ilx:0105073 .
+
+DICOM:60xx_0010 ilxtr:hasIlxId ilx:0108301 .
+
+DICOM:60xx_0011 ilxtr:hasIlxId ilx:0108293 .
+
+DICOM:60xx_0015 ilxtr:hasIlxId ilx:0107824 .
+
+DICOM:60xx_0022 ilxtr:hasIlxId ilx:0108296 .
+
+DICOM:60xx_0040 ilxtr:hasIlxId ilx:0108304 .
+
+DICOM:60xx_0045 ilxtr:hasIlxId ilx:0108302 .
+
+DICOM:60xx_0050 ilxtr:hasIlxId ilx:0108299 .
+
+DICOM:60xx_0051 ilxtr:hasIlxId ilx:0105234 .
+
+DICOM:60xx_0100 ilxtr:hasIlxId ilx:0108292 .
+
+DICOM:60xx_0102 ilxtr:hasIlxId ilx:0108291 .
+
+DICOM:60xx_1001 ilxtr:hasIlxId ilx:0108290 .
+
+DICOM:60xx_1301 ilxtr:hasIlxId ilx:0110177 .
+
+DICOM:60xx_1302 ilxtr:hasIlxId ilx:0110184 .
+
+DICOM:60xx_1303 ilxtr:hasIlxId ilx:0110192 .
+
+DICOM:60xx_1500 ilxtr:hasIlxId ilx:0108297 .
+
+DICOM:60xx_3000 ilxtr:hasIlxId ilx:0108294 .
+
+DICOM:0062_000A ilxtr:hasIlxId ilx:0382517 .
+
+DICOM:0062_000B ilxtr:hasIlxId ilx:0382956 .
+
+DICOM:0062_000C ilxtr:hasIlxId ilx:0382971 .
+
+DICOM:0062_000D ilxtr:hasIlxId ilx:0382067 .
+
+DICOM:0062_000E ilxtr:hasIlxId ilx:0381658 .
+
+DICOM:0062_000F ilxtr:hasIlxId ilx:0381720 .
+
+DICOM:0062_0001 ilxtr:hasIlxId ilx:0382348 .
+
+DICOM:0062_0002 ilxtr:hasIlxId ilx:0381762 .
+
+DICOM:0062_0003 ilxtr:hasIlxId ilx:0381481 .
+
+DICOM:0062_0004 ilxtr:hasIlxId ilx:0383127 .
+
+DICOM:0062_0005 ilxtr:hasIlxId ilx:0382232 .
+
+DICOM:0062_0006 ilxtr:hasIlxId ilx:0382625 .
+
+DICOM:0062_0007 ilxtr:hasIlxId ilx:0382732 .
+
+DICOM:0062_0008 ilxtr:hasIlxId ilx:0381642 .
+
+DICOM:0062_0009 ilxtr:hasIlxId ilx:0382637 .
+
+DICOM:0062_0010 ilxtr:hasIlxId ilx:0381567 .
+
+DICOM:0062_0011 ilxtr:hasIlxId ilx:0381755 .
+
+DICOM:0062_0012 ilxtr:hasIlxId ilx:0383163 .
+
+DICOM:0062_0020 ilxtr:hasIlxId ilx:0382616 .
+
+DICOM:0062_0021 ilxtr:hasIlxId ilx:0382882 .
+
+DICOM:0064_000F ilxtr:hasIlxId ilx:0383074 .
+
+DICOM:0064_0002 ilxtr:hasIlxId ilx:0383063 .
+
+DICOM:0064_0003 ilxtr:hasIlxId ilx:0382443 .
+
+DICOM:0064_0005 ilxtr:hasIlxId ilx:0382264 .
+
+DICOM:0064_0007 ilxtr:hasIlxId ilx:0382441 .
+
+DICOM:0064_0008 ilxtr:hasIlxId ilx:0381477 .
+
+DICOM:0064_0009 ilxtr:hasIlxId ilx:0381803 .
+
+DICOM:0064_0010 ilxtr:hasIlxId ilx:0382594 .
+
+DICOM:0066_000A ilxtr:hasIlxId ilx:0382679 .
+
+DICOM:0066_000B ilxtr:hasIlxId ilx:0381664 .
+
+DICOM:0066_000C ilxtr:hasIlxId ilx:0382449 .
+
+DICOM:0066_000D ilxtr:hasIlxId ilx:0382130 .
+
+DICOM:0066_000E ilxtr:hasIlxId ilx:0382533 .
+
+DICOM:0066_0001 ilxtr:hasIlxId ilx:0382671 .
+
+DICOM:0066_001A ilxtr:hasIlxId ilx:0382466 .
+
+DICOM:0066_001B ilxtr:hasIlxId ilx:0382111 .
+
+DICOM:0066_001C ilxtr:hasIlxId ilx:0382812 .
+
+DICOM:0066_001E ilxtr:hasIlxId ilx:0382118 .
+
+DICOM:0066_001F ilxtr:hasIlxId ilx:0382771 .
+
+DICOM:0066_0002 ilxtr:hasIlxId ilx:0381475 .
+
+DICOM:0066_002A ilxtr:hasIlxId ilx:0382551 .
+
+DICOM:0066_002B ilxtr:hasIlxId ilx:0383027 .
+
+DICOM:0066_002C ilxtr:hasIlxId ilx:0382329 .
+
+DICOM:0066_002D ilxtr:hasIlxId ilx:0381917 .
+
+DICOM:0066_002E ilxtr:hasIlxId ilx:0382733 .
+
+DICOM:0066_002F ilxtr:hasIlxId ilx:0381607 .
+
+DICOM:0066_0003 ilxtr:hasIlxId ilx:0383044 .
+
+DICOM:0066_0004 ilxtr:hasIlxId ilx:0383136 .
+
+DICOM:0066_0009 ilxtr:hasIlxId ilx:0382602 .
+
+DICOM:0066_0010 ilxtr:hasIlxId ilx:0382406 .
+
+DICOM:0066_0011 ilxtr:hasIlxId ilx:0382832 .
+
+DICOM:0066_0012 ilxtr:hasIlxId ilx:0382703 .
+
+DICOM:0066_0013 ilxtr:hasIlxId ilx:0381501 .
+
+DICOM:0066_0015 ilxtr:hasIlxId ilx:0382781 .
+
+DICOM:0066_0016 ilxtr:hasIlxId ilx:0382777 .
+
+DICOM:0066_0017 ilxtr:hasIlxId ilx:0381822 .
+
+DICOM:0066_0018 ilxtr:hasIlxId ilx:0382947 .
+
+DICOM:0066_0019 ilxtr:hasIlxId ilx:0383141 .
+
+DICOM:0066_0020 ilxtr:hasIlxId ilx:0381788 .
+
+DICOM:0066_0021 ilxtr:hasIlxId ilx:0382828 .
+
+DICOM:0066_0026 ilxtr:hasIlxId ilx:0382388 .
+
+DICOM:0066_0027 ilxtr:hasIlxId ilx:0382426 .
+
+DICOM:0066_0028 ilxtr:hasIlxId ilx:0381584 .
+
+DICOM:0066_0030 ilxtr:hasIlxId ilx:0382185 .
+
+DICOM:0066_0031 ilxtr:hasIlxId ilx:0382161 .
+
+DICOM:0066_0032 ilxtr:hasIlxId ilx:0381805 .
+
+DICOM:0066_0034 ilxtr:hasIlxId ilx:0382901 .
+
+DICOM:0066_0035 ilxtr:hasIlxId ilx:0382058 .
+
+DICOM:0066_0036 ilxtr:hasIlxId ilx:0382157 .
+
+DICOM:0066_0037 ilxtr:hasIlxId ilx:0382028 .
+
+DICOM:0066_0038 ilxtr:hasIlxId ilx:0383066 .
+
+DICOM:0066_0040 ilxtr:hasIlxId ilx:0381993 .
+
+DICOM:0066_0041 ilxtr:hasIlxId ilx:0382370 .
+
+DICOM:0066_0042 ilxtr:hasIlxId ilx:0382897 .
+
+DICOM:0066_0043 ilxtr:hasIlxId ilx:0382247 .
+
+DICOM:0066_0101 ilxtr:hasIlxId ilx:0382346 .
+
+DICOM:0066_0102 ilxtr:hasIlxId ilx:0383009 .
+
+DICOM:0066_0103 ilxtr:hasIlxId ilx:0381872 .
+
+DICOM:0066_0104 ilxtr:hasIlxId ilx:0382285 .
+
+DICOM:0066_0105 ilxtr:hasIlxId ilx:0382672 .
+
+DICOM:0066_0106 ilxtr:hasIlxId ilx:0383121 .
+
+DICOM:0066_0107 ilxtr:hasIlxId ilx:0381474 .
+
+DICOM:0066_0108 ilxtr:hasIlxId ilx:0381680 .
+
+DICOM:0066_0121 ilxtr:hasIlxId ilx:0381633 .
+
+DICOM:0066_0124 ilxtr:hasIlxId ilx:0381593 .
+
+DICOM:0066_0125 ilxtr:hasIlxId ilx:0382474 .
+
+DICOM:0066_0129 ilxtr:hasIlxId ilx:0382356 .
+
+DICOM:0066_0130 ilxtr:hasIlxId ilx:0381757 .
+
+DICOM:0066_0132 ilxtr:hasIlxId ilx:0382200 .
+
+DICOM:0066_0133 ilxtr:hasIlxId ilx:0382460 .
+
+DICOM:0066_0134 ilxtr:hasIlxId ilx:0381652 .
+
+DICOM:0068_62A0 ilxtr:hasIlxId ilx:0382872 .
+
+DICOM:0068_62A5 ilxtr:hasIlxId ilx:0381937 .
+
+DICOM:0068_62C0 ilxtr:hasIlxId ilx:0382654 .
+
+DICOM:0068_62D0 ilxtr:hasIlxId ilx:0382378 .
+
+DICOM:0068_62D5 ilxtr:hasIlxId ilx:0381713 .
+
+DICOM:0068_62E0 ilxtr:hasIlxId ilx:0381990 .
+
+DICOM:0068_62F0 ilxtr:hasIlxId ilx:0381836 .
+
+DICOM:0068_62F2 ilxtr:hasIlxId ilx:0381581 .
+
+DICOM:0068_63A0 ilxtr:hasIlxId ilx:0382220 .
+
+DICOM:0068_63A4 ilxtr:hasIlxId ilx:0382121 .
+
+DICOM:0068_63A8 ilxtr:hasIlxId ilx:0381706 .
+
+DICOM:0068_63AC ilxtr:hasIlxId ilx:0381802 .
+
+DICOM:0068_63B0 ilxtr:hasIlxId ilx:0382496 .
+
+DICOM:0068_63C0 ilxtr:hasIlxId ilx:0382734 .
+
+DICOM:0068_63D0 ilxtr:hasIlxId ilx:0383123 .
+
+DICOM:0068_63E0 ilxtr:hasIlxId ilx:0383001 .
+
+DICOM:0068_63F0 ilxtr:hasIlxId ilx:0382379 .
+
+DICOM:0068_64A0 ilxtr:hasIlxId ilx:0381932 .
+
+DICOM:0068_64C0 ilxtr:hasIlxId ilx:0381483 .
+
+DICOM:0068_64D0 ilxtr:hasIlxId ilx:0382298 .
+
+DICOM:0068_64F0 ilxtr:hasIlxId ilx:0381560 .
+
+DICOM:0068_65A0 ilxtr:hasIlxId ilx:0382515 .
+
+DICOM:0068_65B0 ilxtr:hasIlxId ilx:0381733 .
+
+DICOM:0068_65D0 ilxtr:hasIlxId ilx:0382574 .
+
+DICOM:0068_65E0 ilxtr:hasIlxId ilx:0381817 .
+
+DICOM:0068_65F0 ilxtr:hasIlxId ilx:0382090 .
+
+DICOM:0068_6210 ilxtr:hasIlxId ilx:0382795 .
+
+DICOM:0068_6221 ilxtr:hasIlxId ilx:0382035 .
+
+DICOM:0068_6222 ilxtr:hasIlxId ilx:0382676 .
+
+DICOM:0068_6223 ilxtr:hasIlxId ilx:0382770 .
+
+DICOM:0068_6224 ilxtr:hasIlxId ilx:0382539 .
+
+DICOM:0068_6225 ilxtr:hasIlxId ilx:0381533 .
+
+DICOM:0068_6226 ilxtr:hasIlxId ilx:0382505 .
+
+DICOM:0068_6230 ilxtr:hasIlxId ilx:0382870 .
+
+DICOM:0068_6260 ilxtr:hasIlxId ilx:0381678 .
+
+DICOM:0068_6265 ilxtr:hasIlxId ilx:0382758 .
+
+DICOM:0068_6270 ilxtr:hasIlxId ilx:0382333 .
+
+DICOM:0068_6280 ilxtr:hasIlxId ilx:0382373 .
+
+DICOM:0068_6300 ilxtr:hasIlxId ilx:0382752 .
+
+DICOM:0068_6310 ilxtr:hasIlxId ilx:0381631 .
+
+DICOM:0068_6320 ilxtr:hasIlxId ilx:0382071 .
+
+DICOM:0068_6330 ilxtr:hasIlxId ilx:0382790 .
+
+DICOM:0068_6340 ilxtr:hasIlxId ilx:0383029 .
+
+DICOM:0068_6345 ilxtr:hasIlxId ilx:0381838 .
+
+DICOM:0068_6346 ilxtr:hasIlxId ilx:0382073 .
+
+DICOM:0068_6347 ilxtr:hasIlxId ilx:0382647 .
+
+DICOM:0068_6350 ilxtr:hasIlxId ilx:0382392 .
+
+DICOM:0068_6360 ilxtr:hasIlxId ilx:0382892 .
+
+DICOM:0068_6380 ilxtr:hasIlxId ilx:0382380 .
+
+DICOM:0068_6390 ilxtr:hasIlxId ilx:0382002 .
+
+DICOM:0068_6400 ilxtr:hasIlxId ilx:0381653 .
+
+DICOM:0068_6410 ilxtr:hasIlxId ilx:0382684 .
+
+DICOM:0068_6420 ilxtr:hasIlxId ilx:0382295 .
+
+DICOM:0068_6430 ilxtr:hasIlxId ilx:0382611 .
+
+DICOM:0068_6440 ilxtr:hasIlxId ilx:0382856 .
+
+DICOM:0068_6450 ilxtr:hasIlxId ilx:0381820 .
+
+DICOM:0068_6460 ilxtr:hasIlxId ilx:0383152 .
+
+DICOM:0068_6470 ilxtr:hasIlxId ilx:0381508 .
+
+DICOM:0068_6490 ilxtr:hasIlxId ilx:0381908 .
+
+DICOM:0068_6500 ilxtr:hasIlxId ilx:0382934 .
+
+DICOM:0068_6510 ilxtr:hasIlxId ilx:0381665 .
+
+DICOM:0068_6520 ilxtr:hasIlxId ilx:0382112 .
+
+DICOM:0068_6530 ilxtr:hasIlxId ilx:0382115 .
+
+DICOM:0068_6540 ilxtr:hasIlxId ilx:0381623 .
+
+DICOM:0068_6545 ilxtr:hasIlxId ilx:0382610 .
+
+DICOM:0068_6550 ilxtr:hasIlxId ilx:0381616 .
+
+DICOM:0068_6560 ilxtr:hasIlxId ilx:0382914 .
+
+DICOM:0068_6590 ilxtr:hasIlxId ilx:0382280 .
+
+DICOM:0068_6610 ilxtr:hasIlxId ilx:0382448 .
+
+DICOM:0068_6620 ilxtr:hasIlxId ilx:0382636 .
+
+DICOM:0070_0001 ilxtr:hasIlxId ilx:0104750 .
+
+DICOM:0070_1A01 ilxtr:hasIlxId ilx:0382815 .
+
+DICOM:0070_1A03 ilxtr:hasIlxId ilx:0381452 .
+
+DICOM:0070_1A04 ilxtr:hasIlxId ilx:0382494 .
+
+DICOM:0070_1A05 ilxtr:hasIlxId ilx:0381766 .
+
+DICOM:0070_0002 ilxtr:hasIlxId ilx:0104755 .
+
+DICOM:0070_0003 ilxtr:hasIlxId ilx:0101401 .
+
+DICOM:0070_0004 ilxtr:hasIlxId ilx:0100618 .
+
+DICOM:0070_0005 ilxtr:hasIlxId ilx:0104751 .
+
+DICOM:0070_005A ilxtr:hasIlxId ilx:0382991 .
+
+DICOM:0070_0006 ilxtr:hasIlxId ilx:0112170 .
+
+DICOM:0070_0008 ilxtr:hasIlxId ilx:0111647 .
+
+DICOM:0070_0009 ilxtr:hasIlxId ilx:0104761 .
+
+DICOM:0070_0010 ilxtr:hasIlxId ilx:0101404 .
+
+DICOM:0070_0011 ilxtr:hasIlxId ilx:0101402 .
+
+DICOM:0070_0012 ilxtr:hasIlxId ilx:0101403 .
+
+DICOM:0070_0014 ilxtr:hasIlxId ilx:0100617 .
+
+DICOM:0070_0015 ilxtr:hasIlxId ilx:0100619 .
+
+DICOM:0070_0020 ilxtr:hasIlxId ilx:0104753 .
+
+DICOM:0070_0021 ilxtr:hasIlxId ilx:0107827 .
+
+DICOM:0070_0022 ilxtr:hasIlxId ilx:0104752 .
+
+DICOM:0070_0023 ilxtr:hasIlxId ilx:0104762 .
+
+DICOM:0070_0024 ilxtr:hasIlxId ilx:0104754 .
+
+DICOM:0070_030A ilxtr:hasIlxId ilx:0381790 .
+
+DICOM:0070_030B ilxtr:hasIlxId ilx:0383047 .
+
+DICOM:0070_030C ilxtr:hasIlxId ilx:0382541 .
+
+DICOM:0070_030D ilxtr:hasIlxId ilx:0109881 .
+
+DICOM:0070_030F ilxtr:hasIlxId ilx:0104185 .
+
+DICOM:0070_031A ilxtr:hasIlxId ilx:0104189 .
+
+DICOM:0070_031C ilxtr:hasIlxId ilx:0382279 .
+
+DICOM:0070_031E ilxtr:hasIlxId ilx:0104188 .
+
+DICOM:0070_031F ilxtr:hasIlxId ilx:0382926 .
+
+DICOM:0070_0041 ilxtr:hasIlxId ilx:0105235 .
+
+DICOM:0070_0042 ilxtr:hasIlxId ilx:0105252 .
+
+DICOM:0070_0052 ilxtr:hasIlxId ilx:0103326 .
+
+DICOM:0070_0053 ilxtr:hasIlxId ilx:0381518 .
+
+DICOM:0070_0060 ilxtr:hasIlxId ilx:0104760 .
+
+DICOM:0070_0062 ilxtr:hasIlxId ilx:0104757 .
+
+DICOM:0070_0066 ilxtr:hasIlxId ilx:0104758 .
+
+DICOM:0070_0067 ilxtr:hasIlxId ilx:0104759 .
+
+DICOM:0070_0068 ilxtr:hasIlxId ilx:0104756 .
+
+DICOM:0070_0080 ilxtr:hasIlxId ilx:0102509 .
+
+DICOM:0070_0081 ilxtr:hasIlxId ilx:0102507 .
+
+DICOM:0070_0082 ilxtr:hasIlxId ilx:0109238 .
+
+DICOM:0070_0083 ilxtr:hasIlxId ilx:0109239 .
+
+DICOM:0070_0084 ilxtr:hasIlxId ilx:0102505 .
+
+DICOM:0070_0086 ilxtr:hasIlxId ilx:0381900 .
+
+DICOM:0070_0087 ilxtr:hasIlxId ilx:0381558 .
+
+DICOM:0070_0100 ilxtr:hasIlxId ilx:0109246 .
+
+DICOM:0070_0101 ilxtr:hasIlxId ilx:0109245 .
+
+DICOM:0070_0102 ilxtr:hasIlxId ilx:0109243 .
+
+DICOM:0070_0103 ilxtr:hasIlxId ilx:0109244 .
+
+DICOM:0070_150C ilxtr:hasIlxId ilx:0382029 .
+
+DICOM:0070_150D ilxtr:hasIlxId ilx:0381981 .
+
+DICOM:0070_0207 ilxtr:hasIlxId ilx:0381572 .
+
+DICOM:0070_0208 ilxtr:hasIlxId ilx:0381837 .
+
+DICOM:0070_0209 ilxtr:hasIlxId ilx:0383075 .
+
+DICOM:0070_0226 ilxtr:hasIlxId ilx:0381544 .
+
+DICOM:0070_0227 ilxtr:hasIlxId ilx:0382547 .
+
+DICOM:0070_0228 ilxtr:hasIlxId ilx:0382244 .
+
+DICOM:0070_0229 ilxtr:hasIlxId ilx:0382004 .
+
+DICOM:0070_0230 ilxtr:hasIlxId ilx:0382182 .
+
+DICOM:0070_0231 ilxtr:hasIlxId ilx:0382468 .
+
+DICOM:0070_0232 ilxtr:hasIlxId ilx:0382352 .
+
+DICOM:0070_0233 ilxtr:hasIlxId ilx:0382746 .
+
+DICOM:0070_0234 ilxtr:hasIlxId ilx:0381535 .
+
+DICOM:0070_0241 ilxtr:hasIlxId ilx:0383099 .
+
+DICOM:0070_0242 ilxtr:hasIlxId ilx:0382681 .
+
+DICOM:0070_0243 ilxtr:hasIlxId ilx:0382424 .
+
+DICOM:0070_0244 ilxtr:hasIlxId ilx:0383056 .
+
+DICOM:0070_0245 ilxtr:hasIlxId ilx:0382141 .
+
+DICOM:0070_0246 ilxtr:hasIlxId ilx:0382826 .
+
+DICOM:0070_0247 ilxtr:hasIlxId ilx:0381647 .
+
+DICOM:0070_0248 ilxtr:hasIlxId ilx:0381595 .
+
+DICOM:0070_0249 ilxtr:hasIlxId ilx:0381455 .
+
+DICOM:0070_0250 ilxtr:hasIlxId ilx:0381557 .
+
+DICOM:0070_0251 ilxtr:hasIlxId ilx:0382078 .
+
+DICOM:0070_0252 ilxtr:hasIlxId ilx:0381683 .
+
+DICOM:0070_0253 ilxtr:hasIlxId ilx:0381659 .
+
+DICOM:0070_0254 ilxtr:hasIlxId ilx:0381781 .
+
+DICOM:0070_0255 ilxtr:hasIlxId ilx:0382252 .
+
+DICOM:0070_0256 ilxtr:hasIlxId ilx:0383092 .
+
+DICOM:0070_0257 ilxtr:hasIlxId ilx:0382026 .
+
+DICOM:0070_0258 ilxtr:hasIlxId ilx:0382645 .
+
+DICOM:0070_0261 ilxtr:hasIlxId ilx:0383160 .
+
+DICOM:0070_0262 ilxtr:hasIlxId ilx:0382630 .
+
+DICOM:0070_0273 ilxtr:hasIlxId ilx:0381979 .
+
+DICOM:0070_0274 ilxtr:hasIlxId ilx:0381527 .
+
+DICOM:0070_0278 ilxtr:hasIlxId ilx:0382845 .
+
+DICOM:0070_0279 ilxtr:hasIlxId ilx:0383014 .
+
+DICOM:0070_0282 ilxtr:hasIlxId ilx:0381514 .
+
+DICOM:0070_0284 ilxtr:hasIlxId ilx:0382725 .
+
+DICOM:0070_0285 ilxtr:hasIlxId ilx:0382900 .
+
+DICOM:0070_0287 ilxtr:hasIlxId ilx:0382186 .
+
+DICOM:0070_0288 ilxtr:hasIlxId ilx:0382011 .
+
+DICOM:0070_0289 ilxtr:hasIlxId ilx:0381625 .
+
+DICOM:0070_0294 ilxtr:hasIlxId ilx:0382236 .
+
+DICOM:0070_0295 ilxtr:hasIlxId ilx:0381575 .
+
+DICOM:0070_0306 ilxtr:hasIlxId ilx:0382420 .
+
+DICOM:0070_0308 ilxtr:hasIlxId ilx:0109879 .
+
+DICOM:0070_0309 ilxtr:hasIlxId ilx:0382940 .
+
+DICOM:0070_0310 ilxtr:hasIlxId ilx:0104186 .
+
+DICOM:0070_0311 ilxtr:hasIlxId ilx:0104187 .
+
+DICOM:0070_0312 ilxtr:hasIlxId ilx:0382275 .
+
+DICOM:0070_0314 ilxtr:hasIlxId ilx:0112212 .
+
+DICOM:0070_0318 ilxtr:hasIlxId ilx:0382757 .
+
+DICOM:0070_0401 ilxtr:hasIlxId ilx:0382677 .
+
+DICOM:0070_0402 ilxtr:hasIlxId ilx:0383031 .
+
+DICOM:0070_0403 ilxtr:hasIlxId ilx:0382227 .
+
+DICOM:0070_0404 ilxtr:hasIlxId ilx:0381891 .
+
+DICOM:0070_0405 ilxtr:hasIlxId ilx:0382669 .
+
+DICOM:0070_1101 ilxtr:hasIlxId ilx:0382434 .
+
+DICOM:0070_1102 ilxtr:hasIlxId ilx:0381922 .
+
+DICOM:0070_1103 ilxtr:hasIlxId ilx:0383072 .
+
+DICOM:0070_1104 ilxtr:hasIlxId ilx:0382938 .
+
+DICOM:0070_1201 ilxtr:hasIlxId ilx:0382305 .
+
+DICOM:0070_1202 ilxtr:hasIlxId ilx:0383095 .
+
+DICOM:0070_1203 ilxtr:hasIlxId ilx:0382620 .
+
+DICOM:0070_1204 ilxtr:hasIlxId ilx:0383135 .
+
+DICOM:0070_1205 ilxtr:hasIlxId ilx:0382847 .
+
+DICOM:0070_1206 ilxtr:hasIlxId ilx:0381620 .
+
+DICOM:0070_1207 ilxtr:hasIlxId ilx:0383144 .
+
+DICOM:0070_1301 ilxtr:hasIlxId ilx:0382315 .
+
+DICOM:0070_1302 ilxtr:hasIlxId ilx:0381944 .
+
+DICOM:0070_1303 ilxtr:hasIlxId ilx:0382077 .
+
+DICOM:0070_1304 ilxtr:hasIlxId ilx:0382314 .
+
+DICOM:0070_1305 ilxtr:hasIlxId ilx:0381768 .
+
+DICOM:0070_1306 ilxtr:hasIlxId ilx:0381507 .
+
+DICOM:0070_1309 ilxtr:hasIlxId ilx:0382922 .
+
+DICOM:0070_1501 ilxtr:hasIlxId ilx:0382169 .
+
+DICOM:0070_1502 ilxtr:hasIlxId ilx:0381469 .
+
+DICOM:0070_1505 ilxtr:hasIlxId ilx:0382753 .
+
+DICOM:0070_1507 ilxtr:hasIlxId ilx:0382431 .
+
+DICOM:0070_1508 ilxtr:hasIlxId ilx:0382259 .
+
+DICOM:0070_1511 ilxtr:hasIlxId ilx:0383053 .
+
+DICOM:0070_1512 ilxtr:hasIlxId ilx:0382509 .
+
+DICOM:0070_1801 ilxtr:hasIlxId ilx:0381855 .
+
+DICOM:0070_1802 ilxtr:hasIlxId ilx:0382738 .
+
+DICOM:0070_1803 ilxtr:hasIlxId ilx:0382714 .
+
+DICOM:0070_1804 ilxtr:hasIlxId ilx:0382534 .
+
+DICOM:0070_1805 ilxtr:hasIlxId ilx:0382395 .
+
+DICOM:0070_1806 ilxtr:hasIlxId ilx:0381968 .
+
+DICOM:0070_1901 ilxtr:hasIlxId ilx:0383138 .
+
+DICOM:0070_1903 ilxtr:hasIlxId ilx:0382824 .
+
+DICOM:0070_1904 ilxtr:hasIlxId ilx:0382156 .
+
+DICOM:0070_1905 ilxtr:hasIlxId ilx:0382268 .
+
+DICOM:0070_1907 ilxtr:hasIlxId ilx:0381799 .
+
+DICOM:0072_000A ilxtr:hasIlxId ilx:0382410 .
+
+DICOM:0072_000C ilxtr:hasIlxId ilx:0383148 .
+
+DICOM:0072_000E ilxtr:hasIlxId ilx:0382987 .
+
+DICOM:0072_0002 ilxtr:hasIlxId ilx:0382074 .
+
+DICOM:0072_003A ilxtr:hasIlxId ilx:0382127 .
+
+DICOM:0072_003C ilxtr:hasIlxId ilx:0382412 .
+
+DICOM:0072_003E ilxtr:hasIlxId ilx:0383032 .
+
+DICOM:0072_0004 ilxtr:hasIlxId ilx:0381919 .
+
+DICOM:0072_005E ilxtr:hasIlxId ilx:0382210 .
+
+DICOM:0072_005F ilxtr:hasIlxId ilx:0382906 .
+
+DICOM:0072_0006 ilxtr:hasIlxId ilx:0382235 .
+
+DICOM:0072_006A ilxtr:hasIlxId ilx:0382063 .
+
+DICOM:0072_006B ilxtr:hasIlxId ilx:0381743 .
+
+DICOM:0072_006C ilxtr:hasIlxId ilx:0381513 .
+
+DICOM:0072_006D ilxtr:hasIlxId ilx:0381918 .
+
+DICOM:0072_006E ilxtr:hasIlxId ilx:0381666 .
+
+DICOM:0072_006F ilxtr:hasIlxId ilx:0381939 .
+
+DICOM:0072_007A ilxtr:hasIlxId ilx:0382070 .
+
+DICOM:0072_007C ilxtr:hasIlxId ilx:0382508 .
+
+DICOM:0072_007E ilxtr:hasIlxId ilx:0382572 .
+
+DICOM:0072_007F ilxtr:hasIlxId ilx:0382749 .
+
+DICOM:0072_0008 ilxtr:hasIlxId ilx:0383103 .
+
+DICOM:0072_0010 ilxtr:hasIlxId ilx:0382792 .
+
+DICOM:0072_010A ilxtr:hasIlxId ilx:0381556 .
+
+DICOM:0072_010C ilxtr:hasIlxId ilx:0381704 .
+
+DICOM:0072_010E ilxtr:hasIlxId ilx:0382119 .
+
+DICOM:0072_0012 ilxtr:hasIlxId ilx:0382586 .
+
+DICOM:0072_0014 ilxtr:hasIlxId ilx:0381797 .
+
+DICOM:0072_0020 ilxtr:hasIlxId ilx:0382846 .
+
+DICOM:0072_0022 ilxtr:hasIlxId ilx:0381701 .
+
+DICOM:0072_0024 ilxtr:hasIlxId ilx:0381458 .
+
+DICOM:0072_0026 ilxtr:hasIlxId ilx:0382658 .
+
+DICOM:0072_0028 ilxtr:hasIlxId ilx:0382655 .
+
+DICOM:0072_0030 ilxtr:hasIlxId ilx:0382288 .
+
+DICOM:0072_0032 ilxtr:hasIlxId ilx:0381614 .
+
+DICOM:0072_0034 ilxtr:hasIlxId ilx:0381769 .
+
+DICOM:0072_0038 ilxtr:hasIlxId ilx:0382017 .
+
+DICOM:0072_0040 ilxtr:hasIlxId ilx:0381859 .
+
+DICOM:0072_0050 ilxtr:hasIlxId ilx:0382120 .
+
+DICOM:0072_0052 ilxtr:hasIlxId ilx:0381884 .
+
+DICOM:0072_0054 ilxtr:hasIlxId ilx:0381690 .
+
+DICOM:0072_0056 ilxtr:hasIlxId ilx:0382168 .
+
+DICOM:0072_0060 ilxtr:hasIlxId ilx:0383067 .
+
+DICOM:0072_0061 ilxtr:hasIlxId ilx:0382962 .
+
+DICOM:0072_0062 ilxtr:hasIlxId ilx:0382428 .
+
+DICOM:0072_0063 ilxtr:hasIlxId ilx:0382217 .
+
+DICOM:0072_0064 ilxtr:hasIlxId ilx:0382713 .
+
+DICOM:0072_0065 ilxtr:hasIlxId ilx:0382766 .
+
+DICOM:0072_0066 ilxtr:hasIlxId ilx:0383050 .
+
+DICOM:0072_0067 ilxtr:hasIlxId ilx:0381960 .
+
+DICOM:0072_0068 ilxtr:hasIlxId ilx:0382199 .
+
+DICOM:0072_0069 ilxtr:hasIlxId ilx:0381761 .
+
+DICOM:0072_0070 ilxtr:hasIlxId ilx:0381851 .
+
+DICOM:0072_0071 ilxtr:hasIlxId ilx:0383159 .
+
+DICOM:0072_0072 ilxtr:hasIlxId ilx:0382318 .
+
+DICOM:0072_0073 ilxtr:hasIlxId ilx:0382695 .
+
+DICOM:0072_0074 ilxtr:hasIlxId ilx:0382818 .
+
+DICOM:0072_0075 ilxtr:hasIlxId ilx:0382621 .
+
+DICOM:0072_0076 ilxtr:hasIlxId ilx:0382316 .
+
+DICOM:0072_0078 ilxtr:hasIlxId ilx:0382635 .
+
+DICOM:0072_0080 ilxtr:hasIlxId ilx:0381497 .
+
+DICOM:0072_0100 ilxtr:hasIlxId ilx:0382702 .
+
+DICOM:0072_0102 ilxtr:hasIlxId ilx:0381715 .
+
+DICOM:0072_0104 ilxtr:hasIlxId ilx:0381793 .
+
+DICOM:0072_0106 ilxtr:hasIlxId ilx:0382013 .
+
+DICOM:0072_0108 ilxtr:hasIlxId ilx:0382042 .
+
+DICOM:0072_0200 ilxtr:hasIlxId ilx:0381951 .
+
+DICOM:0072_0202 ilxtr:hasIlxId ilx:0382928 .
+
+DICOM:0072_0203 ilxtr:hasIlxId ilx:0382278 .
+
+DICOM:0072_0204 ilxtr:hasIlxId ilx:0381734 .
+
+DICOM:0072_0206 ilxtr:hasIlxId ilx:0382589 .
+
+DICOM:0072_0208 ilxtr:hasIlxId ilx:0381962 .
+
+DICOM:0072_0210 ilxtr:hasIlxId ilx:0382353 .
+
+DICOM:0072_0212 ilxtr:hasIlxId ilx:0382485 .
+
+DICOM:0072_0214 ilxtr:hasIlxId ilx:0382563 .
+
+DICOM:0072_0216 ilxtr:hasIlxId ilx:0382045 .
+
+DICOM:0072_0218 ilxtr:hasIlxId ilx:0382221 .
+
+DICOM:0072_0300 ilxtr:hasIlxId ilx:0381691 .
+
+DICOM:0072_0302 ilxtr:hasIlxId ilx:0382959 .
+
+DICOM:0072_0304 ilxtr:hasIlxId ilx:0381705 .
+
+DICOM:0072_0306 ilxtr:hasIlxId ilx:0382417 .
+
+DICOM:0072_0308 ilxtr:hasIlxId ilx:0382638 .
+
+DICOM:0072_0310 ilxtr:hasIlxId ilx:0382258 .
+
+DICOM:0072_0312 ilxtr:hasIlxId ilx:0382237 .
+
+DICOM:0072_0314 ilxtr:hasIlxId ilx:0381555 .
+
+DICOM:0072_0316 ilxtr:hasIlxId ilx:0382550 .
+
+DICOM:0072_0318 ilxtr:hasIlxId ilx:0383042 .
+
+DICOM:0072_0320 ilxtr:hasIlxId ilx:0382774 .
+
+DICOM:0072_0330 ilxtr:hasIlxId ilx:0382402 .
+
+DICOM:0072_0400 ilxtr:hasIlxId ilx:0381601 .
+
+DICOM:0072_0402 ilxtr:hasIlxId ilx:0381604 .
+
+DICOM:0072_0404 ilxtr:hasIlxId ilx:0382396 .
+
+DICOM:0072_0406 ilxtr:hasIlxId ilx:0381612 .
+
+DICOM:0072_0420 ilxtr:hasIlxId ilx:0381456 .
+
+DICOM:0072_0421 ilxtr:hasIlxId ilx:0382097 .
+
+DICOM:0072_0422 ilxtr:hasIlxId ilx:0382641 .
+
+DICOM:0072_0424 ilxtr:hasIlxId ilx:0383102 .
+
+DICOM:0072_0427 ilxtr:hasIlxId ilx:0382963 .
+
+DICOM:0072_0430 ilxtr:hasIlxId ilx:0381832 .
+
+DICOM:0072_0432 ilxtr:hasIlxId ilx:0381779 .
+
+DICOM:0072_0434 ilxtr:hasIlxId ilx:0382692 .
+
+DICOM:0072_0500 ilxtr:hasIlxId ilx:0381591 .
+
+DICOM:0072_0510 ilxtr:hasIlxId ilx:0381796 .
+
+DICOM:0072_0512 ilxtr:hasIlxId ilx:0381871 .
+
+DICOM:0072_0514 ilxtr:hasIlxId ilx:0383078 .
+
+DICOM:0072_0516 ilxtr:hasIlxId ilx:0382503 .
+
+DICOM:0072_0520 ilxtr:hasIlxId ilx:0382061 .
+
+DICOM:0072_0600 ilxtr:hasIlxId ilx:0382793 .
+
+DICOM:0072_0602 ilxtr:hasIlxId ilx:0381569 .
+
+DICOM:0072_0604 ilxtr:hasIlxId ilx:0383062 .
+
+DICOM:0072_0700 ilxtr:hasIlxId ilx:0382240 .
+
+DICOM:0072_0702 ilxtr:hasIlxId ilx:0382988 .
+
+DICOM:0072_0704 ilxtr:hasIlxId ilx:0382960 .
+
+DICOM:0072_0705 ilxtr:hasIlxId ilx:0382866 .
+
+DICOM:0072_0706 ilxtr:hasIlxId ilx:0381925 .
+
+DICOM:0072_0710 ilxtr:hasIlxId ilx:0381742 .
+
+DICOM:0072_0712 ilxtr:hasIlxId ilx:0382174 .
+
+DICOM:0072_0714 ilxtr:hasIlxId ilx:0382500 .
+
+DICOM:0072_0716 ilxtr:hasIlxId ilx:0382569 .
+
+DICOM:0072_0717 ilxtr:hasIlxId ilx:0383149 .
+
+DICOM:0072_0718 ilxtr:hasIlxId ilx:0381703 .
+
+DICOM:0074_1057 ilxtr:hasIlxId ilx:0382019 .
+
+DICOM:0076_000A ilxtr:hasIlxId ilx:0382857 .
+
+DICOM:0076_00A0 ilxtr:hasIlxId ilx:0381852 .
+
+DICOM:0076_00B0 ilxtr:hasIlxId ilx:0382879 .
+
+DICOM:0076_000C ilxtr:hasIlxId ilx:0382696 .
+
+DICOM:0076_00C0 ilxtr:hasIlxId ilx:0382767 .
+
+DICOM:0076_000E ilxtr:hasIlxId ilx:0382580 .
+
+DICOM:0076_0001 ilxtr:hasIlxId ilx:0383129 .
+
+DICOM:0076_0003 ilxtr:hasIlxId ilx:0382599 .
+
+DICOM:0076_0006 ilxtr:hasIlxId ilx:0382537 .
+
+DICOM:0076_0008 ilxtr:hasIlxId ilx:0383000 .
+
+DICOM:0076_0010 ilxtr:hasIlxId ilx:0382328 .
+
+DICOM:0076_0020 ilxtr:hasIlxId ilx:0382715 .
+
+DICOM:0076_0030 ilxtr:hasIlxId ilx:0381676 .
+
+DICOM:0076_0032 ilxtr:hasIlxId ilx:0382584 .
+
+DICOM:0076_0034 ilxtr:hasIlxId ilx:0382957 .
+
+DICOM:0076_0036 ilxtr:hasIlxId ilx:0383172 .
+
+DICOM:0076_0038 ilxtr:hasIlxId ilx:0381764 .
+
+DICOM:0076_0040 ilxtr:hasIlxId ilx:0382439 .
+
+DICOM:0076_0055 ilxtr:hasIlxId ilx:0381752 .
+
+DICOM:0076_0060 ilxtr:hasIlxId ilx:0382320 .
+
+DICOM:0076_0070 ilxtr:hasIlxId ilx:0381887 .
+
+DICOM:0076_0080 ilxtr:hasIlxId ilx:0382223 .
+
+DICOM:0076_0090 ilxtr:hasIlxId ilx:0382086 .
+
+DICOM:0078_00A0 ilxtr:hasIlxId ilx:0382367 .
+
+DICOM:0078_00B0 ilxtr:hasIlxId ilx:0381740 .
+
+DICOM:0078_00B2 ilxtr:hasIlxId ilx:0382368 .
+
+DICOM:0078_00B4 ilxtr:hasIlxId ilx:0383150 .
+
+DICOM:0078_00B6 ilxtr:hasIlxId ilx:0381464 .
+
+DICOM:0078_00B8 ilxtr:hasIlxId ilx:0382462 .
+
+DICOM:0078_0001 ilxtr:hasIlxId ilx:0382811 .
+
+DICOM:0078_002A ilxtr:hasIlxId ilx:0382775 .
+
+DICOM:0078_002E ilxtr:hasIlxId ilx:0382359 .
+
+DICOM:0078_0010 ilxtr:hasIlxId ilx:0381816 .
+
+DICOM:0078_0020 ilxtr:hasIlxId ilx:0381610 .
+
+DICOM:0078_0024 ilxtr:hasIlxId ilx:0382939 .
+
+DICOM:0078_0026 ilxtr:hasIlxId ilx:0382238 .
+
+DICOM:0078_0028 ilxtr:hasIlxId ilx:0382453 .
+
+DICOM:0078_0050 ilxtr:hasIlxId ilx:0382917 .
+
+DICOM:0078_0060 ilxtr:hasIlxId ilx:0382756 .
+
+DICOM:0078_0070 ilxtr:hasIlxId ilx:0381931 .
+
+DICOM:0078_0090 ilxtr:hasIlxId ilx:0381957 .
+
+DICOM:0080_0001 ilxtr:hasIlxId ilx:0382623 .
+
+DICOM:0080_0002 ilxtr:hasIlxId ilx:0381629 .
+
+DICOM:0080_0003 ilxtr:hasIlxId ilx:0381714 .
+
+DICOM:0080_0004 ilxtr:hasIlxId ilx:0382140 .
+
+DICOM:0080_0005 ilxtr:hasIlxId ilx:0382797 .
+
+DICOM:0080_0006 ilxtr:hasIlxId ilx:0381789 .
+
+DICOM:0080_0007 ilxtr:hasIlxId ilx:0382051 .
+
+DICOM:0080_0008 ilxtr:hasIlxId ilx:0382255 .
+
+DICOM:0080_0009 ilxtr:hasIlxId ilx:0382282 .
+
+DICOM:0080_0010 ilxtr:hasIlxId ilx:0382965 .
+
+DICOM:0080_0011 ilxtr:hasIlxId ilx:0382760 .
+
+DICOM:0080_0012 ilxtr:hasIlxId ilx:0382219 .
+
+DICOM:0080_0013 ilxtr:hasIlxId ilx:0381780 .
+
+DICOM:0082_000A ilxtr:hasIlxId ilx:0382796 .
+
+DICOM:0082_000C ilxtr:hasIlxId ilx:0381844 .
+
+DICOM:0082_0001 ilxtr:hasIlxId ilx:0382044 .
+
+DICOM:0082_0003 ilxtr:hasIlxId ilx:0382666 .
+
+DICOM:0082_0004 ilxtr:hasIlxId ilx:0382952 .
+
+DICOM:0082_0005 ilxtr:hasIlxId ilx:0382578 .
+
+DICOM:0082_0006 ilxtr:hasIlxId ilx:0382575 .
+
+DICOM:0082_0007 ilxtr:hasIlxId ilx:0382110 .
+
+DICOM:0082_0008 ilxtr:hasIlxId ilx:0381776 .
+
+DICOM:0082_0010 ilxtr:hasIlxId ilx:0383013 .
+
+DICOM:0082_0016 ilxtr:hasIlxId ilx:0381609 .
+
+DICOM:0082_0017 ilxtr:hasIlxId ilx:0382345 .
+
+DICOM:0082_0018 ilxtr:hasIlxId ilx:0382408 .
+
+DICOM:0082_0019 ilxtr:hasIlxId ilx:0382385 .
+
+DICOM:0082_0021 ilxtr:hasIlxId ilx:0381585 .
+
+DICOM:0082_0022 ilxtr:hasIlxId ilx:0381898 .
+
+DICOM:0082_0023 ilxtr:hasIlxId ilx:0382722 .
+
+DICOM:0082_0032 ilxtr:hasIlxId ilx:0381747 .
+
+DICOM:0082_0033 ilxtr:hasIlxId ilx:0382739 .
+
+DICOM:0082_0034 ilxtr:hasIlxId ilx:0381965 .
+
+DICOM:0082_0035 ilxtr:hasIlxId ilx:0382129 .
+
+DICOM:0082_0036 ilxtr:hasIlxId ilx:0382978 .
+
+DICOM:0082_0037 ilxtr:hasIlxId ilx:0382764 .
+
+DICOM:0082_0038 ilxtr:hasIlxId ilx:0382624 .
+
+DICOM:0088_0130 ilxtr:hasIlxId ilx:0111070 .
+
+DICOM:0088_0140 ilxtr:hasIlxId ilx:0111071 .
+
+DICOM:0088_0200 ilxtr:hasIlxId ilx:0105206 .
+
+DICOM:0100_0410 ilxtr:hasIlxId ilx:0110766 .
+
+DICOM:0100_0420 ilxtr:hasIlxId ilx:0110763 .
+
+DICOM:0100_0424 ilxtr:hasIlxId ilx:0110762 .
+
+DICOM:0100_0426 ilxtr:hasIlxId ilx:0101014 .
+
+DICOM:300A_000A ilxtr:hasIlxId ilx:0111931 .
+
+DICOM:300A_00A0 ilxtr:hasIlxId ilx:0107812 .
+
+DICOM:300A_00A2 ilxtr:hasIlxId ilx:0101419 .
+
+DICOM:300A_00A4 ilxtr:hasIlxId ilx:0101418 .
+
+DICOM:300A_000B ilxtr:hasIlxId ilx:0111937 .
+
+DICOM:300A_00B0 ilxtr:hasIlxId ilx:0101155 .
+
+DICOM:300A_00B2 ilxtr:hasIlxId ilx:0111932 .
+
+DICOM:300A_00B3 ilxtr:hasIlxId ilx:0109269 .
+
+DICOM:300A_00B4 ilxtr:hasIlxId ilx:0110811 .
+
+DICOM:300A_00B6 ilxtr:hasIlxId ilx:0101150 .
+
+DICOM:300A_00B8 ilxtr:hasIlxId ilx:0110241 .
+
+DICOM:300A_00BA ilxtr:hasIlxId ilx:0110802 .
+
+DICOM:300A_00BC ilxtr:hasIlxId ilx:0382705 .
+
+DICOM:300A_00BE ilxtr:hasIlxId ilx:0106149 .
+
+DICOM:300A_000C ilxtr:hasIlxId ilx:0110252 .
+
+DICOM:300A_00C0 ilxtr:hasIlxId ilx:0101154 .
+
+DICOM:300A_00C2 ilxtr:hasIlxId ilx:0101153 .
+
+DICOM:300A_00C3 ilxtr:hasIlxId ilx:0101141 .
+
+DICOM:300A_00C4 ilxtr:hasIlxId ilx:0101157 .
+
+DICOM:300A_00C5 ilxtr:hasIlxId ilx:0382629 .
+
+DICOM:300A_00C6 ilxtr:hasIlxId ilx:0109617 .
+
+DICOM:300A_00C7 ilxtr:hasIlxId ilx:0104998 .
+
+DICOM:300A_00C8 ilxtr:hasIlxId ilx:0109731 .
+
+DICOM:300A_00CA ilxtr:hasIlxId ilx:0108972 .
+
+DICOM:300A_00CC ilxtr:hasIlxId ilx:0105261 .
+
+DICOM:300A_00CE ilxtr:hasIlxId ilx:0111930 .
+
+DICOM:300A_00D0 ilxtr:hasIlxId ilx:0107852 .
+
+DICOM:300A_00D1 ilxtr:hasIlxId ilx:0112614 .
+
+DICOM:300A_00D2 ilxtr:hasIlxId ilx:0112610 .
+
+DICOM:300A_00D3 ilxtr:hasIlxId ilx:0112615 .
+
+DICOM:300A_00D4 ilxtr:hasIlxId ilx:0112609 .
+
+DICOM:300A_00D5 ilxtr:hasIlxId ilx:0112607 .
+
+DICOM:300A_00D6 ilxtr:hasIlxId ilx:0112608 .
+
+DICOM:300A_00D8 ilxtr:hasIlxId ilx:0112611 .
+
+DICOM:300A_00DA ilxtr:hasIlxId ilx:0110808 .
+
+DICOM:300A_00DC ilxtr:hasIlxId ilx:0381736 .
+
+DICOM:300A_00DD ilxtr:hasIlxId ilx:0383083 .
+
+DICOM:300A_00DE ilxtr:hasIlxId ilx:0382716 .
+
+DICOM:300A_000E ilxtr:hasIlxId ilx:0109237 .
+
+DICOM:300A_00E0 ilxtr:hasIlxId ilx:0107813 .
+
+DICOM:300A_00E1 ilxtr:hasIlxId ilx:0106553 .
+
+DICOM:300A_00E2 ilxtr:hasIlxId ilx:0111827 .
+
+DICOM:300A_00E3 ilxtr:hasIlxId ilx:0102424 .
+
+DICOM:300A_00E4 ilxtr:hasIlxId ilx:0102420 .
+
+DICOM:300A_00E5 ilxtr:hasIlxId ilx:0102418 .
+
+DICOM:300A_00E6 ilxtr:hasIlxId ilx:0110805 .
+
+DICOM:300A_00E7 ilxtr:hasIlxId ilx:0102423 .
+
+DICOM:300A_00E8 ilxtr:hasIlxId ilx:0102416 .
+
+DICOM:300A_00E9 ilxtr:hasIlxId ilx:0102421 .
+
+DICOM:300A_00EA ilxtr:hasIlxId ilx:0102422 .
+
+DICOM:300A_00EB ilxtr:hasIlxId ilx:0102426 .
+
+DICOM:300A_00EC ilxtr:hasIlxId ilx:0102425 .
+
+DICOM:300A_00ED ilxtr:hasIlxId ilx:0107811 .
+
+DICOM:300A_00EE ilxtr:hasIlxId ilx:0383181 .
+
+DICOM:300A_00EF ilxtr:hasIlxId ilx:0382323 .
+
+DICOM:300A_00F0 ilxtr:hasIlxId ilx:0107810 .
+
+DICOM:300A_00F2 ilxtr:hasIlxId ilx:0111826 .
+
+DICOM:300A_00F4 ilxtr:hasIlxId ilx:0101347 .
+
+DICOM:300A_00F5 ilxtr:hasIlxId ilx:0101351 .
+
+DICOM:300A_00F6 ilxtr:hasIlxId ilx:0110803 .
+
+DICOM:300A_00F8 ilxtr:hasIlxId ilx:0101352 .
+
+DICOM:300A_00F9 ilxtr:hasIlxId ilx:0100210 .
+
+DICOM:300A_00FA ilxtr:hasIlxId ilx:0101342 .
+
+DICOM:300A_00FB ilxtr:hasIlxId ilx:0101343 .
+
+DICOM:300A_00FC ilxtr:hasIlxId ilx:0101345 .
+
+DICOM:300A_00FE ilxtr:hasIlxId ilx:0101344 .
+
+DICOM:300A_001A ilxtr:hasIlxId ilx:0107647 .
+
+DICOM:300A_01A0 ilxtr:hasIlxId ilx:0110606 .
+
+DICOM:300A_01A2 ilxtr:hasIlxId ilx:0110607 .
+
+DICOM:300A_01A4 ilxtr:hasIlxId ilx:0110604 .
+
+DICOM:300A_01A6 ilxtr:hasIlxId ilx:0110603 .
+
+DICOM:300A_01A8 ilxtr:hasIlxId ilx:0110605 .
+
+DICOM:300A_01B0 ilxtr:hasIlxId ilx:0110581 .
+
+DICOM:300A_01B2 ilxtr:hasIlxId ilx:0110582 .
+
+DICOM:300A_01B4 ilxtr:hasIlxId ilx:0110578 .
+
+DICOM:300A_01B6 ilxtr:hasIlxId ilx:0110579 .
+
+DICOM:300A_01B8 ilxtr:hasIlxId ilx:0110576 .
+
+DICOM:300A_01BA ilxtr:hasIlxId ilx:0110575 .
+
+DICOM:300A_01BC ilxtr:hasIlxId ilx:0110577 .
+
+DICOM:300A_01D0 ilxtr:hasIlxId ilx:0110580 .
+
+DICOM:300A_01D2 ilxtr:hasIlxId ilx:0111476 .
+
+DICOM:300A_01D4 ilxtr:hasIlxId ilx:0111473 .
+
+DICOM:300A_01D6 ilxtr:hasIlxId ilx:0111470 .
+
+DICOM:300A_0002 ilxtr:hasIlxId ilx:0110253 .
+
+DICOM:300A_002A ilxtr:hasIlxId ilx:0108125 .
+
+DICOM:300A_02A0 ilxtr:hasIlxId ilx:0110785 .
+
+DICOM:300A_02A2 ilxtr:hasIlxId ilx:0111872 .
+
+DICOM:300A_02A4 ilxtr:hasIlxId ilx:0111871 .
+
+DICOM:300A_002B ilxtr:hasIlxId ilx:0108126 .
+
+DICOM:300A_02B0 ilxtr:hasIlxId ilx:0102049 .
+
+DICOM:300A_02B2 ilxtr:hasIlxId ilx:0102048 .
+
+DICOM:300A_02B3 ilxtr:hasIlxId ilx:0102044 .
+
+DICOM:300A_02B4 ilxtr:hasIlxId ilx:0102045 .
+
+DICOM:300A_02B8 ilxtr:hasIlxId ilx:0102046 .
+
+DICOM:300A_02BA ilxtr:hasIlxId ilx:0102047 .
+
+DICOM:300A_002C ilxtr:hasIlxId ilx:0108127 .
+
+DICOM:300A_02C8 ilxtr:hasIlxId ilx:0104246 .
+
+DICOM:300A_002D ilxtr:hasIlxId ilx:0108128 .
+
+DICOM:300A_02D0 ilxtr:hasIlxId ilx:0101421 .
+
+DICOM:300A_02D2 ilxtr:hasIlxId ilx:0102541 .
+
+DICOM:300A_02D4 ilxtr:hasIlxId ilx:0102538 .
+
+DICOM:300A_02D6 ilxtr:hasIlxId ilx:0102665 .
+
+DICOM:300A_02E0 ilxtr:hasIlxId ilx:0102417 .
+
+DICOM:300A_02E1 ilxtr:hasIlxId ilx:0102419 .
+
+DICOM:300A_02E2 ilxtr:hasIlxId ilx:0110804 .
+
+DICOM:300A_02EB ilxtr:hasIlxId ilx:0383097 .
+
+DICOM:300A_0003 ilxtr:hasIlxId ilx:0110254 .
+
+DICOM:300A_0004 ilxtr:hasIlxId ilx:0110251 .
+
+DICOM:300A_004A ilxtr:hasIlxId ilx:0101148 .
+
+DICOM:300A_004C ilxtr:hasIlxId ilx:0108600 .
+
+DICOM:300A_004E ilxtr:hasIlxId ilx:0111465 .
+
+DICOM:300A_004F ilxtr:hasIlxId ilx:0382678 .
+
+DICOM:300A_0006 ilxtr:hasIlxId ilx:0110250 .
+
+DICOM:300A_0007 ilxtr:hasIlxId ilx:0110256 .
+
+DICOM:300A_007A ilxtr:hasIlxId ilx:0109920 .
+
+DICOM:300A_007B ilxtr:hasIlxId ilx:0104393 .
+
+DICOM:300A_008B ilxtr:hasIlxId ilx:0382834 .
+
+DICOM:300A_008C ilxtr:hasIlxId ilx:0382615 .
+
+DICOM:300A_008D ilxtr:hasIlxId ilx:0382880 .
+
+DICOM:300A_008E ilxtr:hasIlxId ilx:0382579 .
+
+DICOM:300A_008F ilxtr:hasIlxId ilx:0381984 .
+
+DICOM:300A_0009 ilxtr:hasIlxId ilx:0111934 .
+
+DICOM:300A_0010 ilxtr:hasIlxId ilx:0103529 .
+
+DICOM:300A_010A ilxtr:hasIlxId ilx:0100861 .
+
+DICOM:300A_010C ilxtr:hasIlxId ilx:0102662 .
+
+DICOM:300A_010E ilxtr:hasIlxId ilx:0104245 .
+
+DICOM:300A_011A ilxtr:hasIlxId ilx:0101147 .
+
+DICOM:300A_011C ilxtr:hasIlxId ilx:0381926 .
+
+DICOM:300A_011E ilxtr:hasIlxId ilx:0104550 .
+
+DICOM:300A_011F ilxtr:hasIlxId ilx:0104552 .
+
+DICOM:300A_0012 ilxtr:hasIlxId ilx:0103527 .
+
+DICOM:300A_012A ilxtr:hasIlxId ilx:0111468 .
+
+DICOM:300A_012C ilxtr:hasIlxId ilx:0105735 .
+
+DICOM:300A_012E ilxtr:hasIlxId ilx:0111368 .
+
+DICOM:300A_0013 ilxtr:hasIlxId ilx:0103532 .
+
+DICOM:300A_0014 ilxtr:hasIlxId ilx:0103530 .
+
+DICOM:300A_014A ilxtr:hasIlxId ilx:0382683 .
+
+DICOM:300A_014C ilxtr:hasIlxId ilx:0381729 .
+
+DICOM:300A_014E ilxtr:hasIlxId ilx:0382095 .
+
+DICOM:300A_0015 ilxtr:hasIlxId ilx:0107645 .
+
+DICOM:300A_0016 ilxtr:hasIlxId ilx:0103526 .
+
+DICOM:300A_0018 ilxtr:hasIlxId ilx:0103528 .
+
+DICOM:300A_019A ilxtr:hasIlxId ilx:0383111 .
+
+DICOM:300A_0020 ilxtr:hasIlxId ilx:0103531 .
+
+DICOM:300A_0021 ilxtr:hasIlxId ilx:0102500 .
+
+DICOM:300A_021A ilxtr:hasIlxId ilx:0100289 .
+
+DICOM:300A_021B ilxtr:hasIlxId ilx:0382858 .
+
+DICOM:300A_021C ilxtr:hasIlxId ilx:0382023 .
+
+DICOM:300A_0022 ilxtr:hasIlxId ilx:0103005 .
+
+DICOM:300A_022A ilxtr:hasIlxId ilx:0109728 .
+
+DICOM:300A_022B ilxtr:hasIlxId ilx:0382614 .
+
+DICOM:300A_022C ilxtr:hasIlxId ilx:0100435 .
+
+DICOM:300A_022E ilxtr:hasIlxId ilx:0100436 .
+
+DICOM:300A_0023 ilxtr:hasIlxId ilx:0103004 .
+
+DICOM:300A_0025 ilxtr:hasIlxId ilx:0111526 .
+
+DICOM:300A_0026 ilxtr:hasIlxId ilx:0111527 .
+
+DICOM:300A_026A ilxtr:hasIlxId ilx:0101413 .
+
+DICOM:300A_026C ilxtr:hasIlxId ilx:0101414 .
+
+DICOM:300A_0027 ilxtr:hasIlxId ilx:0111525 .
+
+DICOM:300A_0028 ilxtr:hasIlxId ilx:0111528 .
+
+DICOM:300A_028A ilxtr:hasIlxId ilx:0107834 .
+
+DICOM:300A_028C ilxtr:hasIlxId ilx:0109514 .
+
+DICOM:300A_029C ilxtr:hasIlxId ilx:0110787 .
+
+DICOM:300A_029E ilxtr:hasIlxId ilx:0110788 .
+
+DICOM:300A_0040 ilxtr:hasIlxId ilx:0111798 .
+
+DICOM:300A_0042 ilxtr:hasIlxId ilx:0111797 .
+
+DICOM:300A_0043 ilxtr:hasIlxId ilx:0111796 .
+
+DICOM:300A_0044 ilxtr:hasIlxId ilx:0104551 .
+
+DICOM:300A_0046 ilxtr:hasIlxId ilx:0101145 .
+
+DICOM:300A_0048 ilxtr:hasIlxId ilx:0101151 .
+
+DICOM:300A_0050 ilxtr:hasIlxId ilx:0382852 .
+
+DICOM:300A_0051 ilxtr:hasIlxId ilx:0111475 .
+
+DICOM:300A_0052 ilxtr:hasIlxId ilx:0111472 .
+
+DICOM:300A_0053 ilxtr:hasIlxId ilx:0111469 .
+
+DICOM:300A_0055 ilxtr:hasIlxId ilx:0110255 .
+
+DICOM:300A_0070 ilxtr:hasIlxId ilx:0104389 .
+
+DICOM:300A_0071 ilxtr:hasIlxId ilx:0104388 .
+
+DICOM:300A_0072 ilxtr:hasIlxId ilx:0104387 .
+
+DICOM:300A_0078 ilxtr:hasIlxId ilx:0107822 .
+
+DICOM:300A_0079 ilxtr:hasIlxId ilx:0107820 .
+
+DICOM:300A_0080 ilxtr:hasIlxId ilx:0107809 .
+
+DICOM:300A_0082 ilxtr:hasIlxId ilx:0101143 .
+
+DICOM:300A_0084 ilxtr:hasIlxId ilx:0101142 .
+
+DICOM:300A_0086 ilxtr:hasIlxId ilx:0101152 .
+
+DICOM:300A_0090 ilxtr:hasIlxId ilx:0383085 .
+
+DICOM:300A_0091 ilxtr:hasIlxId ilx:0381989 .
+
+DICOM:300A_0092 ilxtr:hasIlxId ilx:0382108 .
+
+DICOM:300A_0100 ilxtr:hasIlxId ilx:0101349 .
+
+DICOM:300A_0102 ilxtr:hasIlxId ilx:0383182 .
+
+DICOM:300A_0104 ilxtr:hasIlxId ilx:0101346 .
+
+DICOM:300A_0106 ilxtr:hasIlxId ilx:0101339 .
+
+DICOM:300A_0107 ilxtr:hasIlxId ilx:0100863 .
+
+DICOM:300A_0108 ilxtr:hasIlxId ilx:0100862 .
+
+DICOM:300A_0109 ilxtr:hasIlxId ilx:0100864 .
+
+DICOM:300A_0110 ilxtr:hasIlxId ilx:0107815 .
+
+DICOM:300A_0111 ilxtr:hasIlxId ilx:0102542 .
+
+DICOM:300A_0112 ilxtr:hasIlxId ilx:0102540 .
+
+DICOM:300A_0114 ilxtr:hasIlxId ilx:0107644 .
+
+DICOM:300A_0115 ilxtr:hasIlxId ilx:0103525 .
+
+DICOM:300A_0116 ilxtr:hasIlxId ilx:0112613 .
+
+DICOM:300A_0118 ilxtr:hasIlxId ilx:0112612 .
+
+DICOM:300A_0120 ilxtr:hasIlxId ilx:0101144 .
+
+DICOM:300A_0121 ilxtr:hasIlxId ilx:0101149 .
+
+DICOM:300A_0122 ilxtr:hasIlxId ilx:0108599 .
+
+DICOM:300A_0123 ilxtr:hasIlxId ilx:0108601 .
+
+DICOM:300A_0124 ilxtr:hasIlxId ilx:0111466 .
+
+DICOM:300A_0125 ilxtr:hasIlxId ilx:0111464 .
+
+DICOM:300A_0126 ilxtr:hasIlxId ilx:0111467 .
+
+DICOM:300A_0128 ilxtr:hasIlxId ilx:0111474 .
+
+DICOM:300A_0129 ilxtr:hasIlxId ilx:0111471 .
+
+DICOM:300A_0130 ilxtr:hasIlxId ilx:0110807 .
+
+DICOM:300A_0131 ilxtr:hasIlxId ilx:0382876 .
+
+DICOM:300A_0132 ilxtr:hasIlxId ilx:0382510 .
+
+DICOM:300A_0133 ilxtr:hasIlxId ilx:0382561 .
+
+DICOM:300A_0134 ilxtr:hasIlxId ilx:0102664 .
+
+DICOM:300A_0140 ilxtr:hasIlxId ilx:0382433 .
+
+DICOM:300A_0142 ilxtr:hasIlxId ilx:0382040 .
+
+DICOM:300A_0144 ilxtr:hasIlxId ilx:0382838 .
+
+DICOM:300A_0146 ilxtr:hasIlxId ilx:0382878 .
+
+DICOM:300A_0180 ilxtr:hasIlxId ilx:0108597 .
+
+DICOM:300A_0182 ilxtr:hasIlxId ilx:0108596 .
+
+DICOM:300A_0183 ilxtr:hasIlxId ilx:0382670 .
+
+DICOM:300A_0184 ilxtr:hasIlxId ilx:0108584 .
+
+DICOM:300A_0190 ilxtr:hasIlxId ilx:0104267 .
+
+DICOM:300A_0192 ilxtr:hasIlxId ilx:0104268 .
+
+DICOM:300A_0194 ilxtr:hasIlxId ilx:0104265 .
+
+DICOM:300A_0196 ilxtr:hasIlxId ilx:0104264 .
+
+DICOM:300A_0198 ilxtr:hasIlxId ilx:0104266 .
+
+DICOM:300A_0199 ilxtr:hasIlxId ilx:0381946 .
+
+DICOM:300A_0200 ilxtr:hasIlxId ilx:0101423 .
+
+DICOM:300A_0202 ilxtr:hasIlxId ilx:0101424 .
+
+DICOM:300A_0206 ilxtr:hasIlxId ilx:0111933 .
+
+DICOM:300A_0210 ilxtr:hasIlxId ilx:0110800 .
+
+DICOM:300A_0212 ilxtr:hasIlxId ilx:0110799 .
+
+DICOM:300A_0214 ilxtr:hasIlxId ilx:0110809 .
+
+DICOM:300A_0216 ilxtr:hasIlxId ilx:0110796 .
+
+DICOM:300A_0218 ilxtr:hasIlxId ilx:0100288 .
+
+DICOM:300A_0222 ilxtr:hasIlxId ilx:0110790 .
+
+DICOM:300A_0224 ilxtr:hasIlxId ilx:0110791 .
+
+DICOM:300A_0226 ilxtr:hasIlxId ilx:0110795 .
+
+DICOM:300A_0228 ilxtr:hasIlxId ilx:0110794 .
+
+DICOM:300A_0229 ilxtr:hasIlxId ilx:0383041 .
+
+DICOM:300A_0230 ilxtr:hasIlxId ilx:0100859 .
+
+DICOM:300A_0232 ilxtr:hasIlxId ilx:0100860 .
+
+DICOM:300A_0234 ilxtr:hasIlxId ilx:0100858 .
+
+DICOM:300A_0236 ilxtr:hasIlxId ilx:0100857 .
+
+DICOM:300A_0238 ilxtr:hasIlxId ilx:0100856 .
+
+DICOM:300A_0240 ilxtr:hasIlxId ilx:0111577 .
+
+DICOM:300A_0242 ilxtr:hasIlxId ilx:0111578 .
+
+DICOM:300A_0244 ilxtr:hasIlxId ilx:0111576 .
+
+DICOM:300A_0250 ilxtr:hasIlxId ilx:0111830 .
+
+DICOM:300A_0260 ilxtr:hasIlxId ilx:0101416 .
+
+DICOM:300A_0262 ilxtr:hasIlxId ilx:0101415 .
+
+DICOM:300A_0263 ilxtr:hasIlxId ilx:0101411 .
+
+DICOM:300A_0264 ilxtr:hasIlxId ilx:0101417 .
+
+DICOM:300A_0266 ilxtr:hasIlxId ilx:0101412 .
+
+DICOM:300A_0280 ilxtr:hasIlxId ilx:0102043 .
+
+DICOM:300A_0282 ilxtr:hasIlxId ilx:0102037 .
+
+DICOM:300A_0284 ilxtr:hasIlxId ilx:0102034 .
+
+DICOM:300A_0286 ilxtr:hasIlxId ilx:0102053 .
+
+DICOM:300A_0288 ilxtr:hasIlxId ilx:0110798 .
+
+DICOM:300A_0290 ilxtr:hasIlxId ilx:0110784 .
+
+DICOM:300A_0291 ilxtr:hasIlxId ilx:0110780 .
+
+DICOM:300A_0292 ilxtr:hasIlxId ilx:0110786 .
+
+DICOM:300A_0294 ilxtr:hasIlxId ilx:0110783 .
+
+DICOM:300A_0296 ilxtr:hasIlxId ilx:0110781 .
+
+DICOM:300A_0298 ilxtr:hasIlxId ilx:0110782 .
+
+DICOM:300A_0355 ilxtr:hasIlxId ilx:0382973 .
+
+DICOM:300A_0401 ilxtr:hasIlxId ilx:0381809 .
+
+DICOM:300A_0402 ilxtr:hasIlxId ilx:0382863 .
+
+DICOM:300A_0410 ilxtr:hasIlxId ilx:0382415 .
+
+DICOM:300A_0412 ilxtr:hasIlxId ilx:0383033 .
+
+DICOM:300A_0420 ilxtr:hasIlxId ilx:0381947 .
+
+DICOM:300A_0421 ilxtr:hasIlxId ilx:0381630 .
+
+DICOM:300A_0422 ilxtr:hasIlxId ilx:0382662 .
+
+DICOM:300A_0423 ilxtr:hasIlxId ilx:0382512 .
+
+DICOM:300A_0424 ilxtr:hasIlxId ilx:0381566 .
+
+DICOM:300A_0425 ilxtr:hasIlxId ilx:0382743 .
+
+DICOM:300A_0431 ilxtr:hasIlxId ilx:0382787 .
+
+DICOM:300A_0432 ilxtr:hasIlxId ilx:0383003 .
+
+DICOM:300A_0433 ilxtr:hasIlxId ilx:0381784 .
+
+DICOM:300A_0434 ilxtr:hasIlxId ilx:0382267 .
+
+DICOM:300A_0435 ilxtr:hasIlxId ilx:0382103 .
+
+DICOM:300A_0436 ilxtr:hasIlxId ilx:0382012 .
+
+DICOM:300A_0450 ilxtr:hasIlxId ilx:0382954 .
+
+DICOM:300A_0451 ilxtr:hasIlxId ilx:0382281 .
+
+DICOM:300A_0452 ilxtr:hasIlxId ilx:0382524 .
+
+DICOM:300A_0453 ilxtr:hasIlxId ilx:0382532 .
+
+DICOM:300C_000A ilxtr:hasIlxId ilx:0109744 .
+
+DICOM:300C_00A0 ilxtr:hasIlxId ilx:0109799 .
+
+DICOM:300C_00B0 ilxtr:hasIlxId ilx:0109741 .
+
+DICOM:300C_000C ilxtr:hasIlxId ilx:0109743 .
+
+DICOM:300C_00C0 ilxtr:hasIlxId ilx:0109805 .
+
+DICOM:300C_00D0 ilxtr:hasIlxId ilx:0109747 .
+
+DICOM:300C_000E ilxtr:hasIlxId ilx:0109793 .
+
+DICOM:300C_00E0 ilxtr:hasIlxId ilx:0109740 .
+
+DICOM:300C_00F0 ilxtr:hasIlxId ilx:0109749 .
+
+DICOM:300C_00F2 ilxtr:hasIlxId ilx:0381605 .
+
+DICOM:300C_00F4 ilxtr:hasIlxId ilx:0381853 .
+
+DICOM:300C_00F6 ilxtr:hasIlxId ilx:0381974 .
+
+DICOM:300C_0002 ilxtr:hasIlxId ilx:0109786 .
+
+DICOM:300C_0004 ilxtr:hasIlxId ilx:0109739 .
+
+DICOM:300C_0006 ilxtr:hasIlxId ilx:0109738 .
+
+DICOM:300C_006A ilxtr:hasIlxId ilx:0109776 .
+
+DICOM:300C_0007 ilxtr:hasIlxId ilx:0109781 .
+
+DICOM:300C_0008 ilxtr:hasIlxId ilx:0111023 .
+
+DICOM:300C_0009 ilxtr:hasIlxId ilx:0103773 .
+
+DICOM:300C_0020 ilxtr:hasIlxId ilx:0109756 .
+
+DICOM:300C_0022 ilxtr:hasIlxId ilx:0109755 .
+
+DICOM:300C_0040 ilxtr:hasIlxId ilx:0109801 .
+
+DICOM:300C_0042 ilxtr:hasIlxId ilx:0109782 .
+
+DICOM:300C_0050 ilxtr:hasIlxId ilx:0109753 .
+
+DICOM:300C_0051 ilxtr:hasIlxId ilx:0109752 .
+
+DICOM:300C_0055 ilxtr:hasIlxId ilx:0101422 .
+
+DICOM:300C_0060 ilxtr:hasIlxId ilx:0109796 .
+
+DICOM:300C_0080 ilxtr:hasIlxId ilx:0109754 .
+
+DICOM:300E_0002 ilxtr:hasIlxId ilx:0381890 .
+
+DICOM:300E_0004 ilxtr:hasIlxId ilx:0382476 .
+
+DICOM:300E_0005 ilxtr:hasIlxId ilx:0383120 .
+
+DICOM:300E_0008 ilxtr:hasIlxId ilx:0381970 .
+
+DICOM:0400_0005 ilxtr:hasIlxId ilx:0383088 .
+
+DICOM:0400_0010 ilxtr:hasIlxId ilx:0383004 .
+
+DICOM:0400_0015 ilxtr:hasIlxId ilx:0383082 .
+
+DICOM:0400_0020 ilxtr:hasIlxId ilx:0382993 .
+
+DICOM:0400_0100 ilxtr:hasIlxId ilx:0383094 .
+
+DICOM:0400_0105 ilxtr:hasIlxId ilx:0382325 .
+
+DICOM:0400_0110 ilxtr:hasIlxId ilx:0382685 .
+
+DICOM:0400_0115 ilxtr:hasIlxId ilx:0381479 .
+
+DICOM:0400_0120 ilxtr:hasIlxId ilx:0381621 .
+
+DICOM:0400_0305 ilxtr:hasIlxId ilx:0382552 .
+
+DICOM:0400_0310 ilxtr:hasIlxId ilx:0382840 .
+
+DICOM:0400_0401 ilxtr:hasIlxId ilx:0382454 .
+
+DICOM:0400_0402 ilxtr:hasIlxId ilx:0381622 .
+
+DICOM:0400_0403 ilxtr:hasIlxId ilx:0382958 .
+
+DICOM:0400_0404 ilxtr:hasIlxId ilx:0382499 .
+
+DICOM:0400_0500 ilxtr:hasIlxId ilx:0103770 .
+
+DICOM:0400_0510 ilxtr:hasIlxId ilx:0103772 .
+
+DICOM:0400_0520 ilxtr:hasIlxId ilx:0103771 .
+
+DICOM:0400_0550 ilxtr:hasIlxId ilx:0107054 .
+
+DICOM:0400_0561 ilxtr:hasIlxId ilx:0382266 .
+
+DICOM:0400_0562 ilxtr:hasIlxId ilx:0382765 .
+
+DICOM:0400_0563 ilxtr:hasIlxId ilx:0381484 .
+
+DICOM:0400_0564 ilxtr:hasIlxId ilx:0382894 .
+
+DICOM:0400_0565 ilxtr:hasIlxId ilx:0382613 .
+
+DICOM:2000_00A0 ilxtr:hasIlxId ilx:0106780 .
+
+DICOM:2000_00A1 ilxtr:hasIlxId ilx:0109365 .
+
+DICOM:2000_00A4 ilxtr:hasIlxId ilx:0108231 .
+
+DICOM:2000_00A8 ilxtr:hasIlxId ilx:0111338 .
+
+DICOM:2000_001E ilxtr:hasIlxId ilx:0109359 .
+
+DICOM:2000_0061 ilxtr:hasIlxId ilx:0106583 .
+
+DICOM:2000_0063 ilxtr:hasIlxId ilx:0102362 .
+
+DICOM:2000_0510 ilxtr:hasIlxId ilx:0109795 .
+
+DICOM:2010_00A6 ilxtr:hasIlxId ilx:0102974 .
+
+DICOM:2010_00A7 ilxtr:hasIlxId ilx:0108230 .
+
+DICOM:2010_00A8 ilxtr:hasIlxId ilx:0102976 .
+
+DICOM:2010_00A9 ilxtr:hasIlxId ilx:0108279 .
+
+DICOM:2010_015E ilxtr:hasIlxId ilx:0105222 .
+
+DICOM:2010_0052 ilxtr:hasIlxId ilx:0109362 .
+
+DICOM:2010_0054 ilxtr:hasIlxId ilx:0102975 .
+
+DICOM:2010_0110 ilxtr:hasIlxId ilx:0103761 .
+
+DICOM:2010_0160 ilxtr:hasIlxId ilx:0109810 .
+
+DICOM:2010_0376 ilxtr:hasIlxId ilx:0109361 .
+
+DICOM:2020_00A0 ilxtr:hasIlxId ilx:0109934 .
+
+DICOM:2020_0030 ilxtr:hasIlxId ilx:0109933 .
+
+DICOM:2020_0130 ilxtr:hasIlxId ilx:0109766 .
+
+DICOM:2050_0010 ilxtr:hasIlxId ilx:0109241 .
+
+DICOM:2050_0020 ilxtr:hasIlxId ilx:0109242 .
+
+DICOM:2050_0500 ilxtr:hasIlxId ilx:0109778 .
+
+DICOM:2100_0020 ilxtr:hasIlxId ilx:0104011 .
+
+DICOM:2100_0030 ilxtr:hasIlxId ilx:0104012 .
+
+DICOM:2100_0040 ilxtr:hasIlxId ilx:0102618 .
+
+DICOM:2100_0050 ilxtr:hasIlxId ilx:0102619 .
+
+DICOM:2100_0070 ilxtr:hasIlxId ilx:0108144 .
+
+DICOM:2100_0140 ilxtr:hasIlxId ilx:0103130 .
+
+DICOM:2110_0010 ilxtr:hasIlxId ilx:0109363 .
+
+DICOM:2110_0020 ilxtr:hasIlxId ilx:0109364 .
+
+DICOM:2110_0030 ilxtr:hasIlxId ilx:0109360 .
+
+DICOM:2120_0010 ilxtr:hasIlxId ilx:0109581 .
+
+DICOM:2120_0070 ilxtr:hasIlxId ilx:0109779 .
+
+DICOM:2130_0010 ilxtr:hasIlxId ilx:0109357 .
+
+DICOM:2130_0015 ilxtr:hasIlxId ilx:0109358 .
+
+DICOM:2130_0030 ilxtr:hasIlxId ilx:0104228 .
+
+DICOM:2200_000A ilxtr:hasIlxId ilx:0109247 .
+
+DICOM:2200_000B ilxtr:hasIlxId ilx:0111829 .
+
+DICOM:2200_000C ilxtr:hasIlxId ilx:0109935 .
+
+DICOM:2200_000D ilxtr:hasIlxId ilx:0109794 .
+
+DICOM:2200_000F ilxtr:hasIlxId ilx:0100478 .
+
+DICOM:2200_0002 ilxtr:hasIlxId ilx:0105961 .
+
+DICOM:2200_0003 ilxtr:hasIlxId ilx:0105960 .
+
+DICOM:2200_0005 ilxtr:hasIlxId ilx:0101092 .
+
+DICOM:2200_0007 ilxtr:hasIlxId ilx:0100479 .
+
+DICOM:2200_0020 ilxtr:hasIlxId ilx:0109931 .
+
+DICOM:3002_000A ilxtr:hasIlxId ilx:0109924 .
+
+DICOM:3002_000C ilxtr:hasIlxId ilx:0110247 .
+
+DICOM:3002_000D ilxtr:hasIlxId ilx:0112682 .
+
+DICOM:3002_000E ilxtr:hasIlxId ilx:0112681 .
+
+DICOM:3002_0002 ilxtr:hasIlxId ilx:0110244 .
+
+DICOM:3002_0003 ilxtr:hasIlxId ilx:0110245 .
+
+DICOM:3002_0004 ilxtr:hasIlxId ilx:0110243 .
+
+DICOM:3002_0010 ilxtr:hasIlxId ilx:0110246 .
+
+DICOM:3002_0011 ilxtr:hasIlxId ilx:0105245 .
+
+DICOM:3002_0012 ilxtr:hasIlxId ilx:0110248 .
+
+DICOM:3002_0020 ilxtr:hasIlxId ilx:0109610 .
+
+DICOM:3002_0022 ilxtr:hasIlxId ilx:0109611 .
+
+DICOM:3002_0024 ilxtr:hasIlxId ilx:0109612 .
+
+DICOM:3002_0026 ilxtr:hasIlxId ilx:0110249 .
+
+DICOM:3002_0028 ilxtr:hasIlxId ilx:0110806 .
+
+DICOM:3002_0029 ilxtr:hasIlxId ilx:0104392 .
+
+DICOM:3002_0030 ilxtr:hasIlxId ilx:0104028 .
+
+DICOM:3002_0032 ilxtr:hasIlxId ilx:0106846 .
+
+DICOM:3002_0034 ilxtr:hasIlxId ilx:0103195 .
+
+DICOM:3002_0040 ilxtr:hasIlxId ilx:0104305 .
+
+DICOM:3002_0041 ilxtr:hasIlxId ilx:0104304 .
+
+DICOM:3002_0042 ilxtr:hasIlxId ilx:0104303 .
+
+DICOM:3002_0050 ilxtr:hasIlxId ilx:0381700 .
+
+DICOM:3002_0051 ilxtr:hasIlxId ilx:0382018 .
+
+DICOM:3002_0052 ilxtr:hasIlxId ilx:0382016 .
+
+DICOM:3004_000A ilxtr:hasIlxId ilx:0103533 .
+
+DICOM:3004_000C ilxtr:hasIlxId ilx:0104789 .
+
+DICOM:3004_000E ilxtr:hasIlxId ilx:0103523 .
+
+DICOM:3004_00EE ilxtr:hasIlxId ilx:0102427 .
+
+DICOM:3004_0001 ilxtr:hasIlxId ilx:0103613 .
+
+DICOM:3004_0002 ilxtr:hasIlxId ilx:0103535 .
+
+DICOM:3004_0004 ilxtr:hasIlxId ilx:0103534 .
+
+DICOM:3004_0005 ilxtr:hasIlxId ilx:0381856 .
+
+DICOM:3004_0006 ilxtr:hasIlxId ilx:0103522 .
+
+DICOM:3004_0008 ilxtr:hasIlxId ilx:0107686 .
+
+DICOM:3004_0010 ilxtr:hasIlxId ilx:0110242 .
+
+DICOM:3004_0012 ilxtr:hasIlxId ilx:0103536 .
+
+DICOM:3004_0014 ilxtr:hasIlxId ilx:0111773 .
+
+DICOM:3004_0040 ilxtr:hasIlxId ilx:0103608 .
+
+DICOM:3004_0042 ilxtr:hasIlxId ilx:0103607 .
+
+DICOM:3004_0050 ilxtr:hasIlxId ilx:0103612 .
+
+DICOM:3004_0052 ilxtr:hasIlxId ilx:0103603 .
+
+DICOM:3004_0054 ilxtr:hasIlxId ilx:0103614 .
+
+DICOM:3004_0056 ilxtr:hasIlxId ilx:0103609 .
+
+DICOM:3004_0058 ilxtr:hasIlxId ilx:0103602 .
+
+DICOM:3004_0060 ilxtr:hasIlxId ilx:0103610 .
+
+DICOM:3004_0062 ilxtr:hasIlxId ilx:0103611 .
+
+DICOM:3004_0070 ilxtr:hasIlxId ilx:0103606 .
+
+DICOM:3004_0072 ilxtr:hasIlxId ilx:0103604 .
+
+DICOM:3004_0074 ilxtr:hasIlxId ilx:0103605 .
+
+DICOM:3006_00A0 ilxtr:hasIlxId ilx:0109890 .
+
+DICOM:3006_00A4 ilxtr:hasIlxId ilx:0110261 .
+
+DICOM:3006_00A6 ilxtr:hasIlxId ilx:0110183 .
+
+DICOM:3006_00B0 ilxtr:hasIlxId ilx:0110189 .
+
+DICOM:3006_00B2 ilxtr:hasIlxId ilx:0110190 .
+
+DICOM:3006_00B4 ilxtr:hasIlxId ilx:0110191 .
+
+DICOM:3006_00B6 ilxtr:hasIlxId ilx:0381485 .
+
+DICOM:3006_00B7 ilxtr:hasIlxId ilx:0381738 .
+
+DICOM:3006_00B8 ilxtr:hasIlxId ilx:0382932 .
+
+DICOM:3006_00C0 ilxtr:hasIlxId ilx:0104414 .
+
+DICOM:3006_00C2 ilxtr:hasIlxId ilx:0109888 .
+
+DICOM:3006_00C4 ilxtr:hasIlxId ilx:0104417 .
+
+DICOM:3006_00C6 ilxtr:hasIlxId ilx:0104416 .
+
+DICOM:3006_00C8 ilxtr:hasIlxId ilx:0104415 .
+
+DICOM:3006_0002 ilxtr:hasIlxId ilx:0111121 .
+
+DICOM:3006_002A ilxtr:hasIlxId ilx:0110180 .
+
+DICOM:3006_002C ilxtr:hasIlxId ilx:0110193 .
+
+DICOM:3006_0004 ilxtr:hasIlxId ilx:0111122 .
+
+DICOM:3006_0006 ilxtr:hasIlxId ilx:0111120 .
+
+DICOM:3006_0008 ilxtr:hasIlxId ilx:0111119 .
+
+DICOM:3006_0009 ilxtr:hasIlxId ilx:0111124 .
+
+DICOM:3006_0010 ilxtr:hasIlxId ilx:0109760 .
+
+DICOM:3006_0012 ilxtr:hasIlxId ilx:0110258 .
+
+DICOM:3006_0014 ilxtr:hasIlxId ilx:0110257 .
+
+DICOM:3006_0016 ilxtr:hasIlxId ilx:0102522 .
+
+DICOM:3006_0018 ilxtr:hasIlxId ilx:0383015 .
+
+DICOM:3006_0020 ilxtr:hasIlxId ilx:0111123 .
+
+DICOM:3006_0022 ilxtr:hasIlxId ilx:0383191 .
+
+DICOM:3006_0024 ilxtr:hasIlxId ilx:0109761 .
+
+DICOM:3006_0026 ilxtr:hasIlxId ilx:0110185 .
+
+DICOM:3006_0028 ilxtr:hasIlxId ilx:0110179 .
+
+DICOM:3006_0030 ilxtr:hasIlxId ilx:0110259 .
+
+DICOM:3006_0033 ilxtr:hasIlxId ilx:0110263 .
+
+DICOM:3006_0036 ilxtr:hasIlxId ilx:0110181 .
+
+DICOM:3006_0038 ilxtr:hasIlxId ilx:0110182 .
+
+DICOM:3006_0039 ilxtr:hasIlxId ilx:0110178 .
+
+DICOM:3006_0040 ilxtr:hasIlxId ilx:0102525 .
+
+DICOM:3006_0042 ilxtr:hasIlxId ilx:0102521 .
+
+DICOM:3006_0044 ilxtr:hasIlxId ilx:0102526 .
+
+DICOM:3006_0045 ilxtr:hasIlxId ilx:0102524 .
+
+DICOM:3006_0046 ilxtr:hasIlxId ilx:0107814 .
+
+DICOM:3006_0048 ilxtr:hasIlxId ilx:0102523 .
+
+DICOM:3006_0049 ilxtr:hasIlxId ilx:0100978 .
+
+DICOM:3006_0050 ilxtr:hasIlxId ilx:0102520 .
+
+DICOM:3006_0080 ilxtr:hasIlxId ilx:0110262 .
+
+DICOM:3006_0082 ilxtr:hasIlxId ilx:0107874 .
+
+DICOM:3006_0084 ilxtr:hasIlxId ilx:0109785 .
+
+DICOM:3006_0085 ilxtr:hasIlxId ilx:0110188 .
+
+DICOM:3006_0086 ilxtr:hasIlxId ilx:0110260 .
+
+DICOM:3006_0088 ilxtr:hasIlxId ilx:0110187 .
+
+DICOM:3008_00A0 ilxtr:hasIlxId ilx:0101146 .
+
+DICOM:3008_00B0 ilxtr:hasIlxId ilx:0109712 .
+
+DICOM:3008_00C0 ilxtr:hasIlxId ilx:0109709 .
+
+DICOM:3008_00D0 ilxtr:hasIlxId ilx:0109705 .
+
+DICOM:3008_00E0 ilxtr:hasIlxId ilx:0111940 .
+
+DICOM:3008_002A ilxtr:hasIlxId ilx:0111942 .
+
+DICOM:3008_002B ilxtr:hasIlxId ilx:0111941 .
+
+DICOM:3008_002C ilxtr:hasIlxId ilx:0111944 .
+
+DICOM:3008_003A ilxtr:hasIlxId ilx:0110864 .
+
+DICOM:3008_003B ilxtr:hasIlxId ilx:0103003 .
+
+DICOM:3008_005A ilxtr:hasIlxId ilx:0107821 .
+
+DICOM:3008_006A ilxtr:hasIlxId ilx:0381938 .
+
+DICOM:3008_007A ilxtr:hasIlxId ilx:0103774 .
+
+DICOM:3008_0010 ilxtr:hasIlxId ilx:0106595 .
+
+DICOM:3008_0012 ilxtr:hasIlxId ilx:0106593 .
+
+DICOM:3008_013A ilxtr:hasIlxId ilx:0110862 .
+
+DICOM:3008_013C ilxtr:hasIlxId ilx:0103001 .
+
+DICOM:3008_0014 ilxtr:hasIlxId ilx:0106596 .
+
+DICOM:3008_0016 ilxtr:hasIlxId ilx:0106597 .
+
+DICOM:3008_0020 ilxtr:hasIlxId ilx:0111936 .
+
+DICOM:3008_0022 ilxtr:hasIlxId ilx:0102680 .
+
+DICOM:3008_0024 ilxtr:hasIlxId ilx:0111927 .
+
+DICOM:3008_0025 ilxtr:hasIlxId ilx:0111928 .
+
+DICOM:3008_0030 ilxtr:hasIlxId ilx:0109800 .
+
+DICOM:3008_0032 ilxtr:hasIlxId ilx:0110861 .
+
+DICOM:3008_0033 ilxtr:hasIlxId ilx:0110863 .
+
+DICOM:3008_0036 ilxtr:hasIlxId ilx:0103000 .
+
+DICOM:3008_0037 ilxtr:hasIlxId ilx:0103002 .
+
+DICOM:3008_0040 ilxtr:hasIlxId ilx:0102539 .
+
+DICOM:3008_0042 ilxtr:hasIlxId ilx:0110859 .
+
+DICOM:3008_0044 ilxtr:hasIlxId ilx:0102998 .
+
+DICOM:3008_0048 ilxtr:hasIlxId ilx:0103524 .
+
+DICOM:3008_0050 ilxtr:hasIlxId ilx:0111939 .
+
+DICOM:3008_0052 ilxtr:hasIlxId ilx:0102663 .
+
+DICOM:3008_0054 ilxtr:hasIlxId ilx:0104263 .
+
+DICOM:3008_0056 ilxtr:hasIlxId ilx:0107110 .
+
+DICOM:3008_0060 ilxtr:hasIlxId ilx:0108307 .
+
+DICOM:3008_0061 ilxtr:hasIlxId ilx:0382139 .
+
+DICOM:3008_0062 ilxtr:hasIlxId ilx:0108305 .
+
+DICOM:3008_0063 ilxtr:hasIlxId ilx:0381854 .
+
+DICOM:3008_0064 ilxtr:hasIlxId ilx:0106594 .
+
+DICOM:3008_0065 ilxtr:hasIlxId ilx:0381656 .
+
+DICOM:3008_0066 ilxtr:hasIlxId ilx:0108306 .
+
+DICOM:3008_0067 ilxtr:hasIlxId ilx:0382773 .
+
+DICOM:3008_0068 ilxtr:hasIlxId ilx:0383084 .
+
+DICOM:3008_0070 ilxtr:hasIlxId ilx:0381750 .
+
+DICOM:3008_0072 ilxtr:hasIlxId ilx:0382995 .
+
+DICOM:3008_0074 ilxtr:hasIlxId ilx:0381791 .
+
+DICOM:3008_0076 ilxtr:hasIlxId ilx:0382867 .
+
+DICOM:3008_0078 ilxtr:hasIlxId ilx:0111024 .
+
+DICOM:3008_0080 ilxtr:hasIlxId ilx:0109771 .
+
+DICOM:3008_0082 ilxtr:hasIlxId ilx:0109770 .
+
+DICOM:3008_0090 ilxtr:hasIlxId ilx:0109746 .
+
+DICOM:3008_0092 ilxtr:hasIlxId ilx:0109745 .
+
+DICOM:3008_0100 ilxtr:hasIlxId ilx:0109711 .
+
+DICOM:3008_0105 ilxtr:hasIlxId ilx:0110801 .
+
+DICOM:3008_0110 ilxtr:hasIlxId ilx:0111935 .
+
+DICOM:3008_0116 ilxtr:hasIlxId ilx:0100855 .
+
+DICOM:3008_0120 ilxtr:hasIlxId ilx:0109706 .
+
+DICOM:3008_0122 ilxtr:hasIlxId ilx:0109742 .
+
+DICOM:3008_0130 ilxtr:hasIlxId ilx:0109707 .
+
+DICOM:3008_0132 ilxtr:hasIlxId ilx:0110858 .
+
+DICOM:3008_0134 ilxtr:hasIlxId ilx:0102997 .
+
+DICOM:3008_0136 ilxtr:hasIlxId ilx:0110860 .
+
+DICOM:3008_0138 ilxtr:hasIlxId ilx:0102999 .
+
+DICOM:3008_0140 ilxtr:hasIlxId ilx:0109710 .
+
+DICOM:3008_0142 ilxtr:hasIlxId ilx:0109792 .
+
+DICOM:3008_0150 ilxtr:hasIlxId ilx:0109708 .
+
+DICOM:3008_0152 ilxtr:hasIlxId ilx:0383126 .
+
+DICOM:3008_0160 ilxtr:hasIlxId ilx:0101420 .
+
+DICOM:3008_0162 ilxtr:hasIlxId ilx:0110307 .
+
+DICOM:3008_0164 ilxtr:hasIlxId ilx:0110308 .
+
+DICOM:3008_0166 ilxtr:hasIlxId ilx:0110309 .
+
+DICOM:3008_0168 ilxtr:hasIlxId ilx:0110310 .
+
+DICOM:3008_0171 ilxtr:hasIlxId ilx:0381955 .
+
+DICOM:3008_0172 ilxtr:hasIlxId ilx:0382994 .
+
+DICOM:3008_0173 ilxtr:hasIlxId ilx:0383038 .
+
+DICOM:3008_0200 ilxtr:hasIlxId ilx:0102683 .
+
+DICOM:3008_0202 ilxtr:hasIlxId ilx:0111938 .
+
+DICOM:3008_0220 ilxtr:hasIlxId ilx:0104390 .
+
+DICOM:3008_0223 ilxtr:hasIlxId ilx:0383187 .
+
+DICOM:3008_0224 ilxtr:hasIlxId ilx:0104391 .
+
+DICOM:3008_0230 ilxtr:hasIlxId ilx:0101156 .
+
+DICOM:3008_0240 ilxtr:hasIlxId ilx:0104394 .
+
+DICOM:3008_0250 ilxtr:hasIlxId ilx:0383174 .
+
+DICOM:3008_0251 ilxtr:hasIlxId ilx:0111943 .
+
+DICOM:4008_010A ilxtr:hasIlxId ilx:0105616 .
+
+DICOM:4008_010B ilxtr:hasIlxId ilx:0105615 .
+
+DICOM:4008_010C ilxtr:hasIlxId ilx:0105606 .
+
+DICOM:4008_011A ilxtr:hasIlxId ilx:0103346 .
+
+DICOM:4008_0040 ilxtr:hasIlxId ilx:0109982 .
+
+DICOM:4008_0042 ilxtr:hasIlxId ilx:0109983 .
+
+DICOM:4008_0050 ilxtr:hasIlxId ilx:0109769 .
+
+DICOM:4008_0100 ilxtr:hasIlxId ilx:0105611 .
+
+DICOM:4008_0101 ilxtr:hasIlxId ilx:0105612 .
+
+DICOM:4008_0102 ilxtr:hasIlxId ilx:0105613 .
+
+DICOM:4008_0103 ilxtr:hasIlxId ilx:0109736 .
+
+DICOM:4008_0108 ilxtr:hasIlxId ilx:0105617 .
+
+DICOM:4008_0109 ilxtr:hasIlxId ilx:0105618 .
+
+DICOM:4008_0111 ilxtr:hasIlxId ilx:0105605 .
+
+DICOM:4008_0112 ilxtr:hasIlxId ilx:0105603 .
+
+DICOM:4008_0113 ilxtr:hasIlxId ilx:0105604 .
+
+DICOM:4008_0114 ilxtr:hasIlxId ilx:0108862 .
+
+DICOM:4008_0115 ilxtr:hasIlxId ilx:0105608 .
+
+DICOM:4008_0117 ilxtr:hasIlxId ilx:0105607 .
+
+DICOM:4008_0118 ilxtr:hasIlxId ilx:0109981 .
+
+DICOM:4008_0119 ilxtr:hasIlxId ilx:0103347 .
+
+DICOM:4008_0200 ilxtr:hasIlxId ilx:0105609 .
+
+DICOM:4008_0202 ilxtr:hasIlxId ilx:0105610 .
+
+DICOM:4008_0210 ilxtr:hasIlxId ilx:0105619 .
+
+DICOM:4008_0212 ilxtr:hasIlxId ilx:0105614 .
+
+DICOM:4008_0300 ilxtr:hasIlxId ilx:0105304 .
+
+DICOM:4008_4000 ilxtr:hasIlxId ilx:0109980 .
+
+DICOM:5200_9229 ilxtr:hasIlxId ilx:0110597 .
+
+DICOM:5200_9230 ilxtr:hasIlxId ilx:0108677 .
+
+DICOM:5400_0100 ilxtr:hasIlxId ilx:0112590 .
+
+DICOM:5400_100A ilxtr:hasIlxId ilx:0112588 .
+
+DICOM:5400_0110 ilxtr:hasIlxId ilx:0102036 .
+
+DICOM:5400_0112 ilxtr:hasIlxId ilx:0102035 .
+
+DICOM:5400_1004 ilxtr:hasIlxId ilx:0112583 .
+
+DICOM:5400_1006 ilxtr:hasIlxId ilx:0112589 .
+
+DICOM:5400_1010 ilxtr:hasIlxId ilx:0112586 .
+
+DICOM:5600_0010 ilxtr:hasIlxId ilx:0104256 .
+
+DICOM:5600_0020 ilxtr:hasIlxId ilx:0110884 .
+
+DICOM:FFFA_FFFA ilxtr:hasIlxId ilx:0382419 .
+
+### Serialized using the ttlser deterministic serializer v1.2.0


### PR DESCRIPTION
# Issue 
Discussion/Resolution and response to email about the CURIE ID's with prefix DICOM that does not resolve to a valid URL

# Comments

- NLX:149518 http://uri.neuinfo.org/nif/nifstd/nlx_149518
- ILX:0100260 [ http://uri.interlex.org/ilx_0100260](https://urldefense.com/v3/__http://uri.interlex.org/ilx_0100260__;!!LLK065n_VXAQ!iJuoXRwiyqpnc7NLoPcjzrkvYNT0PmYg677D346neBuCD8WF0PdIk_mzlC_J4MhxLeOFNZCRX_7L3BD4a7a6gg$)
- DICOM:0018_1310 http://uri.interlex.org/dicom/uris/terms/0018_1310
- example file for mapping https://github.com/SciCrunch/NIF-Ontology/blob/master/ttl/generated/NPOKB-ILX-mapping.ttl
https://github.com/tgbugs/pyontutils/blob/ab7e0dda2ad78e0f8f15c500e2b4272eb4e079d1/nifstd/resolver/make_config.py#L1 the script that creates the nginx mapping file